### PR TITLE
refactor: make swapEnabled a required field on SubgraphPoolBase

### DIFF
--- a/src/pools/index.ts
+++ b/src/pools/index.ts
@@ -10,8 +10,7 @@ export function parseNewPool(
     currentBlockTimestamp = 0
 ): WeightedPool | StablePool | ElementPool | undefined {
     // We're not interested in any pools which don't allow swapping
-    // (Explicit check for false as many of the tests omit this flag)
-    if (pool.swapEnabled === false) return undefined;
+    if (!pool.swapEnabled) return undefined;
 
     let newPool: WeightedPool | StablePool | ElementPool;
     if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export interface SubgraphPoolBase {
     address: string;
     poolType: string;
     swapFee: string;
+    swapEnabled: boolean;
     totalShares: string;
     tokens: SubgraphToken[];
     tokensList: string[];
@@ -75,9 +76,6 @@ export interface SubgraphPoolBase {
     unitSeconds?: number;
     principalToken?: string;
     baseToken?: string;
-
-    // LBP specific fields
-    swapEnabled?: boolean;
 }
 
 export type SubgraphToken = {

--- a/test/elementTrades.spec.ts
+++ b/test/elementTrades.spec.ts
@@ -53,6 +53,7 @@ describe(`Tests against Element generated test trade file.`, () => {
                     address: 'n/a',
                     poolType: 'Element',
                     swapFee: testTrades.init.percent_fee.toString(),
+                    swapEnabled: true,
                     totalShares: trade.input.total_supply.toString(),
                     unitSeconds: 1,
                     expiryTime: trade.input.time,

--- a/test/testData/elementPools/elementFinanceTest1.json
+++ b/test/testData/elementPools/elementFinanceTest1.json
@@ -14,6 +14,7 @@
             "id": "0xelementPool1",
             "poolType": "Element",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "totalShares": "265819.67027583614",
             "unitSeconds": "60",
             "expiryTime": "1610880693",

--- a/test/testData/filterTestPools.json
+++ b/test/testData/filterTestPools.json
@@ -4,6 +4,7 @@
             "id": "0x0481d726c3d25250a8963221945ed93b8a5315a9",
             "totalShares": "100",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -56,6 +57,7 @@
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "totalShares": "100",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -148,6 +150,7 @@
             "id": "0x09574f862d32794b8636cfb9c98e6597be049c4b",
             "totalShares": "100",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -180,6 +183,7 @@
             "id": "0x10fd0adaf5de39ddd81165d770367fde8883157d",
             "totalShares": "100",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -212,6 +216,7 @@
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "totalShares": "100",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -254,6 +259,7 @@
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "totalShares": "100",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -286,6 +292,7 @@
             "id": "0x247ff2b322df7439b78898375be7cdadca11cf17",
             "totalShares": "100",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -328,6 +335,7 @@
             "id": "0x254d519110d215fb657c621afc7d4b76ce2c0265",
             "totalShares": "100",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -360,6 +368,7 @@
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "totalShares": "100",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -422,6 +431,7 @@
             "id": "0x2dbd24322757d2e28de4230b1ca5b88e49a76979",
             "totalShares": "100",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -504,6 +514,7 @@
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "totalShares": "100",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -536,6 +547,7 @@
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "totalShares": "100",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -580,6 +592,7 @@
             "id": "0x6c3f90f043a72fa612cbac8115ee7e52bde6e490",
             "totalShares": "785224145.723155205181003818",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "600",
             "tokens": [
                 {
@@ -617,6 +630,7 @@
             "id": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
             "totalShares": "78350279.810168052058997162",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "500",
             "tokens": [
                 {
@@ -664,6 +678,7 @@
             "id": "0x0481d726c3d25250a8963221945ed93b8a5315a9",
             "totalShares": "100",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -716,6 +731,7 @@
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "totalShares": "100",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -760,6 +776,7 @@
             "id": "0x0481d726c3d25250a8963221945ed93b8a5315a9",
             "totalShares": "100",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -802,6 +819,7 @@
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "totalShares": "100",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/lido/staticPools.json
+++ b/test/testData/lido/staticPools.json
@@ -20,6 +20,7 @@
             "principalToken": null,
             "swapEnabled": true,
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -65,6 +66,7 @@
             "principalToken": null,
             "swapEnabled": true,
             "swapFee": "0.0033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -101,6 +103,7 @@
             "principalToken": null,
             "swapEnabled": true,
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",

--- a/test/testData/stablePools/metaPool.json
+++ b/test/testData/stablePools/metaPool.json
@@ -14,6 +14,7 @@
             "id": "0xebfed10e11dc08fcda1af1fda146945e8710f22e00000000000000000000007f",
             "address": "0xebfed10e11dc08fcda1af1fda146945e8710f22e",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "10",
             "tokens": [
                 {
@@ -47,6 +48,7 @@
             "id": "0x119a129203a3882b85ca77c954af86ebfae16bdd0000000000000000000000a0",
             "address": "0x119a129203a3882b85ca77c954af86ebfae16bdd",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "10",
             "tokens": [
                 {

--- a/test/testData/stablePools/multihop.json
+++ b/test/testData/stablePools/multihop.json
@@ -14,6 +14,7 @@
             "id": "0xebfed10e11dc08fcda1af1fda146945e8710f22e00000000000000000000007f",
             "address": "0xebfed10e11dc08fcda1af1fda146945e8710f22e",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "amp": "10",
             "tokens": [
                 {
@@ -38,6 +39,7 @@
             "id": "0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e",
             "address": "0xa6f548df93de924d73be7d25dc02554c6bd66db5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "amp": "10",
             "tokens": [
                 {

--- a/test/testData/stablePools/singlePool.json
+++ b/test/testData/stablePools/singlePool.json
@@ -14,6 +14,7 @@
             "id": "0xebfed10e11dc08fcda1af1fda146945e8710f22e00000000000000000000007f",
             "address": "0xebfed10e11dc08fcda1af1fda146945e8710f22e",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "10",
             "tokens": [
                 {

--- a/test/testData/testPools/0x04ec8acaa4f419bc1525eaa8d37faae2d4acb64c5521a3718593c626962de170.json
+++ b/test/testData/testPools/0x04ec8acaa4f419bc1525eaa8d37faae2d4acb64c5521a3718593c626962de170.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x04ec8acaa4f419bc1525eaa8d37faae2d4acb64c5521a3718593c626962de170.json
+++ b/test/testData/testPools/0x04ec8acaa4f419bc1525eaa8d37faae2d4acb64c5521a3718593c626962de170.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -171,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -198,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -232,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -259,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -286,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -313,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -340,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -367,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -422,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -470,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -511,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -538,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -621,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -648,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -696,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -723,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -750,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -854,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -881,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -908,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -935,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -962,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1003,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1030,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1071,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1098,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1237,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1264,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1291,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1318,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1345,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1400,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1427,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1475,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1502,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1550,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1577,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1604,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1631,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1672,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1699,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1726,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1753,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1780,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1835,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1876,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1987,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2063,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2181,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2229,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2256,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2283,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2338,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2365,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2455,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2510,6 +2568,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2544,6 +2603,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2571,6 +2631,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2598,6 +2659,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2674,6 +2736,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2701,6 +2764,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2735,6 +2799,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2762,6 +2827,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2789,6 +2855,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2816,6 +2883,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2843,6 +2911,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2877,6 +2946,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2904,6 +2974,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2931,6 +3002,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2958,6 +3030,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3062,6 +3135,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3096,6 +3170,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3123,6 +3198,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3150,6 +3226,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3177,6 +3254,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3218,6 +3296,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3245,6 +3324,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3272,6 +3352,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3299,6 +3380,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3326,6 +3408,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3395,6 +3478,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3443,6 +3527,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3470,6 +3555,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3497,6 +3583,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3524,6 +3611,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3551,6 +3639,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3620,6 +3709,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3647,6 +3737,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3674,6 +3765,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3701,6 +3793,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3728,6 +3821,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3755,6 +3849,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3782,6 +3877,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3809,6 +3905,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3843,6 +3940,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3870,6 +3968,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3897,6 +3996,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3924,6 +4024,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3958,6 +4059,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3985,6 +4087,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4012,6 +4115,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4067,6 +4171,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4108,6 +4213,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4135,6 +4241,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4183,6 +4290,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4259,6 +4367,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4286,6 +4395,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4341,6 +4451,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4368,6 +4479,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4451,6 +4563,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4492,6 +4605,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4519,6 +4633,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4546,6 +4661,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4573,6 +4689,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4600,6 +4717,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4627,6 +4745,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4654,6 +4773,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4681,6 +4801,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4708,6 +4829,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4763,6 +4885,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4832,6 +4955,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4859,6 +4983,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4886,6 +5011,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4913,6 +5039,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5052,6 +5179,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5107,6 +5235,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5141,6 +5270,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5168,6 +5298,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5195,6 +5326,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5222,6 +5354,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5277,6 +5410,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5304,6 +5438,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5359,6 +5494,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5386,6 +5522,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5441,6 +5578,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5503,6 +5641,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5530,6 +5669,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5557,6 +5697,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5584,6 +5725,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5611,6 +5753,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5666,6 +5809,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5700,6 +5844,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5727,6 +5872,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5754,6 +5900,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5809,6 +5956,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5836,6 +5984,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5863,6 +6012,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5918,6 +6068,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5945,6 +6096,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5972,6 +6124,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5999,6 +6152,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6026,6 +6180,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6053,6 +6208,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6101,6 +6257,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6128,6 +6285,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6169,6 +6327,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6217,6 +6376,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6244,6 +6404,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6271,6 +6432,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6326,6 +6488,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6402,6 +6565,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6471,6 +6635,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6498,6 +6663,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6532,6 +6698,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6559,6 +6726,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6586,6 +6754,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6613,6 +6782,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6640,6 +6810,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6667,6 +6838,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6694,6 +6866,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6721,6 +6894,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6783,6 +6957,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6852,6 +7027,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6879,6 +7055,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6934,6 +7111,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6961,6 +7139,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7023,6 +7202,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7050,6 +7230,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7077,6 +7258,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7104,6 +7286,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7138,6 +7321,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7193,6 +7377,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7220,6 +7405,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7275,6 +7461,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7302,6 +7489,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7357,6 +7545,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7384,6 +7573,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7411,6 +7601,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7438,6 +7629,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7493,6 +7685,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7520,6 +7713,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7659,6 +7853,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7686,6 +7881,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7713,6 +7909,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7740,6 +7937,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7767,6 +7965,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7829,6 +8028,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7863,6 +8063,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7890,6 +8091,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7917,6 +8119,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7965,6 +8168,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7992,6 +8196,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8019,6 +8224,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8046,6 +8252,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8073,6 +8280,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8100,6 +8308,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8127,6 +8336,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8203,6 +8413,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8230,6 +8441,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8264,6 +8476,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8291,6 +8504,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8318,6 +8532,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8359,6 +8574,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8386,6 +8602,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8420,6 +8637,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8517,6 +8735,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8544,6 +8763,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8571,6 +8791,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8668,6 +8889,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8695,6 +8917,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8722,6 +8945,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8756,6 +8980,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8783,6 +9008,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8831,6 +9057,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8879,6 +9106,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8934,6 +9162,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8961,6 +9190,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8988,6 +9218,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9015,6 +9246,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9042,6 +9274,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9111,6 +9344,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9138,6 +9372,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9165,6 +9400,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9220,6 +9456,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9261,6 +9498,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9358,6 +9596,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9406,6 +9645,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9433,6 +9673,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9502,6 +9743,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9550,6 +9792,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9577,6 +9820,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9604,6 +9848,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9631,6 +9876,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9658,6 +9904,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9685,6 +9932,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9712,6 +9960,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9739,6 +9988,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9766,6 +10016,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9793,6 +10044,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9820,6 +10072,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9847,6 +10100,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9874,6 +10128,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9901,6 +10156,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9928,6 +10184,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9955,6 +10212,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9982,6 +10240,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10009,6 +10268,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10050,6 +10310,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10077,6 +10338,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10104,6 +10366,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10159,6 +10422,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10186,6 +10450,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10213,6 +10478,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10247,6 +10513,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10274,6 +10541,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10301,6 +10569,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10328,6 +10597,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10355,6 +10625,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10410,6 +10681,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10437,6 +10709,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10485,6 +10758,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10540,6 +10814,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10567,6 +10842,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10594,6 +10870,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10649,6 +10926,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10676,6 +10954,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10766,6 +11045,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10793,6 +11073,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10820,6 +11101,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10847,6 +11129,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10916,6 +11199,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10950,6 +11234,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11033,6 +11318,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11060,6 +11346,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11108,6 +11395,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11135,6 +11423,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11183,6 +11472,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11210,6 +11500,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11237,6 +11528,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11299,6 +11591,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11340,6 +11633,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11367,6 +11661,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11394,6 +11689,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11421,6 +11717,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11448,6 +11745,7 @@
         {
             "id": "0x4b3fa856cef9aa85ed9bbfa8992d6138c5f150e6",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -11517,6 +11815,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11586,6 +11885,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11613,6 +11913,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11640,6 +11941,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11702,6 +12004,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11736,6 +12039,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11763,6 +12067,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11790,6 +12095,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11817,6 +12123,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11844,6 +12151,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11871,6 +12179,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11898,6 +12207,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11925,6 +12235,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11952,6 +12263,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11979,6 +12291,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12034,6 +12347,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12061,6 +12375,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12088,6 +12403,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12115,6 +12431,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12177,6 +12494,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12211,6 +12529,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12238,6 +12557,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12265,6 +12585,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12320,6 +12641,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12375,6 +12697,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12402,6 +12725,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12429,6 +12753,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12456,6 +12781,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12483,6 +12809,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12510,6 +12837,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12565,6 +12893,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12634,6 +12963,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12661,6 +12991,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12688,6 +13019,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12722,6 +13054,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12854,6 +13187,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12951,6 +13285,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12985,6 +13320,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -13054,6 +13390,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13081,6 +13418,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13108,6 +13446,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13135,6 +13474,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13162,6 +13502,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13189,6 +13530,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13244,6 +13586,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13271,6 +13614,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13319,6 +13663,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13416,6 +13761,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13485,6 +13831,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13631,6 +13978,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13686,6 +14034,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13713,6 +14062,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13740,6 +14090,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13795,6 +14146,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13822,6 +14174,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13849,6 +14202,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13876,6 +14230,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13903,6 +14258,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13930,6 +14286,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13957,6 +14314,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13984,6 +14342,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -14011,6 +14370,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -14101,6 +14461,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14128,6 +14489,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14155,6 +14517,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14182,6 +14545,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14335,6 +14699,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14362,6 +14727,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14389,6 +14755,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14416,6 +14783,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14457,6 +14825,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14484,6 +14853,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14511,6 +14881,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14538,6 +14909,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14593,6 +14965,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14620,6 +14993,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14647,6 +15021,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14744,6 +15119,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14771,6 +15147,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14798,6 +15175,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14853,6 +15231,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14880,6 +15259,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14942,6 +15322,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14969,6 +15350,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14996,6 +15378,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -15023,6 +15406,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15050,6 +15434,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15077,6 +15462,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15132,6 +15518,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15201,6 +15588,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15228,6 +15616,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15255,6 +15644,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15282,6 +15672,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15309,6 +15700,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15336,6 +15728,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15363,6 +15756,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15502,6 +15896,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15529,6 +15924,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15556,6 +15952,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15583,6 +15980,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15610,6 +16008,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15651,6 +16050,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15678,6 +16078,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15705,6 +16106,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15732,6 +16134,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15759,6 +16162,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15793,6 +16197,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15820,6 +16225,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15847,6 +16253,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15944,6 +16351,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15971,6 +16379,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15998,6 +16407,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -16025,6 +16435,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -16052,6 +16463,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16079,6 +16491,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16106,6 +16519,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16133,6 +16547,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16160,6 +16575,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16187,6 +16603,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16214,6 +16631,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16255,6 +16673,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16282,6 +16701,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16309,6 +16729,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16371,6 +16792,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16398,6 +16820,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16425,6 +16848,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16452,6 +16876,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16479,6 +16904,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16534,6 +16960,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16561,6 +16988,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16588,6 +17016,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16615,6 +17044,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16642,6 +17072,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16732,6 +17163,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16759,6 +17191,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16786,6 +17219,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16813,6 +17247,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16840,6 +17275,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16867,6 +17303,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16894,6 +17331,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -17040,6 +17478,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17067,6 +17506,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17094,6 +17534,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17121,6 +17562,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17148,6 +17590,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17182,6 +17625,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17237,6 +17681,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17306,6 +17751,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17333,6 +17779,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17360,6 +17807,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17387,6 +17835,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17414,6 +17863,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17441,6 +17891,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17468,6 +17919,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17558,6 +18010,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17585,6 +18038,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17612,6 +18066,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17639,6 +18094,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17666,6 +18122,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17714,6 +18171,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17755,6 +18213,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17782,6 +18241,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17809,6 +18269,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17843,6 +18304,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17870,6 +18332,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17939,6 +18402,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17966,6 +18430,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -18000,6 +18465,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -18027,6 +18493,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -18054,6 +18521,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18109,6 +18577,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18164,6 +18633,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18233,6 +18703,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18260,6 +18731,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18287,6 +18759,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18314,6 +18787,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18369,6 +18843,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18438,6 +18913,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18465,6 +18941,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18534,6 +19011,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18561,6 +19039,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18588,6 +19067,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18615,6 +19095,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18642,6 +19123,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18669,6 +19151,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18696,6 +19179,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18730,6 +19214,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18764,6 +19249,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18791,6 +19277,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18818,6 +19305,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18873,6 +19361,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18900,6 +19389,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18927,6 +19417,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18954,6 +19445,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18988,6 +19480,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -19015,6 +19508,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -19042,6 +19536,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19069,6 +19564,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19096,6 +19592,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19130,6 +19627,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19157,6 +19655,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19212,6 +19711,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19239,6 +19739,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19322,6 +19823,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19356,6 +19858,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19411,6 +19914,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19438,6 +19942,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19465,6 +19970,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19492,6 +19998,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19526,6 +20033,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19553,6 +20061,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19580,6 +20089,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19607,6 +20117,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19662,6 +20173,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19689,6 +20201,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19716,6 +20229,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19764,6 +20278,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19791,6 +20306,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19818,6 +20334,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19845,6 +20362,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19872,6 +20390,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19899,6 +20418,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19926,6 +20446,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19953,6 +20474,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19980,6 +20502,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -20049,6 +20572,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20076,6 +20600,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20103,6 +20628,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20130,6 +20656,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20164,6 +20691,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20191,6 +20719,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20218,6 +20747,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20245,6 +20775,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20314,6 +20845,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20341,6 +20873,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20382,6 +20915,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20409,6 +20943,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20478,6 +21013,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20540,6 +21076,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20567,6 +21104,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20636,6 +21174,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20663,6 +21202,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20690,6 +21230,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20717,6 +21258,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20744,6 +21286,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20771,6 +21314,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20798,6 +21342,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20825,6 +21370,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20859,6 +21405,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20949,6 +21496,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20976,6 +21524,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -21003,6 +21552,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -21037,6 +21587,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21071,6 +21622,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21112,6 +21664,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21167,6 +21720,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21194,6 +21748,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21221,6 +21776,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21290,6 +21846,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21317,6 +21874,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21358,6 +21916,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21413,6 +21972,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21440,6 +22000,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21467,6 +22028,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21501,6 +22063,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21528,6 +22091,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21555,6 +22119,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21582,6 +22147,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21609,6 +22175,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21636,6 +22203,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21677,6 +22245,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21704,6 +22273,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21731,6 +22301,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21758,6 +22329,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21834,6 +22406,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21861,6 +22434,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21888,6 +22462,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21915,6 +22490,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21942,6 +22518,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21969,6 +22546,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22017,6 +22595,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22051,6 +22630,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22078,6 +22658,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22105,6 +22686,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22132,6 +22714,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22159,6 +22742,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22186,6 +22770,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22213,6 +22798,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22254,6 +22840,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22281,6 +22868,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22308,6 +22896,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22447,6 +23036,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22488,6 +23078,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22515,6 +23106,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22549,6 +23141,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22604,6 +23197,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22631,6 +23225,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22658,6 +23253,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22706,6 +23302,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22747,6 +23344,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22774,6 +23372,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22801,6 +23400,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22870,6 +23470,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22904,6 +23505,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22931,6 +23533,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22965,6 +23568,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22999,6 +23603,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -23026,6 +23631,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -23053,6 +23659,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23080,6 +23687,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23107,6 +23715,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23134,6 +23743,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23161,6 +23771,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23216,6 +23827,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23243,6 +23855,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23298,6 +23911,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23360,6 +23974,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23387,6 +24002,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23414,6 +24030,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23455,6 +24072,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23510,6 +24128,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23537,6 +24156,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23564,6 +24184,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23591,6 +24212,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23625,6 +24247,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23652,6 +24275,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23686,6 +24310,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23713,6 +24338,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23761,6 +24387,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23788,6 +24415,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23815,6 +24443,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23842,6 +24471,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23869,6 +24499,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23924,6 +24555,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23951,6 +24583,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23978,6 +24611,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -24033,6 +24667,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -24060,6 +24695,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24108,6 +24744,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24156,6 +24793,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24183,6 +24821,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24210,6 +24849,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24237,6 +24877,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24264,6 +24905,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24291,6 +24933,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24318,6 +24961,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24345,6 +24989,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24372,6 +25017,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24399,6 +25045,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24426,6 +25073,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24453,6 +25101,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24480,6 +25129,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24514,6 +25164,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24576,6 +25227,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24603,6 +25255,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24630,6 +25283,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24769,6 +25423,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24838,6 +25493,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24865,6 +25521,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24892,6 +25549,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24961,6 +25619,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24988,6 +25647,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25015,6 +25675,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -25042,6 +25703,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -25076,6 +25738,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25117,6 +25780,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25144,6 +25808,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25171,6 +25836,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25198,6 +25864,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25225,6 +25892,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25252,6 +25920,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25279,6 +25948,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25306,6 +25976,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25375,6 +26046,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25402,6 +26074,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25429,6 +26102,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25463,6 +26137,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25490,6 +26165,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25538,6 +26214,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25572,6 +26249,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25599,6 +26277,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25626,6 +26305,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25653,6 +26333,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25680,6 +26361,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25707,6 +26389,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25734,6 +26417,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25761,6 +26445,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25823,6 +26508,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25850,6 +26536,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25884,6 +26571,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25911,6 +26599,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25938,6 +26627,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25986,6 +26676,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26013,6 +26704,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -26040,6 +26732,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26067,6 +26760,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26101,6 +26795,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26198,6 +26893,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26225,6 +26921,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26287,6 +26984,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26314,6 +27012,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26341,6 +27040,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26368,6 +27068,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26395,6 +27096,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26422,6 +27124,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26449,6 +27152,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26483,6 +27187,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26510,6 +27215,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26579,6 +27285,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26606,6 +27313,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26703,6 +27411,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26730,6 +27439,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26757,6 +27467,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26784,6 +27495,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26811,6 +27523,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26838,6 +27551,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26893,6 +27607,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26920,6 +27635,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27108,6 +27824,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27135,6 +27852,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27162,6 +27880,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27189,6 +27908,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27223,6 +27943,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27250,6 +27971,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27326,6 +28048,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27353,6 +28076,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27394,6 +28118,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27421,6 +28146,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27462,6 +28188,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27552,6 +28279,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27579,6 +28307,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27606,6 +28335,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27633,6 +28363,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27660,6 +28391,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27687,6 +28419,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27714,6 +28447,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27741,6 +28475,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27768,6 +28503,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27795,6 +28531,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27822,6 +28559,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27849,6 +28587,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27876,6 +28615,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27903,6 +28643,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -28007,6 +28748,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -28062,6 +28804,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -28089,6 +28832,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -28116,6 +28860,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28143,6 +28888,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28170,6 +28916,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28197,6 +28944,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28252,6 +29000,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28279,6 +29028,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28306,6 +29056,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28340,6 +29091,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28395,6 +29147,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28422,6 +29175,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28449,6 +29203,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28518,6 +29273,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28545,6 +29301,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28572,6 +29329,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28599,6 +29357,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28626,6 +29385,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28653,6 +29413,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28680,6 +29441,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28707,6 +29469,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28762,6 +29525,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28789,6 +29553,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28816,6 +29581,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28850,6 +29616,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28877,6 +29644,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28911,6 +29679,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28938,6 +29707,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28965,6 +29735,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28992,6 +29763,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -29075,6 +29847,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29102,6 +29875,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29171,6 +29945,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29268,6 +30043,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29295,6 +30071,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29322,6 +30099,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29349,6 +30127,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29418,6 +30197,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29445,6 +30225,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29500,6 +30281,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29527,6 +30309,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29554,6 +30337,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29581,6 +30365,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29622,6 +30407,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29649,6 +30435,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29683,6 +30470,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29710,6 +30498,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29737,6 +30526,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29764,6 +30554,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29791,6 +30582,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29825,6 +30617,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29852,6 +30645,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29879,6 +30673,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29906,6 +30701,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29933,6 +30729,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29960,6 +30757,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -30057,6 +30855,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -30084,6 +30883,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -30111,6 +30911,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30138,6 +30939,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30165,6 +30967,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30192,6 +30995,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30219,6 +31023,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30246,6 +31051,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30287,6 +31093,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30314,6 +31121,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30341,6 +31149,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30396,6 +31205,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30423,6 +31233,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30450,6 +31261,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30477,6 +31289,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30504,6 +31317,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30531,6 +31345,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30558,6 +31373,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30613,6 +31429,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30640,6 +31457,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30674,6 +31492,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30736,6 +31555,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30763,6 +31583,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30790,6 +31611,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30817,6 +31639,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30844,6 +31667,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30871,6 +31695,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30898,6 +31723,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30925,6 +31751,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30952,6 +31779,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31007,6 +31835,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -31034,6 +31863,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -31061,6 +31891,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31088,6 +31919,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -31115,6 +31947,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31142,6 +31975,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31176,6 +32010,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31203,6 +32038,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31258,6 +32094,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31285,6 +32122,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31312,6 +32150,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31339,6 +32178,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31366,6 +32206,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31393,6 +32234,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31420,6 +32262,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31447,6 +32290,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31572,6 +32416,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31599,6 +32444,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31626,6 +32472,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31653,6 +32500,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31708,6 +32556,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31735,6 +32584,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31790,6 +32640,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31817,6 +32668,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31844,6 +32696,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31899,6 +32752,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31933,6 +32787,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32023,6 +32878,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32050,6 +32906,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -32133,6 +32990,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32174,6 +33032,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32201,6 +33060,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32256,6 +33116,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32283,6 +33144,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32310,6 +33172,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32344,6 +33207,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32371,6 +33235,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32398,6 +33263,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32425,6 +33291,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32452,6 +33319,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32479,6 +33347,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32506,6 +33375,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32533,6 +33403,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32560,6 +33431,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32615,6 +33487,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32642,6 +33515,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32669,6 +33543,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32696,6 +33571,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32723,6 +33599,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32750,6 +33627,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32777,6 +33655,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32832,6 +33711,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32880,6 +33760,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32921,6 +33802,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32948,6 +33830,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32975,6 +33858,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -33002,6 +33886,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33092,6 +33977,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33119,6 +34005,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33146,6 +34033,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33180,6 +34068,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33207,6 +34096,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33234,6 +34124,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33275,6 +34166,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33330,6 +34222,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33357,6 +34250,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33454,6 +34348,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33530,6 +34425,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33606,6 +34502,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33696,6 +34593,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33737,6 +34635,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33778,6 +34677,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33833,6 +34733,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33860,6 +34761,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33894,6 +34796,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33921,6 +34824,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -34004,6 +34908,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -34031,6 +34936,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -34058,6 +34964,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34085,6 +34992,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34112,6 +35020,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -34139,6 +35048,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34180,6 +35090,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34207,6 +35118,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34276,6 +35188,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34303,6 +35216,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34330,6 +35244,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34357,6 +35272,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34384,6 +35300,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34411,6 +35328,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34445,6 +35363,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34479,6 +35398,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34576,6 +35496,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34603,6 +35524,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34630,6 +35552,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34657,6 +35580,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34684,6 +35608,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34711,6 +35636,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34766,6 +35692,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34793,6 +35720,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34883,6 +35811,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34938,6 +35867,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34965,6 +35895,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34992,6 +35923,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35019,6 +35951,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -35067,6 +36000,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35094,6 +36028,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35121,6 +36056,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35253,6 +36189,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35280,6 +36217,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35307,6 +36245,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35334,6 +36273,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35361,6 +36301,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35388,6 +36329,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35415,6 +36357,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35442,6 +36385,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35469,6 +36413,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35496,6 +36441,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35558,6 +36504,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35606,6 +36553,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35633,6 +36581,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35660,6 +36609,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35687,6 +36637,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35714,6 +36665,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35748,6 +36700,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35775,6 +36728,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35802,6 +36756,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35829,6 +36784,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35856,6 +36812,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35904,6 +36861,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35959,6 +36917,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35986,6 +36945,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -36013,6 +36973,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36047,6 +37008,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -36074,6 +37036,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36143,6 +37106,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36191,6 +37155,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36246,6 +37211,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36287,6 +37253,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36314,6 +37281,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36383,6 +37351,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36410,6 +37379,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36437,6 +37407,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36464,6 +37435,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36568,6 +37540,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36595,6 +37568,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36622,6 +37596,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36719,6 +37694,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36746,6 +37722,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36773,6 +37750,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36800,6 +37778,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36827,6 +37806,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36854,6 +37834,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36881,6 +37862,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36908,6 +37890,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36935,6 +37918,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36962,6 +37946,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36989,6 +37974,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -37023,6 +38009,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -37050,6 +38037,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -37077,6 +38065,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37132,6 +38121,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37159,6 +38149,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37186,6 +38177,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37241,6 +38233,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37268,6 +38261,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37323,6 +38317,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37350,6 +38345,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37377,6 +38373,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37425,6 +38422,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37452,6 +38450,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37479,6 +38478,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37506,6 +38506,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37547,6 +38548,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37574,6 +38576,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37608,6 +38611,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37635,6 +38639,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37669,6 +38674,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37724,6 +38730,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37751,6 +38758,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37778,6 +38786,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37826,6 +38835,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37860,6 +38870,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37922,6 +38933,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37949,6 +38961,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37976,6 +38989,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38024,6 +39038,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -38051,6 +39066,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38078,6 +39094,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -38126,6 +39143,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38153,6 +39171,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38264,6 +39283,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38319,6 +39339,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38346,6 +39367,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38394,6 +39416,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38421,6 +39444,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38490,6 +39514,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38517,6 +39542,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38572,6 +39598,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38599,6 +39626,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38626,6 +39654,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38653,6 +39682,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38680,6 +39710,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38707,6 +39738,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38769,6 +39801,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38796,6 +39829,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38844,6 +39878,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38871,6 +39906,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38898,6 +39934,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38925,6 +39962,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38980,6 +40018,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39007,6 +40046,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -39034,6 +40074,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -39061,6 +40102,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -39130,6 +40172,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39157,6 +40200,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39184,6 +40228,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39260,6 +40305,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39287,6 +40333,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39321,6 +40368,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39355,6 +40403,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39389,6 +40438,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39416,6 +40466,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39443,6 +40494,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39470,6 +40522,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39504,6 +40557,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39531,6 +40585,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39558,6 +40613,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39585,6 +40641,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39619,6 +40676,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39653,6 +40711,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39680,6 +40739,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39707,6 +40767,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39818,6 +40879,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39845,6 +40907,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39872,6 +40935,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39899,6 +40963,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39954,6 +41019,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39981,6 +41047,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40015,6 +41082,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40042,6 +41110,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -40139,6 +41208,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40166,6 +41236,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40193,6 +41264,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40220,6 +41292,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40289,6 +41362,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x087d606d31d5c60e7b5ae9dbec31e7fc4f0bf71a81abfc5b0bf03390e925034f.json
+++ b/test/testData/testPools/0x087d606d31d5c60e7b5ae9dbec31e7fc4f0bf71a81abfc5b0bf03390e925034f.json
@@ -1161,6 +1161,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2468,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5859,6 +5861,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8134,6 +8137,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8451,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14644,6 +14649,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -20178,6 +20184,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -33486,6 +33493,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",

--- a/test/testData/testPools/0x08ec2862ec5c1ede9087dfe0015d72603767b2ed243a17fbd431d5df37a50826.json
+++ b/test/testData/testPools/0x08ec2862ec5c1ede9087dfe0015d72603767b2ed243a17fbd431d5df37a50826.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x0a554ce1e35b9820f121ac7faa97069650df754117d6c5eb7c1158f915878343.json
+++ b/test/testData/testPools/0x0a554ce1e35b9820f121ac7faa97069650df754117d6c5eb7c1158f915878343.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x0a554ce1e35b9820f121ac7faa97069650df754117d6c5eb7c1158f915878343.json
+++ b/test/testData/testPools/0x0a554ce1e35b9820f121ac7faa97069650df754117d6c5eb7c1158f915878343.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -171,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -198,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -232,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -259,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -286,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -313,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -340,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -367,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -422,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -470,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -511,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -538,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -621,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -648,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -696,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -723,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -750,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -854,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -881,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -908,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -935,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -962,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1003,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1030,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1071,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1098,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1237,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1264,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1291,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1318,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1345,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1400,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1427,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1475,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1502,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1550,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1577,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1604,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1631,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1672,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1699,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1726,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1753,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1780,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1835,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1876,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1987,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2063,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2181,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2229,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2256,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2283,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2338,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2365,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2455,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2510,6 +2568,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2544,6 +2603,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2571,6 +2631,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2598,6 +2659,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2674,6 +2736,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2701,6 +2764,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2735,6 +2799,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2762,6 +2827,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2789,6 +2855,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2816,6 +2883,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2843,6 +2911,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2877,6 +2946,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2904,6 +2974,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2931,6 +3002,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2958,6 +3030,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3062,6 +3135,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3096,6 +3170,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3123,6 +3198,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3150,6 +3226,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3177,6 +3254,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3218,6 +3296,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3245,6 +3324,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3272,6 +3352,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3299,6 +3380,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3326,6 +3408,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3395,6 +3478,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3443,6 +3527,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3470,6 +3555,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3497,6 +3583,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3524,6 +3611,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3551,6 +3639,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3620,6 +3709,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3647,6 +3737,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3674,6 +3765,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3701,6 +3793,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3728,6 +3821,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3755,6 +3849,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3782,6 +3877,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3809,6 +3905,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3843,6 +3940,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3870,6 +3968,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3897,6 +3996,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3924,6 +4024,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3958,6 +4059,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3985,6 +4087,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4012,6 +4115,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4067,6 +4171,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4108,6 +4213,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4135,6 +4241,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4183,6 +4290,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4259,6 +4367,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4286,6 +4395,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4341,6 +4451,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4368,6 +4479,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4451,6 +4563,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4492,6 +4605,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4519,6 +4633,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4546,6 +4661,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4573,6 +4689,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4600,6 +4717,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4627,6 +4745,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4654,6 +4773,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4681,6 +4801,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4708,6 +4829,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4763,6 +4885,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4832,6 +4955,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4859,6 +4983,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4886,6 +5011,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4913,6 +5039,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5052,6 +5179,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5107,6 +5235,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5141,6 +5270,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5168,6 +5298,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5195,6 +5326,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5222,6 +5354,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5277,6 +5410,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5304,6 +5438,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5359,6 +5494,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5386,6 +5522,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5441,6 +5578,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5503,6 +5641,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5530,6 +5669,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5557,6 +5697,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5584,6 +5725,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5611,6 +5753,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5666,6 +5809,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5700,6 +5844,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5727,6 +5872,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5754,6 +5900,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5809,6 +5956,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5836,6 +5984,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5863,6 +6012,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5918,6 +6068,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5945,6 +6096,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5972,6 +6124,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5999,6 +6152,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6026,6 +6180,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6053,6 +6208,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6101,6 +6257,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6128,6 +6285,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6169,6 +6327,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6217,6 +6376,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6244,6 +6404,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6271,6 +6432,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6326,6 +6488,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6402,6 +6565,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6471,6 +6635,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6498,6 +6663,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6532,6 +6698,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6559,6 +6726,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6586,6 +6754,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6613,6 +6782,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6640,6 +6810,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6667,6 +6838,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6694,6 +6866,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6721,6 +6894,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6783,6 +6957,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6852,6 +7027,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6879,6 +7055,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6934,6 +7111,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6961,6 +7139,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7023,6 +7202,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7050,6 +7230,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7077,6 +7258,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7104,6 +7286,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7138,6 +7321,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7193,6 +7377,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7220,6 +7405,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7275,6 +7461,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7302,6 +7489,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7357,6 +7545,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7384,6 +7573,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7411,6 +7601,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7438,6 +7629,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7493,6 +7685,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7520,6 +7713,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7659,6 +7853,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7686,6 +7881,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7713,6 +7909,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7740,6 +7937,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7767,6 +7965,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7829,6 +8028,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7863,6 +8063,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7890,6 +8091,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7917,6 +8119,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7965,6 +8168,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7992,6 +8196,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8019,6 +8224,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8046,6 +8252,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8073,6 +8280,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8100,6 +8308,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8127,6 +8336,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8203,6 +8413,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8230,6 +8441,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8264,6 +8476,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8291,6 +8504,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8318,6 +8532,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8359,6 +8574,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8386,6 +8602,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8420,6 +8637,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8517,6 +8735,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8544,6 +8763,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8571,6 +8791,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8668,6 +8889,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8695,6 +8917,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8722,6 +8945,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8756,6 +8980,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8783,6 +9008,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8831,6 +9057,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8879,6 +9106,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8934,6 +9162,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8961,6 +9190,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8988,6 +9218,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9015,6 +9246,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9042,6 +9274,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9111,6 +9344,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9138,6 +9372,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9165,6 +9400,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9220,6 +9456,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9261,6 +9498,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9358,6 +9596,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9406,6 +9645,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9433,6 +9673,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9502,6 +9743,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9550,6 +9792,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9577,6 +9820,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9604,6 +9848,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9631,6 +9876,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9658,6 +9904,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9685,6 +9932,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9712,6 +9960,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9739,6 +9988,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9766,6 +10016,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9793,6 +10044,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9820,6 +10072,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9847,6 +10100,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9874,6 +10128,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9901,6 +10156,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9928,6 +10184,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9955,6 +10212,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9982,6 +10240,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10009,6 +10268,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10050,6 +10310,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10077,6 +10338,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10104,6 +10366,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10159,6 +10422,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10186,6 +10450,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10213,6 +10478,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10247,6 +10513,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10274,6 +10541,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10301,6 +10569,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10328,6 +10597,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10355,6 +10625,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10410,6 +10681,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10437,6 +10709,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10485,6 +10758,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10540,6 +10814,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10567,6 +10842,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10594,6 +10870,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10649,6 +10926,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10676,6 +10954,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10766,6 +11045,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10793,6 +11073,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10820,6 +11101,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10847,6 +11129,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10916,6 +11199,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10950,6 +11234,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11033,6 +11318,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11060,6 +11346,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11108,6 +11395,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11135,6 +11423,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11183,6 +11472,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11210,6 +11500,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11237,6 +11528,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11299,6 +11591,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11340,6 +11633,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11367,6 +11661,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11394,6 +11689,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11421,6 +11717,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11448,6 +11745,7 @@
         {
             "id": "0x4b3fa856cef9aa85ed9bbfa8992d6138c5f150e6",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -11517,6 +11815,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11586,6 +11885,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11613,6 +11913,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11640,6 +11941,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11702,6 +12004,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11736,6 +12039,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11763,6 +12067,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11790,6 +12095,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11817,6 +12123,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11844,6 +12151,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11871,6 +12179,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11898,6 +12207,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11925,6 +12235,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11952,6 +12263,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11979,6 +12291,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12034,6 +12347,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12061,6 +12375,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12088,6 +12403,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12115,6 +12431,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12177,6 +12494,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12211,6 +12529,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12238,6 +12557,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12265,6 +12585,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12320,6 +12641,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12375,6 +12697,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12402,6 +12725,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12429,6 +12753,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12456,6 +12781,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12483,6 +12809,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12510,6 +12837,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12565,6 +12893,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12634,6 +12963,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12661,6 +12991,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12688,6 +13019,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12722,6 +13054,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12854,6 +13187,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12951,6 +13285,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12985,6 +13320,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -13054,6 +13390,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13081,6 +13418,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13108,6 +13446,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13135,6 +13474,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13162,6 +13502,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13189,6 +13530,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13244,6 +13586,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13271,6 +13614,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13319,6 +13663,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13416,6 +13761,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13485,6 +13831,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13631,6 +13978,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13686,6 +14034,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13713,6 +14062,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13740,6 +14090,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13795,6 +14146,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13822,6 +14174,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13849,6 +14202,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13876,6 +14230,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13903,6 +14258,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13930,6 +14286,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13957,6 +14314,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13984,6 +14342,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -14011,6 +14370,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -14101,6 +14461,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14128,6 +14489,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14155,6 +14517,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14182,6 +14545,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14335,6 +14699,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14362,6 +14727,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14389,6 +14755,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14416,6 +14783,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14457,6 +14825,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14484,6 +14853,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14511,6 +14881,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14538,6 +14909,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14593,6 +14965,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14620,6 +14993,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14647,6 +15021,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14744,6 +15119,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14771,6 +15147,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14798,6 +15175,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14853,6 +15231,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14880,6 +15259,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14942,6 +15322,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14969,6 +15350,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14996,6 +15378,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -15023,6 +15406,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15050,6 +15434,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15077,6 +15462,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15132,6 +15518,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15201,6 +15588,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15228,6 +15616,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15255,6 +15644,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15282,6 +15672,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15309,6 +15700,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15336,6 +15728,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15363,6 +15756,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15502,6 +15896,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15529,6 +15924,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15556,6 +15952,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15583,6 +15980,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15610,6 +16008,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15651,6 +16050,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15678,6 +16078,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15705,6 +16106,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15732,6 +16134,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15759,6 +16162,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15793,6 +16197,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15820,6 +16225,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15847,6 +16253,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15944,6 +16351,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15971,6 +16379,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15998,6 +16407,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -16025,6 +16435,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -16052,6 +16463,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16079,6 +16491,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16106,6 +16519,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16133,6 +16547,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16160,6 +16575,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16187,6 +16603,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16214,6 +16631,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16255,6 +16673,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16282,6 +16701,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16309,6 +16729,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16371,6 +16792,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16398,6 +16820,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16425,6 +16848,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16452,6 +16876,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16479,6 +16904,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16534,6 +16960,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16561,6 +16988,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16588,6 +17016,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16615,6 +17044,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16642,6 +17072,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16732,6 +17163,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16759,6 +17191,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16786,6 +17219,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16813,6 +17247,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16840,6 +17275,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16867,6 +17303,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16894,6 +17331,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -17040,6 +17478,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17067,6 +17506,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17094,6 +17534,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17121,6 +17562,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17148,6 +17590,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17182,6 +17625,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17237,6 +17681,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17306,6 +17751,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17333,6 +17779,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17360,6 +17807,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17387,6 +17835,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17414,6 +17863,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17441,6 +17891,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17468,6 +17919,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17558,6 +18010,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17585,6 +18038,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17612,6 +18066,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17639,6 +18094,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17666,6 +18122,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17714,6 +18171,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17755,6 +18213,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17782,6 +18241,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17809,6 +18269,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17843,6 +18304,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17870,6 +18332,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17939,6 +18402,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17966,6 +18430,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -18000,6 +18465,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -18027,6 +18493,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -18054,6 +18521,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18109,6 +18577,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18164,6 +18633,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18233,6 +18703,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18260,6 +18731,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18287,6 +18759,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18314,6 +18787,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18369,6 +18843,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18438,6 +18913,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18465,6 +18941,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18534,6 +19011,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18561,6 +19039,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18588,6 +19067,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18615,6 +19095,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18642,6 +19123,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18669,6 +19151,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18696,6 +19179,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18730,6 +19214,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18764,6 +19249,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18791,6 +19277,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18818,6 +19305,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18873,6 +19361,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18900,6 +19389,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18927,6 +19417,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18954,6 +19445,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18988,6 +19480,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -19015,6 +19508,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -19042,6 +19536,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19069,6 +19564,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19096,6 +19592,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19130,6 +19627,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19157,6 +19655,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19212,6 +19711,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19239,6 +19739,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19322,6 +19823,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19356,6 +19858,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19411,6 +19914,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19438,6 +19942,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19465,6 +19970,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19492,6 +19998,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19526,6 +20033,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19553,6 +20061,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19580,6 +20089,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19607,6 +20117,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19662,6 +20173,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19689,6 +20201,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19716,6 +20229,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19764,6 +20278,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19791,6 +20306,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19818,6 +20334,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19845,6 +20362,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19872,6 +20390,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19899,6 +20418,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19926,6 +20446,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19953,6 +20474,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19980,6 +20502,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -20049,6 +20572,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20076,6 +20600,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20103,6 +20628,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20130,6 +20656,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20164,6 +20691,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20191,6 +20719,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20218,6 +20747,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20245,6 +20775,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20314,6 +20845,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20341,6 +20873,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20382,6 +20915,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20409,6 +20943,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20478,6 +21013,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20540,6 +21076,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20567,6 +21104,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20636,6 +21174,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20663,6 +21202,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20690,6 +21230,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20717,6 +21258,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20744,6 +21286,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20771,6 +21314,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20798,6 +21342,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20825,6 +21370,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20859,6 +21405,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20949,6 +21496,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20976,6 +21524,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -21003,6 +21552,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -21037,6 +21587,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21071,6 +21622,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21112,6 +21664,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21167,6 +21720,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21194,6 +21748,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21221,6 +21776,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21290,6 +21846,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21317,6 +21874,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21358,6 +21916,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21413,6 +21972,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21440,6 +22000,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21467,6 +22028,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21501,6 +22063,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21528,6 +22091,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21555,6 +22119,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21582,6 +22147,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21609,6 +22175,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21636,6 +22203,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21677,6 +22245,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21704,6 +22273,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21731,6 +22301,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21758,6 +22329,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21834,6 +22406,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21861,6 +22434,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21888,6 +22462,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21915,6 +22490,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21942,6 +22518,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21969,6 +22546,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22017,6 +22595,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22051,6 +22630,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22078,6 +22658,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22105,6 +22686,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22132,6 +22714,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22159,6 +22742,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22186,6 +22770,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22213,6 +22798,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22254,6 +22840,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22281,6 +22868,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22308,6 +22896,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22447,6 +23036,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22488,6 +23078,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22515,6 +23106,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22549,6 +23141,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22604,6 +23197,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22631,6 +23225,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22658,6 +23253,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22706,6 +23302,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22747,6 +23344,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22774,6 +23372,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22801,6 +23400,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22870,6 +23470,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22904,6 +23505,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22931,6 +23533,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22965,6 +23568,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22999,6 +23603,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -23026,6 +23631,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -23053,6 +23659,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23080,6 +23687,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23107,6 +23715,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23134,6 +23743,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23161,6 +23771,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23216,6 +23827,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23243,6 +23855,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23298,6 +23911,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23360,6 +23974,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23387,6 +24002,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23414,6 +24030,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23455,6 +24072,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23510,6 +24128,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23537,6 +24156,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23564,6 +24184,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23591,6 +24212,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23625,6 +24247,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23652,6 +24275,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23686,6 +24310,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23713,6 +24338,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23761,6 +24387,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23788,6 +24415,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23815,6 +24443,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23842,6 +24471,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23869,6 +24499,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23924,6 +24555,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23951,6 +24583,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23978,6 +24611,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -24033,6 +24667,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -24060,6 +24695,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24108,6 +24744,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24156,6 +24793,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24183,6 +24821,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24210,6 +24849,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24237,6 +24877,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24264,6 +24905,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24291,6 +24933,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24318,6 +24961,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24345,6 +24989,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24372,6 +25017,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24399,6 +25045,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24426,6 +25073,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24453,6 +25101,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24480,6 +25129,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24514,6 +25164,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24576,6 +25227,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24603,6 +25255,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24630,6 +25283,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24769,6 +25423,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24838,6 +25493,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24865,6 +25521,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24892,6 +25549,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24961,6 +25619,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24988,6 +25647,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25015,6 +25675,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -25042,6 +25703,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -25076,6 +25738,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25117,6 +25780,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25144,6 +25808,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25171,6 +25836,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25198,6 +25864,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25225,6 +25892,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25252,6 +25920,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25279,6 +25948,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25306,6 +25976,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25375,6 +26046,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25402,6 +26074,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25429,6 +26102,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25463,6 +26137,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25490,6 +26165,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25538,6 +26214,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25572,6 +26249,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25599,6 +26277,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25626,6 +26305,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25653,6 +26333,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25680,6 +26361,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25707,6 +26389,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25734,6 +26417,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25761,6 +26445,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25823,6 +26508,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25850,6 +26536,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25884,6 +26571,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25911,6 +26599,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25938,6 +26627,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25986,6 +26676,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26013,6 +26704,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -26040,6 +26732,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26067,6 +26760,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26101,6 +26795,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26198,6 +26893,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26225,6 +26921,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26287,6 +26984,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26314,6 +27012,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26341,6 +27040,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26368,6 +27068,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26395,6 +27096,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26422,6 +27124,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26449,6 +27152,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26483,6 +27187,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26510,6 +27215,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26579,6 +27285,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26606,6 +27313,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26703,6 +27411,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26730,6 +27439,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26757,6 +27467,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26784,6 +27495,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26811,6 +27523,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26838,6 +27551,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26893,6 +27607,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26920,6 +27635,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27108,6 +27824,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27135,6 +27852,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27162,6 +27880,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27189,6 +27908,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27223,6 +27943,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27250,6 +27971,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27326,6 +28048,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27353,6 +28076,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27394,6 +28118,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27421,6 +28146,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27462,6 +28188,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27552,6 +28279,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27579,6 +28307,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27606,6 +28335,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27633,6 +28363,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27660,6 +28391,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27687,6 +28419,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27714,6 +28447,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27741,6 +28475,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27768,6 +28503,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27795,6 +28531,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27822,6 +28559,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27849,6 +28587,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27876,6 +28615,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27903,6 +28643,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -28007,6 +28748,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -28062,6 +28804,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -28089,6 +28832,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -28116,6 +28860,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28143,6 +28888,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28170,6 +28916,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28197,6 +28944,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28252,6 +29000,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28279,6 +29028,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28306,6 +29056,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28340,6 +29091,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28395,6 +29147,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28422,6 +29175,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28449,6 +29203,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28518,6 +29273,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28545,6 +29301,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28572,6 +29329,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28599,6 +29357,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28626,6 +29385,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28653,6 +29413,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28680,6 +29441,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28707,6 +29469,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28762,6 +29525,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28789,6 +29553,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28816,6 +29581,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28850,6 +29616,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28877,6 +29644,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28911,6 +29679,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28938,6 +29707,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28965,6 +29735,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28992,6 +29763,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -29075,6 +29847,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29102,6 +29875,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29171,6 +29945,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29268,6 +30043,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29295,6 +30071,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29322,6 +30099,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29349,6 +30127,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29418,6 +30197,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29445,6 +30225,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29500,6 +30281,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29527,6 +30309,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29554,6 +30337,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29581,6 +30365,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29622,6 +30407,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29649,6 +30435,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29683,6 +30470,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29710,6 +30498,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29737,6 +30526,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29764,6 +30554,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29791,6 +30582,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29825,6 +30617,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29852,6 +30645,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29879,6 +30673,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29906,6 +30701,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29933,6 +30729,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29960,6 +30757,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -30057,6 +30855,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -30084,6 +30883,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -30111,6 +30911,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30138,6 +30939,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30165,6 +30967,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30192,6 +30995,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30219,6 +31023,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30246,6 +31051,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30287,6 +31093,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30314,6 +31121,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30341,6 +31149,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30396,6 +31205,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30423,6 +31233,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30450,6 +31261,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30477,6 +31289,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30504,6 +31317,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30531,6 +31345,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30558,6 +31373,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30613,6 +31429,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30640,6 +31457,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30674,6 +31492,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30736,6 +31555,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30763,6 +31583,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30790,6 +31611,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30817,6 +31639,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30844,6 +31667,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30871,6 +31695,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30898,6 +31723,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30925,6 +31751,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30952,6 +31779,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31007,6 +31835,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -31034,6 +31863,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -31061,6 +31891,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31088,6 +31919,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -31115,6 +31947,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31142,6 +31975,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31176,6 +32010,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31203,6 +32038,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31258,6 +32094,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31285,6 +32122,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31312,6 +32150,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31339,6 +32178,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31366,6 +32206,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31393,6 +32234,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31420,6 +32262,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31447,6 +32290,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31572,6 +32416,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31599,6 +32444,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31626,6 +32472,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31653,6 +32500,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31708,6 +32556,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31735,6 +32584,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31790,6 +32640,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31817,6 +32668,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31844,6 +32696,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31899,6 +32752,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31933,6 +32787,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32023,6 +32878,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32050,6 +32906,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -32133,6 +32990,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32174,6 +33032,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32201,6 +33060,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32256,6 +33116,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32283,6 +33144,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32310,6 +33172,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32344,6 +33207,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32371,6 +33235,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32398,6 +33263,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32425,6 +33291,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32452,6 +33319,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32479,6 +33347,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32506,6 +33375,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32533,6 +33403,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32560,6 +33431,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32615,6 +33487,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32642,6 +33515,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32669,6 +33543,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32696,6 +33571,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32723,6 +33599,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32750,6 +33627,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32777,6 +33655,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32832,6 +33711,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32880,6 +33760,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32921,6 +33802,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32948,6 +33830,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32975,6 +33858,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -33002,6 +33886,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33092,6 +33977,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33119,6 +34005,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33146,6 +34033,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33180,6 +34068,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33207,6 +34096,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33234,6 +34124,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33275,6 +34166,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33330,6 +34222,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33357,6 +34250,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33454,6 +34348,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33530,6 +34425,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33606,6 +34502,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33696,6 +34593,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33737,6 +34635,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33778,6 +34677,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33833,6 +34733,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33860,6 +34761,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33894,6 +34796,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33921,6 +34824,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -34004,6 +34908,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -34031,6 +34936,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -34058,6 +34964,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34085,6 +34992,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34112,6 +35020,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -34139,6 +35048,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34180,6 +35090,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34207,6 +35118,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34276,6 +35188,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34303,6 +35216,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34330,6 +35244,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34357,6 +35272,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34384,6 +35300,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34411,6 +35328,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34445,6 +35363,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34479,6 +35398,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34576,6 +35496,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34603,6 +35524,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34630,6 +35552,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34657,6 +35580,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34684,6 +35608,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34711,6 +35636,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34766,6 +35692,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34793,6 +35720,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34883,6 +35811,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34938,6 +35867,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34965,6 +35895,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34992,6 +35923,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35019,6 +35951,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -35067,6 +36000,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35094,6 +36028,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35121,6 +36056,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35253,6 +36189,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35280,6 +36217,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35307,6 +36245,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35334,6 +36273,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35361,6 +36301,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35388,6 +36329,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35415,6 +36357,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35442,6 +36385,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35469,6 +36413,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35496,6 +36441,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35558,6 +36504,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35606,6 +36553,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35633,6 +36581,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35660,6 +36609,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35687,6 +36637,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35714,6 +36665,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35748,6 +36700,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35775,6 +36728,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35802,6 +36756,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35829,6 +36784,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35856,6 +36812,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35904,6 +36861,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35959,6 +36917,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35986,6 +36945,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -36013,6 +36973,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36047,6 +37008,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -36074,6 +37036,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36143,6 +37106,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36191,6 +37155,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36246,6 +37211,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36287,6 +37253,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36314,6 +37281,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36383,6 +37351,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36410,6 +37379,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36437,6 +37407,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36464,6 +37435,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36568,6 +37540,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36595,6 +37568,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36622,6 +37596,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36719,6 +37694,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36746,6 +37722,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36773,6 +37750,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36800,6 +37778,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36827,6 +37806,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36854,6 +37834,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36881,6 +37862,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36908,6 +37890,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36935,6 +37918,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36962,6 +37946,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36989,6 +37974,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -37023,6 +38009,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -37050,6 +38037,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -37077,6 +38065,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37132,6 +38121,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37159,6 +38149,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37186,6 +38177,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37241,6 +38233,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37268,6 +38261,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37323,6 +38317,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37350,6 +38345,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37377,6 +38373,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37425,6 +38422,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37452,6 +38450,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37479,6 +38478,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37506,6 +38506,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37547,6 +38548,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37574,6 +38576,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37608,6 +38611,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37635,6 +38639,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37669,6 +38674,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37724,6 +38730,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37751,6 +38758,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37778,6 +38786,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37826,6 +38835,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37860,6 +38870,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37922,6 +38933,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37949,6 +38961,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37976,6 +38989,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38024,6 +39038,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -38051,6 +39066,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38078,6 +39094,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -38126,6 +39143,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38153,6 +39171,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38264,6 +39283,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38319,6 +39339,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38346,6 +39367,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38394,6 +39416,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38421,6 +39444,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38490,6 +39514,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38517,6 +39542,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38572,6 +39598,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38599,6 +39626,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38626,6 +39654,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38653,6 +39682,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38680,6 +39710,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38707,6 +39738,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38769,6 +39801,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38796,6 +39829,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38844,6 +39878,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38871,6 +39906,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38898,6 +39934,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38925,6 +39962,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38980,6 +40018,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39007,6 +40046,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -39034,6 +40074,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -39061,6 +40102,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -39130,6 +40172,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39157,6 +40200,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39184,6 +40228,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39260,6 +40305,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39287,6 +40333,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39321,6 +40368,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39355,6 +40403,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39389,6 +40438,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39416,6 +40466,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39443,6 +40494,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39470,6 +40522,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39504,6 +40557,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39531,6 +40585,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39558,6 +40613,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39585,6 +40641,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39619,6 +40676,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39653,6 +40711,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39680,6 +40739,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39707,6 +40767,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39818,6 +40879,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39845,6 +40907,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39872,6 +40935,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39899,6 +40963,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39954,6 +41019,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39981,6 +41047,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40015,6 +41082,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40042,6 +41110,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -40139,6 +41208,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40166,6 +41236,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40193,6 +41264,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40220,6 +41292,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40289,6 +41362,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x0a96d61ff013aff7dde200d3aaa6b7e1bc3a30d1701b9a0d60bb63d931cdbdcc.json
+++ b/test/testData/testPools/0x0a96d61ff013aff7dde200d3aaa6b7e1bc3a30d1701b9a0d60bb63d931cdbdcc.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -94,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -169,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -196,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -230,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -257,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -284,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -311,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -338,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -365,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -392,6 +405,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -419,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -467,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -508,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -535,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -562,6 +580,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +608,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -616,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -643,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -691,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -718,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -745,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -800,6 +825,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -848,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -875,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -902,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -929,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -956,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -997,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1024,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1065,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1092,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1161,6 +1196,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1230,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1257,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1284,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1311,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1338,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1365,6 +1406,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1392,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1419,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1467,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1494,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1542,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1569,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1596,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1623,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1664,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1691,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1718,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1745,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1772,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1799,6 +1854,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1826,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1867,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1894,6 +1952,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1987,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -1976,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2004,6 +2065,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2051,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2169,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2168,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2216,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2243,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2270,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2325,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2352,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2379,6 +2449,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2477,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2440,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2467,6 +2540,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2494,6 +2569,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2528,6 +2604,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2555,6 +2632,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2582,6 +2660,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2609,6 +2688,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2657,6 +2737,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2684,6 +2765,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2718,6 +2800,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2745,6 +2828,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2772,6 +2856,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2799,6 +2884,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2826,6 +2912,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2860,6 +2947,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2887,6 +2975,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2914,6 +3003,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2941,6 +3031,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -2975,6 +3066,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3044,6 +3136,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3078,6 +3171,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3105,6 +3199,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3132,6 +3227,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3159,6 +3255,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3200,6 +3297,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3227,6 +3325,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3254,6 +3353,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3281,6 +3381,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3308,6 +3409,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3335,6 +3437,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3376,6 +3479,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3424,6 +3528,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3451,6 +3556,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3478,6 +3584,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3505,6 +3612,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3532,6 +3640,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3601,6 +3710,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3628,6 +3738,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3655,6 +3766,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3682,6 +3794,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3709,6 +3822,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3736,6 +3850,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3763,6 +3878,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3790,6 +3906,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3824,6 +3941,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3851,6 +3969,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3878,6 +3997,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3905,6 +4025,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3939,6 +4060,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3966,6 +4088,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -3993,6 +4116,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4020,6 +4144,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4047,6 +4172,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4088,6 +4214,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4115,6 +4242,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4163,6 +4291,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4190,6 +4319,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4238,6 +4368,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4265,6 +4396,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4292,6 +4424,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4319,6 +4452,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4346,6 +4480,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4373,6 +4508,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4428,6 +4564,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4469,6 +4606,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4496,6 +4634,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4523,6 +4662,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4550,6 +4690,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4577,6 +4718,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4604,6 +4746,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4774,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4658,6 +4802,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4685,6 +4830,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4712,6 +4858,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4739,6 +4886,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4808,6 +4956,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4835,6 +4984,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4862,6 +5012,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4889,6 +5040,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -4930,6 +5082,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5152,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5026,6 +5180,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5053,6 +5208,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5080,6 +5236,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5114,6 +5271,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5141,6 +5299,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5168,6 +5327,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5195,6 +5355,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5222,6 +5383,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5249,6 +5411,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5276,6 +5439,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5303,6 +5467,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5495,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5357,6 +5523,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5412,6 +5579,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5439,6 +5607,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5473,6 +5642,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5500,6 +5670,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5527,6 +5698,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5554,6 +5726,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5581,6 +5754,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5608,6 +5782,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5635,6 +5810,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5669,6 +5845,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5696,6 +5873,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5723,6 +5901,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5778,6 +5957,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5805,6 +5985,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5832,6 +6013,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5859,6 +6041,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -5886,6 +6070,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5913,6 +6098,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5940,6 +6126,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5967,6 +6154,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5994,6 +6182,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6021,6 +6210,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6069,6 +6259,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6096,6 +6287,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6137,6 +6329,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6185,6 +6378,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6212,6 +6406,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6239,6 +6434,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6294,6 +6490,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6328,6 +6525,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6369,6 +6567,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6438,6 +6637,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6465,6 +6665,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6499,6 +6700,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6526,6 +6728,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6553,6 +6756,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6580,6 +6784,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6607,6 +6812,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6634,6 +6840,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6661,6 +6868,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6688,6 +6896,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6750,6 +6959,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6819,6 +7029,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6846,6 +7057,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6873,6 +7085,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6900,6 +7113,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6927,6 +7141,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6954,6 +7169,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -6988,6 +7204,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7015,6 +7232,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7042,6 +7260,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7069,6 +7288,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7103,6 +7323,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7130,6 +7351,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7157,6 +7379,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7184,6 +7407,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7239,6 +7463,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7266,6 +7491,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7293,6 +7519,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7320,6 +7547,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7347,6 +7575,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7374,6 +7603,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7401,6 +7631,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7428,6 +7659,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7455,6 +7687,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7482,6 +7715,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7551,6 +7785,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7827,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7855,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7646,6 +7883,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7673,6 +7911,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7700,6 +7939,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7727,6 +7967,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7761,6 +8002,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7788,6 +8030,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7822,6 +8065,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7849,6 +8093,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7876,6 +8121,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7924,6 +8170,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7951,6 +8198,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -7978,6 +8226,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8005,6 +8254,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8032,6 +8282,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8059,6 +8310,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8086,6 +8338,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8134,6 +8387,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8161,6 +8416,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8188,6 +8444,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8222,6 +8479,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8249,6 +8507,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8276,6 +8535,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8317,6 +8577,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8344,6 +8605,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8378,6 +8640,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8447,6 +8710,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8474,6 +8738,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8501,6 +8766,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8528,6 +8794,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8597,6 +8864,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8624,6 +8892,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8651,6 +8920,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8678,6 +8948,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8712,6 +8983,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8739,6 +9011,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8787,6 +9060,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8835,6 +9109,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8862,6 +9137,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +9165,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8916,6 +9193,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8943,6 +9221,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -8970,6 +9249,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8997,6 +9277,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9066,6 +9347,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9093,6 +9375,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9120,6 +9403,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9147,6 +9431,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9174,6 +9459,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9215,6 +9501,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9242,6 +9529,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -9311,6 +9599,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9359,6 +9648,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9386,6 +9676,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9455,6 +9746,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9503,6 +9795,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9530,6 +9823,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9557,6 +9851,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9584,6 +9879,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9611,6 +9907,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9638,6 +9935,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9665,6 +9963,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9692,6 +9991,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9719,6 +10019,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9746,6 +10047,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9773,6 +10075,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9800,6 +10103,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9827,6 +10131,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9854,6 +10159,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9881,6 +10187,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9908,6 +10215,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9935,6 +10243,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -9962,6 +10271,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10003,6 +10313,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10030,6 +10341,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10057,6 +10369,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10112,6 +10425,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10139,6 +10453,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10166,6 +10481,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10200,6 +10516,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10227,6 +10544,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10254,6 +10572,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10281,6 +10600,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10308,6 +10628,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10335,6 +10656,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10362,6 +10684,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10389,6 +10712,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10437,6 +10761,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10464,6 +10789,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10491,6 +10817,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10518,6 +10845,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10545,6 +10873,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10572,6 +10901,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10599,6 +10929,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10626,6 +10957,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10653,6 +10985,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10715,6 +11048,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10742,6 +11076,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10769,6 +11104,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10796,6 +11132,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10865,6 +11202,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10899,6 +11237,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -10926,6 +11265,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11293,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -10980,6 +11321,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11007,6 +11349,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11055,6 +11398,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11082,6 +11426,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11130,6 +11475,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11157,6 +11503,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11184,6 +11531,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11246,6 +11594,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11287,6 +11636,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11314,6 +11664,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11341,6 +11692,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11368,6 +11720,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11395,6 +11748,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11464,6 +11818,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11491,6 +11846,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11518,6 +11874,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11545,6 +11902,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11579,6 +11937,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11613,6 +11972,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11640,6 +12000,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11667,6 +12028,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11694,6 +12056,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11721,6 +12084,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11748,6 +12112,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11775,6 +12140,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11802,6 +12168,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11829,6 +12196,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11856,6 +12224,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11883,6 +12252,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -11910,6 +12280,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -11937,6 +12308,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -11964,6 +12336,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -11991,6 +12364,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12053,6 +12427,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12087,6 +12462,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12114,6 +12490,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12141,6 +12518,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12168,6 +12546,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12195,6 +12574,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12250,6 +12630,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12277,6 +12658,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12304,6 +12686,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12331,6 +12714,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12358,6 +12742,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12385,6 +12770,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12412,6 +12798,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12439,6 +12826,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12508,6 +12896,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12535,6 +12924,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12562,6 +12952,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12596,6 +12987,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12623,6 +13015,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +13043,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +13092,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12725,6 +13120,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +13162,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12821,6 +13218,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12855,6 +13253,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12924,6 +13323,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -12951,6 +13351,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -12978,6 +13379,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13005,6 +13407,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13032,6 +13435,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13059,6 +13463,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13086,6 +13491,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13113,6 +13519,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13140,6 +13547,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13188,6 +13596,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13257,6 +13666,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13284,6 +13694,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13325,6 +13736,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13352,6 +13764,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13386,6 +13799,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13841,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13496,6 +13911,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13523,6 +13939,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13550,6 +13967,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13577,6 +13995,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13604,6 +14023,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13659,6 +14079,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13686,6 +14107,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13713,6 +14135,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13740,6 +14163,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13767,6 +14191,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13794,6 +14219,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13821,6 +14247,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13848,6 +14275,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13875,6 +14303,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -13902,6 +14331,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13964,6 +14394,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -13991,6 +14422,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14018,6 +14450,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14045,6 +14478,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14072,6 +14506,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14534,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14604,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14195,6 +14632,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14222,6 +14660,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14249,6 +14688,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14276,6 +14716,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14317,6 +14758,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14344,6 +14786,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14371,6 +14814,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14398,6 +14842,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14425,6 +14870,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14452,6 +14898,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14479,6 +14926,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14506,6 +14954,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14575,6 +15024,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14602,6 +15052,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14629,6 +15080,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14656,6 +15108,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14683,6 +15136,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14710,6 +15164,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14737,6 +15192,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14764,6 +15220,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14798,6 +15255,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14825,6 +15283,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14852,6 +15311,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14879,6 +15339,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14906,6 +15367,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -14933,6 +15395,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -14960,6 +15423,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -14987,6 +15451,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15056,6 +15521,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15083,6 +15549,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15110,6 +15577,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15137,6 +15605,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15164,6 +15633,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15191,6 +15661,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15218,6 +15689,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15259,6 +15731,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15801,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15355,6 +15829,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15382,6 +15857,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15409,6 +15885,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15436,6 +15913,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15463,6 +15941,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15504,6 +15983,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15531,6 +16011,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15558,6 +16039,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15585,6 +16067,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15612,6 +16095,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15646,6 +16130,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15673,6 +16158,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15700,6 +16186,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15727,6 +16214,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -15796,6 +16284,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15823,6 +16312,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15850,6 +16340,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15877,6 +16368,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15904,6 +16396,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -15931,6 +16424,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15958,6 +16452,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -15985,6 +16480,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16012,6 +16508,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16039,6 +16536,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16066,6 +16564,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16107,6 +16606,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16134,6 +16634,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16161,6 +16662,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16223,6 +16725,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16250,6 +16753,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16277,6 +16781,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16304,6 +16809,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16331,6 +16837,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16358,6 +16865,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16385,6 +16893,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16412,6 +16921,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16439,6 +16949,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16466,6 +16977,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16493,6 +17005,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16548,6 +17061,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16582,6 +17096,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16609,6 +17124,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16636,6 +17152,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16663,6 +17180,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16690,6 +17208,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16717,6 +17236,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16744,6 +17264,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16785,6 +17306,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +17376,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -16888,6 +17411,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16915,6 +17439,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -16942,6 +17467,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16969,6 +17495,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -16996,6 +17523,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17030,6 +17558,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17057,6 +17586,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17084,6 +17614,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17153,6 +17684,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17180,6 +17712,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17207,6 +17740,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17234,6 +17768,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17261,6 +17796,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17288,6 +17824,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17315,6 +17852,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17342,6 +17880,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17404,6 +17943,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17431,6 +17971,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17458,6 +17999,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17485,6 +18027,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17512,6 +18055,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17560,6 +18104,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17601,6 +18146,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17628,6 +18174,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17655,6 +18202,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17689,6 +18237,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17716,6 +18265,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17743,6 +18293,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17784,6 +18335,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17811,6 +18363,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17845,6 +18398,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17872,6 +18426,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17899,6 +18454,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17926,6 +18482,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17953,6 +18510,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -17980,6 +18538,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18007,6 +18566,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18076,6 +18636,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18103,6 +18664,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18130,6 +18692,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18157,6 +18720,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18184,6 +18748,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -18211,6 +18776,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18280,6 +18846,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18307,6 +18874,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18376,6 +18944,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18403,6 +18972,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18430,6 +19000,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18457,6 +19028,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18484,6 +19056,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18511,6 +19084,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18538,6 +19112,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18572,6 +19147,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18606,6 +19182,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18633,6 +19210,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18660,6 +19238,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18715,6 +19294,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18742,6 +19322,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18769,6 +19350,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18796,6 +19378,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18830,6 +19413,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18857,6 +19441,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18884,6 +19469,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18911,6 +19497,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18938,6 +19525,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -18972,6 +19560,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18999,6 +19588,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19026,6 +19616,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19053,6 +19644,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19080,6 +19672,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19107,6 +19700,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19728,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19161,6 +19756,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19195,6 +19791,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19222,6 +19819,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19249,6 +19847,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19276,6 +19875,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19303,6 +19903,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19330,6 +19931,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19364,6 +19966,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19398,6 +20001,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19425,6 +20029,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19452,6 +20057,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19479,6 +20085,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19506,6 +20113,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -19533,6 +20141,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19560,6 +20169,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19587,6 +20197,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19635,6 +20246,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19662,6 +20274,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19689,6 +20302,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19716,6 +20330,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19743,6 +20358,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19770,6 +20386,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19797,6 +20414,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19824,6 +20442,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19851,6 +20470,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -19920,6 +20540,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19947,6 +20568,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19974,6 +20596,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20001,6 +20624,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20035,6 +20659,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20062,6 +20687,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20089,6 +20715,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20116,6 +20743,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20143,6 +20771,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20184,6 +20813,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20211,6 +20841,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20252,6 +20883,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20279,6 +20911,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20348,6 +20981,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20410,6 +21044,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20437,6 +21072,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20506,6 +21142,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20533,6 +21170,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20560,6 +21198,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20587,6 +21226,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20614,6 +21254,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20641,6 +21282,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20668,6 +21310,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20695,6 +21338,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20729,6 +21373,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20756,6 +21401,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -20818,6 +21464,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20845,6 +21492,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20872,6 +21520,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -20906,6 +21555,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20940,6 +21590,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -20981,6 +21632,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21036,6 +21688,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21063,6 +21716,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21090,6 +21744,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21159,6 +21814,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21186,6 +21842,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21227,6 +21884,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21254,6 +21912,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21281,6 +21940,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21308,6 +21968,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21335,6 +21996,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21369,6 +22031,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21396,6 +22059,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21423,6 +22087,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21450,6 +22115,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21477,6 +22143,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21504,6 +22171,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21545,6 +22213,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21572,6 +22241,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21599,6 +22269,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21626,6 +22297,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21653,6 +22325,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -21701,6 +22374,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21728,6 +22402,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21755,6 +22430,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21782,6 +22458,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21809,6 +22486,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21836,6 +22514,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21884,6 +22563,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -21918,6 +22598,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21945,6 +22626,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -21972,6 +22654,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21999,6 +22682,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22026,6 +22710,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22053,6 +22738,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22080,6 +22766,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22121,6 +22808,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22148,6 +22836,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22175,6 +22864,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22202,6 +22892,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22920,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22962,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22311,6 +23004,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22352,6 +23046,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22379,6 +23074,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22413,6 +23109,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22440,6 +23137,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -22467,6 +23165,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22494,6 +23193,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22521,6 +23221,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22569,6 +23270,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22610,6 +23312,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22637,6 +23340,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22664,6 +23368,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22733,6 +23438,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22767,6 +23473,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22794,6 +23501,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22828,6 +23536,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22862,6 +23571,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22889,6 +23599,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22916,6 +23627,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -22943,6 +23655,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22970,6 +23683,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22997,6 +23711,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23024,6 +23739,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23051,6 +23767,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23078,6 +23795,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23105,6 +23823,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23160,6 +23879,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23187,6 +23907,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23221,6 +23942,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23248,6 +23970,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23275,6 +23998,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23316,6 +24040,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23343,6 +24068,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23370,6 +24096,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23397,6 +24124,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23424,6 +24152,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23451,6 +24180,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23485,6 +24215,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23512,6 +24243,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23546,6 +24278,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23573,6 +24306,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23621,6 +24355,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23648,6 +24383,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23675,6 +24411,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23702,6 +24439,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23729,6 +24467,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23756,6 +24495,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23783,6 +24523,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23810,6 +24551,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23837,6 +24579,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23864,6 +24607,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -23891,6 +24635,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -23918,6 +24663,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -23966,6 +24712,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24014,6 +24761,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24041,6 +24789,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24068,6 +24817,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24095,6 +24845,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24122,6 +24873,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24149,6 +24901,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24176,6 +24929,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24203,6 +24957,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24230,6 +24985,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24257,6 +25013,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24284,6 +25041,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24311,6 +25069,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24338,6 +25097,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24372,6 +25132,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24434,6 +25195,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24461,6 +25223,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24488,6 +25251,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24515,6 +25279,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +25321,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -24625,6 +25391,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24694,6 +25461,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24721,6 +25489,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24748,6 +25517,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24817,6 +25587,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24844,6 +25615,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24871,6 +25643,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24898,6 +25671,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -24932,6 +25706,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24973,6 +25748,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25000,6 +25776,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25027,6 +25804,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25054,6 +25832,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25081,6 +25860,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25108,6 +25888,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25135,6 +25916,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25162,6 +25944,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25189,6 +25972,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25230,6 +26014,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25257,6 +26042,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25284,6 +26070,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25318,6 +26105,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25345,6 +26133,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25393,6 +26182,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25427,6 +26217,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25454,6 +26245,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25481,6 +26273,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25508,6 +26301,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25535,6 +26329,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25562,6 +26357,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25589,6 +26385,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25616,6 +26413,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25650,6 +26448,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25677,6 +26476,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25704,6 +26504,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25738,6 +26539,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25765,6 +26567,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25792,6 +26595,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25840,6 +26644,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25867,6 +26672,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -25894,6 +26700,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25921,6 +26728,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25955,6 +26763,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25996,6 +26805,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26833,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26050,6 +26861,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26077,6 +26889,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26139,6 +26952,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26166,6 +26980,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26193,6 +27008,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26220,6 +27036,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26247,6 +27064,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26274,6 +27092,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26301,6 +27120,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26335,6 +27155,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26362,6 +27183,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26431,6 +27253,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26458,6 +27281,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26527,6 +27351,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26554,6 +27379,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26581,6 +27407,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26608,6 +27435,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26635,6 +27463,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26662,6 +27491,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26689,6 +27519,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26716,6 +27547,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26743,6 +27575,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26770,6 +27603,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26797,6 +27631,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +27694,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27764,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -26955,6 +27792,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -26982,6 +27820,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27009,6 +27848,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27036,6 +27876,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27070,6 +27911,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27097,6 +27939,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27124,6 +27967,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27172,6 +28016,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27199,6 +28044,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27240,6 +28086,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27267,6 +28114,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27308,6 +28156,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27335,6 +28184,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +28212,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27396,6 +28247,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27423,6 +28275,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27450,6 +28303,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27477,6 +28331,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27504,6 +28359,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27531,6 +28387,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27558,6 +28415,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27585,6 +28443,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27612,6 +28471,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27639,6 +28499,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27666,6 +28527,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27693,6 +28555,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27720,6 +28583,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27747,6 +28611,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27774,6 +28639,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +28667,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27849,6 +28716,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -27876,6 +28744,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27903,6 +28772,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -27930,6 +28800,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -27957,6 +28828,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27984,6 +28856,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28011,6 +28884,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28038,6 +28912,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28065,6 +28940,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28092,6 +28968,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28119,6 +28996,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28146,6 +29024,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28180,6 +29059,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28207,6 +29087,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28234,6 +29115,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28261,6 +29143,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28288,6 +29171,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28357,6 +29241,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28384,6 +29269,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28411,6 +29297,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28438,6 +29325,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28465,6 +29353,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28492,6 +29381,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28519,6 +29409,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28546,6 +29437,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28573,6 +29465,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28600,6 +29493,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28627,6 +29521,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28654,6 +29549,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28688,6 +29584,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28715,6 +29612,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28749,6 +29647,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28776,6 +29675,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28803,6 +29703,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28830,6 +29731,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -28857,6 +29759,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28912,6 +29815,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28939,6 +29843,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29008,6 +29913,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29077,6 +29983,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29104,6 +30011,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29131,6 +30039,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29158,6 +30067,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29185,6 +30095,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29226,6 +30137,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29253,6 +30165,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29280,6 +30193,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29335,6 +30249,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29362,6 +30277,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29389,6 +30305,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29416,6 +30333,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29457,6 +30375,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29484,6 +30403,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29518,6 +30438,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29545,6 +30466,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29572,6 +30494,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29599,6 +30522,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29626,6 +30550,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29660,6 +30585,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29687,6 +30613,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29714,6 +30641,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29741,6 +30669,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29768,6 +30697,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29795,6 +30725,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29822,6 +30753,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -29849,6 +30781,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29918,6 +30851,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -29945,6 +30879,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -29972,6 +30907,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -29999,6 +30935,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30026,6 +30963,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30053,6 +30991,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30080,6 +31019,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30107,6 +31047,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30148,6 +31089,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30175,6 +31117,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30202,6 +31145,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30229,6 +31173,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30256,6 +31201,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30283,6 +31229,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30310,6 +31257,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30337,6 +31285,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30364,6 +31313,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30391,6 +31341,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30418,6 +31369,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30445,6 +31397,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -30472,6 +31425,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30499,6 +31453,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30533,6 +31488,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30595,6 +31551,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30622,6 +31579,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30649,6 +31607,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30676,6 +31635,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30703,6 +31663,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30730,6 +31691,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30757,6 +31719,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30784,6 +31747,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30811,6 +31775,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30866,6 +31831,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -30893,6 +31859,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30920,6 +31887,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30947,6 +31915,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -30974,6 +31943,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31001,6 +31971,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31035,6 +32006,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31062,6 +32034,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31089,6 +32062,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31116,6 +32090,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31143,6 +32118,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31170,6 +32146,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31197,6 +32174,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31224,6 +32202,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31251,6 +32230,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31278,6 +32258,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31305,6 +32286,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31346,6 +32328,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +32384,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31428,6 +32412,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31455,6 +32440,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31482,6 +32468,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31509,6 +32496,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31536,6 +32524,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31563,6 +32552,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31590,6 +32580,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31645,6 +32636,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31672,6 +32664,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31699,6 +32692,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31754,6 +32748,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31788,6 +32783,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31843,6 +32839,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31877,6 +32874,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31904,6 +32902,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -31938,6 +32937,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31986,6 +32986,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32027,6 +33028,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32054,6 +33056,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32081,6 +33084,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32108,6 +33112,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32135,6 +33140,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32162,6 +33168,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32196,6 +33203,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32223,6 +33231,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32250,6 +33259,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32277,6 +33287,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32304,6 +33315,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32331,6 +33343,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32358,6 +33371,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32385,6 +33399,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32412,6 +33427,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32439,6 +33455,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32466,6 +33483,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32493,6 +33511,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32520,6 +33539,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32547,6 +33567,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32574,6 +33595,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32601,6 +33623,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32628,6 +33651,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32655,6 +33679,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32682,6 +33707,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32730,6 +33756,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32771,6 +33798,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32798,6 +33826,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32825,6 +33854,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32852,6 +33882,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32914,6 +33945,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -32941,6 +33973,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -32968,6 +34001,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32995,6 +34029,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33029,6 +34064,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33056,6 +34092,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33083,6 +34120,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33124,6 +34162,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33151,6 +34190,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33178,6 +34218,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33205,6 +34246,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33232,6 +34274,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33301,6 +34344,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33328,6 +34372,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33376,6 +34421,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33403,6 +34449,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33451,6 +34498,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +34526,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +34555,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33539,6 +34590,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33580,6 +34632,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33621,6 +34674,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33648,6 +34702,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33675,6 +34730,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33702,6 +34758,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33736,6 +34793,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33763,6 +34821,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33790,6 +34849,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +34877,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -33844,6 +34905,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -33871,6 +34933,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -33898,6 +34961,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33925,6 +34989,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +35017,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -33979,6 +35045,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34020,6 +35087,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34047,6 +35115,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34116,6 +35185,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34143,6 +35213,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34170,6 +35241,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34197,6 +35269,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34224,6 +35297,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34251,6 +35325,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34285,6 +35360,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34319,6 +35395,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34346,6 +35423,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34415,6 +35493,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34442,6 +35521,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34469,6 +35549,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34496,6 +35577,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34523,6 +35605,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34550,6 +35633,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34605,6 +35689,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34632,6 +35717,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34666,6 +35752,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +35780,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34720,6 +35808,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34747,6 +35836,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34774,6 +35864,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34801,6 +35892,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34828,6 +35920,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -34855,6 +35948,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -34903,6 +35997,7 @@
         {
             "id": "0xe02e8ddecbe302ba1a40107c726e3ee889b0ff10",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
@@ -34937,6 +36032,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34964,6 +36060,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34991,6 +36088,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35018,6 +36116,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +36144,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +36193,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35120,6 +36221,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35147,6 +36249,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35174,6 +36277,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35201,6 +36305,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35228,6 +36333,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35255,6 +36361,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35282,6 +36389,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35309,6 +36417,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35336,6 +36445,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35363,6 +36473,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35425,6 +36536,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35473,6 +36585,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35500,6 +36613,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35527,6 +36641,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35554,6 +36669,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35581,6 +36697,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35615,6 +36732,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35642,6 +36760,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35669,6 +36788,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35696,6 +36816,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35723,6 +36844,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35771,6 +36893,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35798,6 +36921,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -35825,6 +36949,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35852,6 +36977,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -35879,6 +37005,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35913,6 +37040,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -35940,6 +37068,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36009,6 +37138,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36057,6 +37187,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36112,6 +37243,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36153,6 +37285,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36180,6 +37313,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36249,6 +37383,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36276,6 +37411,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36303,6 +37439,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36330,6 +37467,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36357,6 +37495,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +37523,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36432,6 +37572,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36459,6 +37600,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36486,6 +37628,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36513,6 +37656,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36582,6 +37726,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36609,6 +37754,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36636,6 +37782,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36663,6 +37810,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36690,6 +37838,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36717,6 +37866,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36744,6 +37894,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36771,6 +37922,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36798,6 +37950,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36825,6 +37978,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36852,6 +38006,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -36886,6 +38041,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -36913,6 +38069,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -36940,6 +38097,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36967,6 +38125,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -36994,6 +38153,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37021,6 +38181,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37048,6 +38209,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37103,6 +38265,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37130,6 +38293,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37185,6 +38349,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37212,6 +38377,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37239,6 +38405,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37287,6 +38454,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37314,6 +38482,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37341,6 +38510,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37368,6 +38538,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37409,6 +38580,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37436,6 +38608,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37470,6 +38643,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37497,6 +38671,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37531,6 +38706,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37558,6 +38734,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37585,6 +38762,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37612,6 +38790,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37639,6 +38818,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37687,6 +38867,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37721,6 +38902,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37748,6 +38930,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -37782,6 +38965,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37809,6 +38993,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37836,6 +39021,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -37884,6 +39070,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37911,6 +39098,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37938,6 +39126,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -37986,6 +39175,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38013,6 +39203,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38040,6 +39231,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +39273,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38122,6 +39315,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38149,6 +39343,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38176,6 +39371,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38203,6 +39399,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38251,6 +39448,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38278,6 +39476,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38319,6 +39518,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38346,6 +39546,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38373,6 +39574,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38400,6 +39602,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38427,6 +39630,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38454,6 +39658,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38481,6 +39686,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38508,6 +39714,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38535,6 +39742,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38562,6 +39770,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38596,6 +39805,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38623,6 +39833,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38650,6 +39861,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38698,6 +39910,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38725,6 +39938,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38752,6 +39966,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38779,6 +39994,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38806,6 +40022,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -38833,6 +40050,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -38860,6 +40078,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -38887,6 +40106,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -38914,6 +40134,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38983,6 +40204,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39010,6 +40232,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39037,6 +40260,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39064,6 +40288,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39112,6 +40337,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39139,6 +40365,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39173,6 +40400,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39207,6 +40435,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39241,6 +40470,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39268,6 +40498,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39295,6 +40526,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39322,6 +40554,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39356,6 +40589,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39383,6 +40617,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39410,6 +40645,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39437,6 +40673,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39471,6 +40708,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39505,6 +40743,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39532,6 +40771,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39559,6 +40799,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39600,6 +40841,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39669,6 +40911,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39696,6 +40939,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39723,6 +40967,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39750,6 +40995,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39777,6 +41023,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39804,6 +41051,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39831,6 +41079,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39865,6 +41114,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39892,6 +41142,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -39919,6 +41170,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39988,6 +41240,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40015,6 +41268,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40042,6 +41296,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40069,6 +41324,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40138,6 +41394,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x0a96d61ff013aff7dde200d3aaa6b7e1bc3a30d1701b9a0d60bb63d931cdbdcc.json
+++ b/test/testData/testPools/0x0a96d61ff013aff7dde200d3aaa6b7e1bc3a30d1701b9a0d60bb63d931cdbdcc.json
@@ -2541,7 +2541,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6042,7 +6041,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8387,7 +8385,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -34526,7 +34523,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0x138b142350336ae74acf0de423849206089e7100177e6d1dcbc8c6f0aedc76a4.json
+++ b/test/testData/testPools/0x138b142350336ae74acf0de423849206089e7100177e6d1dcbc8c6f0aedc76a4.json
@@ -100,6 +100,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -129,6 +130,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -451,6 +453,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -636,6 +639,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -665,6 +669,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -895,6 +900,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1289,6 +1295,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1511,6 +1518,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1981,6 +1989,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2084,6 +2093,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2121,6 +2131,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2204,6 +2215,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2317,6 +2329,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2616,6 +2629,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2645,6 +2659,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2711,6 +2726,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2864,6 +2880,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3260,6 +3277,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3651,6 +3669,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4393,6 +4412,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4578,6 +4598,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4689,6 +4710,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4776,6 +4798,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5143,6 +5166,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5381,6 +5405,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5458,6 +5483,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5516,6 +5542,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5698,6 +5725,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5785,6 +5813,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5933,6 +5962,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6115,6 +6145,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6387,6 +6418,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6897,6 +6929,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7492,6 +7525,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7579,6 +7613,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7769,6 +7804,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7946,6 +7982,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8091,6 +8128,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8226,6 +8264,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8271,6 +8310,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8453,6 +8493,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8857,6 +8898,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9198,6 +9240,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9362,6 +9405,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9650,6 +9694,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9959,6 +10004,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10062,6 +10108,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11248,6 +11295,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11388,6 +11436,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11504,6 +11553,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11591,6 +11641,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11890,6 +11941,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11919,6 +11971,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12641,6 +12694,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13005,6 +13059,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13314,6 +13369,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13578,6 +13634,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13808,6 +13865,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13837,6 +13895,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13890,6 +13949,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13964,6 +14024,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14313,6 +14374,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14501,6 +14563,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14575,6 +14638,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14641,6 +14705,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14686,6 +14751,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14792,6 +14858,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -15201,6 +15268,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15415,6 +15483,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15444,6 +15513,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15521,6 +15591,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15798,6 +15869,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15962,6 +16034,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -16078,6 +16151,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -16165,6 +16239,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16376,6 +16451,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16701,6 +16777,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16778,6 +16855,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -17208,6 +17286,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17892,6 +17971,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18098,6 +18178,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -18354,6 +18435,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -18431,6 +18513,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18650,6 +18733,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18959,6 +19043,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -19395,6 +19480,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19593,6 +19679,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -19651,6 +19738,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19873,6 +19961,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -20787,6 +20876,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20874,6 +20964,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20903,6 +20994,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20998,6 +21090,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -21267,6 +21360,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21956,6 +22050,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -22625,6 +22720,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23170,6 +23266,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23600,6 +23697,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24194,6 +24292,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -24223,6 +24322,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -24268,6 +24368,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -24453,6 +24554,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -25116,6 +25218,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25264,6 +25367,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -25433,6 +25537,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25879,6 +25984,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -25995,6 +26101,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -26700,6 +26807,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26745,6 +26853,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -27435,6 +27544,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -27934,6 +28044,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -28309,6 +28420,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -28338,6 +28450,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28888,6 +29001,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -29091,6 +29205,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29178,6 +29293,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29247,6 +29363,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -29324,6 +29441,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -29535,6 +29653,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -29765,6 +29884,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -29794,6 +29914,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -30237,6 +30358,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30266,6 +30388,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30348,6 +30471,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30551,6 +30675,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -30704,6 +30829,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31100,6 +31226,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31406,6 +31533,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31650,6 +31778,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31811,6 +31940,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -32455,6 +32585,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32867,6 +32998,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -33128,6 +33260,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -33825,6 +33958,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -34102,6 +34236,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -34163,6 +34298,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34308,6 +34444,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -34644,6 +34781,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34747,6 +34885,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34903,6 +35042,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -35288,6 +35428,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -35520,6 +35661,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35803,6 +35945,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -36059,6 +36202,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36146,6 +36290,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36252,6 +36397,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -36334,6 +36480,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36416,6 +36563,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -36445,6 +36593,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -36601,6 +36750,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36630,6 +36780,7 @@
         {
             "id": "0xd8e72a62e214864cbd9381cc04fa1006a8c8fb10",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23b608675a2b2fb1890d3abbd85c5775c51691d5",
@@ -36831,6 +36982,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -36860,6 +37012,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -37433,6 +37586,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37782,6 +37936,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -37811,6 +37966,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -37869,6 +38025,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -38125,6 +38282,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38154,6 +38312,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38207,6 +38366,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -38970,6 +39130,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -39581,6 +39742,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39610,6 +39772,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39750,6 +39913,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40241,6 +40405,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -40883,6 +41048,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -41089,6 +41255,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -41406,6 +41573,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -41451,6 +41619,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -41525,6 +41694,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -41710,6 +41880,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -41797,6 +41968,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -42008,6 +42180,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -42235,6 +42408,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -42515,6 +42689,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -43096,6 +43271,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -43289,6 +43465,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -43442,6 +43619,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x139894ec2cacfeca1035e78968124dbb2d34034bde146f5f2ab311ada75ad04f.json
+++ b/test/testData/testPools/0x139894ec2cacfeca1035e78968124dbb2d34034bde146f5f2ab311ada75ad04f.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x139894ec2cacfeca1035e78968124dbb2d34034bde146f5f2ab311ada75ad04f.json
+++ b/test/testData/testPools/0x139894ec2cacfeca1035e78968124dbb2d34034bde146f5f2ab311ada75ad04f.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -171,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -198,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -232,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -259,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -286,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -313,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -340,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -367,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -422,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -470,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -511,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -538,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -621,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -648,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -696,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -723,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -750,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -854,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -881,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -908,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -935,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -962,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1003,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1030,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1071,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1098,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1237,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1264,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1291,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1318,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1345,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1400,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1427,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1475,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1502,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1550,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1577,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1604,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1631,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1672,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1699,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1726,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1753,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1780,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1835,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1876,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1987,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2063,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2181,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2229,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2256,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2283,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2338,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2365,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2455,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2510,6 +2568,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2544,6 +2603,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2571,6 +2631,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2598,6 +2659,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2674,6 +2736,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2701,6 +2764,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2735,6 +2799,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2762,6 +2827,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2789,6 +2855,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2816,6 +2883,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2843,6 +2911,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2877,6 +2946,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2904,6 +2974,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2931,6 +3002,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2958,6 +3030,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3062,6 +3135,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3096,6 +3170,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3123,6 +3198,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3150,6 +3226,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3177,6 +3254,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3218,6 +3296,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3245,6 +3324,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3272,6 +3352,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3299,6 +3380,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3326,6 +3408,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3395,6 +3478,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3443,6 +3527,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3470,6 +3555,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3497,6 +3583,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3524,6 +3611,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3551,6 +3639,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3620,6 +3709,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3647,6 +3737,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3674,6 +3765,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3701,6 +3793,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3728,6 +3821,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3755,6 +3849,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3782,6 +3877,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3809,6 +3905,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3843,6 +3940,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3870,6 +3968,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3897,6 +3996,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3924,6 +4024,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3958,6 +4059,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3985,6 +4087,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4012,6 +4115,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4067,6 +4171,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4108,6 +4213,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4135,6 +4241,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4183,6 +4290,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4259,6 +4367,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4286,6 +4395,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4341,6 +4451,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4368,6 +4479,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4451,6 +4563,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4492,6 +4605,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4519,6 +4633,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4546,6 +4661,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4573,6 +4689,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4600,6 +4717,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4627,6 +4745,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4654,6 +4773,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4681,6 +4801,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4708,6 +4829,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4763,6 +4885,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4832,6 +4955,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4859,6 +4983,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4886,6 +5011,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4913,6 +5039,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5052,6 +5179,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5107,6 +5235,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5141,6 +5270,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5168,6 +5298,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5195,6 +5326,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5222,6 +5354,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5277,6 +5410,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5304,6 +5438,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5359,6 +5494,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5386,6 +5522,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5441,6 +5578,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5503,6 +5641,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5530,6 +5669,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5557,6 +5697,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5584,6 +5725,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5611,6 +5753,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5666,6 +5809,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5700,6 +5844,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5727,6 +5872,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5754,6 +5900,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5809,6 +5956,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5836,6 +5984,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5863,6 +6012,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5918,6 +6068,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5945,6 +6096,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5972,6 +6124,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5999,6 +6152,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6026,6 +6180,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6053,6 +6208,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6101,6 +6257,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6128,6 +6285,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6169,6 +6327,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6217,6 +6376,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6244,6 +6404,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6271,6 +6432,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6326,6 +6488,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6402,6 +6565,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6471,6 +6635,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6498,6 +6663,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6532,6 +6698,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6559,6 +6726,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6586,6 +6754,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6613,6 +6782,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6640,6 +6810,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6667,6 +6838,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6694,6 +6866,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6721,6 +6894,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6783,6 +6957,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6852,6 +7027,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6879,6 +7055,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6934,6 +7111,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6961,6 +7139,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7023,6 +7202,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7050,6 +7230,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7077,6 +7258,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7104,6 +7286,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7138,6 +7321,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7193,6 +7377,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7220,6 +7405,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7275,6 +7461,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7302,6 +7489,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7357,6 +7545,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7384,6 +7573,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7411,6 +7601,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7438,6 +7629,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7493,6 +7685,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7520,6 +7713,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7659,6 +7853,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7686,6 +7881,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7713,6 +7909,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7740,6 +7937,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7767,6 +7965,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7829,6 +8028,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7863,6 +8063,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7890,6 +8091,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7917,6 +8119,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7965,6 +8168,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7992,6 +8196,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8019,6 +8224,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8046,6 +8252,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8073,6 +8280,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8100,6 +8308,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8127,6 +8336,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8203,6 +8413,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8230,6 +8441,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8264,6 +8476,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8291,6 +8504,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8318,6 +8532,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8359,6 +8574,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8386,6 +8602,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8420,6 +8637,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8517,6 +8735,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8544,6 +8763,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8571,6 +8791,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8668,6 +8889,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8695,6 +8917,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8722,6 +8945,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8756,6 +8980,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8783,6 +9008,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8831,6 +9057,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8879,6 +9106,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8934,6 +9162,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8961,6 +9190,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8988,6 +9218,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9015,6 +9246,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9042,6 +9274,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9111,6 +9344,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9138,6 +9372,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9165,6 +9400,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9220,6 +9456,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9261,6 +9498,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9358,6 +9596,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9406,6 +9645,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9433,6 +9673,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9502,6 +9743,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9550,6 +9792,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9577,6 +9820,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9604,6 +9848,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9631,6 +9876,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9658,6 +9904,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9685,6 +9932,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9712,6 +9960,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9739,6 +9988,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9766,6 +10016,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9793,6 +10044,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9820,6 +10072,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9847,6 +10100,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9874,6 +10128,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9901,6 +10156,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9928,6 +10184,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9955,6 +10212,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9982,6 +10240,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10009,6 +10268,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10050,6 +10310,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10077,6 +10338,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10104,6 +10366,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10159,6 +10422,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10186,6 +10450,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10213,6 +10478,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10247,6 +10513,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10274,6 +10541,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10301,6 +10569,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10328,6 +10597,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10355,6 +10625,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10410,6 +10681,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10437,6 +10709,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10485,6 +10758,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10540,6 +10814,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10567,6 +10842,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10594,6 +10870,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10649,6 +10926,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10676,6 +10954,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10766,6 +11045,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10793,6 +11073,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10820,6 +11101,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10847,6 +11129,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10916,6 +11199,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10950,6 +11234,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11033,6 +11318,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11060,6 +11346,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11108,6 +11395,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11135,6 +11423,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11183,6 +11472,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11210,6 +11500,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11237,6 +11528,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11299,6 +11591,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11340,6 +11633,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11367,6 +11661,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11394,6 +11689,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11421,6 +11717,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11448,6 +11745,7 @@
         {
             "id": "0x4b3fa856cef9aa85ed9bbfa8992d6138c5f150e6",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -11517,6 +11815,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11586,6 +11885,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11613,6 +11913,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11640,6 +11941,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11702,6 +12004,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11736,6 +12039,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11763,6 +12067,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11790,6 +12095,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11817,6 +12123,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11844,6 +12151,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11871,6 +12179,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11898,6 +12207,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11925,6 +12235,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11952,6 +12263,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11979,6 +12291,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12034,6 +12347,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12061,6 +12375,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12088,6 +12403,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12115,6 +12431,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12177,6 +12494,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12211,6 +12529,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12238,6 +12557,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12265,6 +12585,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12320,6 +12641,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12375,6 +12697,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12402,6 +12725,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12429,6 +12753,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12456,6 +12781,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12483,6 +12809,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12510,6 +12837,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12565,6 +12893,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12634,6 +12963,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12661,6 +12991,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12688,6 +13019,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12722,6 +13054,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12854,6 +13187,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12951,6 +13285,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12985,6 +13320,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -13054,6 +13390,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13081,6 +13418,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13108,6 +13446,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13135,6 +13474,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13162,6 +13502,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13189,6 +13530,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13244,6 +13586,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13271,6 +13614,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13319,6 +13663,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13416,6 +13761,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13485,6 +13831,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13631,6 +13978,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13686,6 +14034,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13713,6 +14062,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13740,6 +14090,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13795,6 +14146,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13822,6 +14174,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13849,6 +14202,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13876,6 +14230,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13903,6 +14258,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13930,6 +14286,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13957,6 +14314,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13984,6 +14342,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -14011,6 +14370,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -14101,6 +14461,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14128,6 +14489,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14155,6 +14517,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14182,6 +14545,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14335,6 +14699,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14362,6 +14727,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14389,6 +14755,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14416,6 +14783,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14457,6 +14825,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14484,6 +14853,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14511,6 +14881,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14538,6 +14909,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14593,6 +14965,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14620,6 +14993,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14647,6 +15021,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14744,6 +15119,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14771,6 +15147,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14798,6 +15175,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14853,6 +15231,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14880,6 +15259,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14942,6 +15322,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14969,6 +15350,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14996,6 +15378,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -15023,6 +15406,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15050,6 +15434,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15077,6 +15462,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15132,6 +15518,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15201,6 +15588,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15228,6 +15616,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15255,6 +15644,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15282,6 +15672,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15309,6 +15700,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15336,6 +15728,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15363,6 +15756,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15502,6 +15896,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15529,6 +15924,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15556,6 +15952,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15583,6 +15980,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15610,6 +16008,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15651,6 +16050,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15678,6 +16078,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15705,6 +16106,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15732,6 +16134,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15759,6 +16162,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15793,6 +16197,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15820,6 +16225,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15847,6 +16253,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15944,6 +16351,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15971,6 +16379,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15998,6 +16407,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -16025,6 +16435,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -16052,6 +16463,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16079,6 +16491,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16106,6 +16519,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16133,6 +16547,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16160,6 +16575,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16187,6 +16603,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16214,6 +16631,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16255,6 +16673,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16282,6 +16701,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16309,6 +16729,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16371,6 +16792,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16398,6 +16820,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16425,6 +16848,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16452,6 +16876,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16479,6 +16904,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16534,6 +16960,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16561,6 +16988,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16588,6 +17016,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16615,6 +17044,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16642,6 +17072,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16732,6 +17163,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16759,6 +17191,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16786,6 +17219,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16813,6 +17247,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16840,6 +17275,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16867,6 +17303,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16894,6 +17331,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -17040,6 +17478,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17067,6 +17506,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17094,6 +17534,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17121,6 +17562,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17148,6 +17590,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17182,6 +17625,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17237,6 +17681,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17306,6 +17751,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17333,6 +17779,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17360,6 +17807,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17387,6 +17835,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17414,6 +17863,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17441,6 +17891,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17468,6 +17919,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17558,6 +18010,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17585,6 +18038,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17612,6 +18066,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17639,6 +18094,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17666,6 +18122,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17714,6 +18171,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17755,6 +18213,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17782,6 +18241,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17809,6 +18269,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17843,6 +18304,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17870,6 +18332,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17939,6 +18402,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17966,6 +18430,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -18000,6 +18465,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -18027,6 +18493,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -18054,6 +18521,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18109,6 +18577,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18164,6 +18633,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18233,6 +18703,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18260,6 +18731,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18287,6 +18759,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18314,6 +18787,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18369,6 +18843,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18438,6 +18913,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18465,6 +18941,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18534,6 +19011,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18561,6 +19039,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18588,6 +19067,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18615,6 +19095,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18642,6 +19123,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18669,6 +19151,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18696,6 +19179,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18730,6 +19214,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18764,6 +19249,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18791,6 +19277,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18818,6 +19305,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18873,6 +19361,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18900,6 +19389,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18927,6 +19417,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18954,6 +19445,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18988,6 +19480,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -19015,6 +19508,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -19042,6 +19536,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19069,6 +19564,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19096,6 +19592,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19130,6 +19627,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19157,6 +19655,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19212,6 +19711,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19239,6 +19739,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19322,6 +19823,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19356,6 +19858,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19411,6 +19914,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19438,6 +19942,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19465,6 +19970,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19492,6 +19998,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19526,6 +20033,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19553,6 +20061,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19580,6 +20089,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19607,6 +20117,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19662,6 +20173,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19689,6 +20201,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19716,6 +20229,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19764,6 +20278,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19791,6 +20306,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19818,6 +20334,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19845,6 +20362,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19872,6 +20390,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19899,6 +20418,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19926,6 +20446,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19953,6 +20474,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19980,6 +20502,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -20049,6 +20572,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20076,6 +20600,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20103,6 +20628,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20130,6 +20656,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20164,6 +20691,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20191,6 +20719,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20218,6 +20747,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20245,6 +20775,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20314,6 +20845,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20341,6 +20873,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20382,6 +20915,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20409,6 +20943,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20478,6 +21013,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20540,6 +21076,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20567,6 +21104,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20636,6 +21174,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20663,6 +21202,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20690,6 +21230,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20717,6 +21258,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20744,6 +21286,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20771,6 +21314,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20798,6 +21342,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20825,6 +21370,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20859,6 +21405,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20949,6 +21496,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20976,6 +21524,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -21003,6 +21552,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -21037,6 +21587,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21071,6 +21622,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21112,6 +21664,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21167,6 +21720,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21194,6 +21748,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21221,6 +21776,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21290,6 +21846,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21317,6 +21874,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21358,6 +21916,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21413,6 +21972,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21440,6 +22000,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21467,6 +22028,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21501,6 +22063,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21528,6 +22091,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21555,6 +22119,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21582,6 +22147,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21609,6 +22175,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21636,6 +22203,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21677,6 +22245,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21704,6 +22273,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21731,6 +22301,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21758,6 +22329,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21834,6 +22406,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21861,6 +22434,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21888,6 +22462,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21915,6 +22490,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21942,6 +22518,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21969,6 +22546,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22017,6 +22595,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22051,6 +22630,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22078,6 +22658,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22105,6 +22686,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22132,6 +22714,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22159,6 +22742,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22186,6 +22770,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22213,6 +22798,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22254,6 +22840,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22281,6 +22868,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22308,6 +22896,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22447,6 +23036,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22488,6 +23078,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22515,6 +23106,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22549,6 +23141,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22604,6 +23197,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22631,6 +23225,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22658,6 +23253,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22706,6 +23302,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22747,6 +23344,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22774,6 +23372,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22801,6 +23400,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22870,6 +23470,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22904,6 +23505,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22931,6 +23533,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22965,6 +23568,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22999,6 +23603,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -23026,6 +23631,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -23053,6 +23659,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23080,6 +23687,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23107,6 +23715,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23134,6 +23743,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23161,6 +23771,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23216,6 +23827,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23243,6 +23855,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23298,6 +23911,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23360,6 +23974,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23387,6 +24002,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23414,6 +24030,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23455,6 +24072,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23510,6 +24128,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23537,6 +24156,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23564,6 +24184,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23591,6 +24212,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23625,6 +24247,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23652,6 +24275,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23686,6 +24310,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23713,6 +24338,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23761,6 +24387,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23788,6 +24415,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23815,6 +24443,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23842,6 +24471,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23869,6 +24499,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23924,6 +24555,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23951,6 +24583,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23978,6 +24611,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -24033,6 +24667,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -24060,6 +24695,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24108,6 +24744,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24156,6 +24793,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24183,6 +24821,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24210,6 +24849,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24237,6 +24877,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24264,6 +24905,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24291,6 +24933,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24318,6 +24961,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24345,6 +24989,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24372,6 +25017,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24399,6 +25045,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24426,6 +25073,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24453,6 +25101,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24480,6 +25129,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24514,6 +25164,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24576,6 +25227,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24603,6 +25255,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24630,6 +25283,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24769,6 +25423,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24838,6 +25493,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24865,6 +25521,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24892,6 +25549,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24961,6 +25619,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24988,6 +25647,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25015,6 +25675,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -25042,6 +25703,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -25076,6 +25738,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25117,6 +25780,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25144,6 +25808,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25171,6 +25836,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25198,6 +25864,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25225,6 +25892,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25252,6 +25920,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25279,6 +25948,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25306,6 +25976,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25375,6 +26046,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25402,6 +26074,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25429,6 +26102,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25463,6 +26137,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25490,6 +26165,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25538,6 +26214,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25572,6 +26249,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25599,6 +26277,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25626,6 +26305,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25653,6 +26333,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25680,6 +26361,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25707,6 +26389,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25734,6 +26417,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25761,6 +26445,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25823,6 +26508,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25850,6 +26536,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25884,6 +26571,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25911,6 +26599,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25938,6 +26627,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25986,6 +26676,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26013,6 +26704,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -26040,6 +26732,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26067,6 +26760,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26101,6 +26795,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26198,6 +26893,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26225,6 +26921,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26287,6 +26984,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26314,6 +27012,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26341,6 +27040,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26368,6 +27068,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26395,6 +27096,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26422,6 +27124,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26449,6 +27152,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26483,6 +27187,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26510,6 +27215,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26579,6 +27285,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26606,6 +27313,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26703,6 +27411,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26730,6 +27439,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26757,6 +27467,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26784,6 +27495,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26811,6 +27523,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26838,6 +27551,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26893,6 +27607,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26920,6 +27635,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27108,6 +27824,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27135,6 +27852,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27162,6 +27880,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27189,6 +27908,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27223,6 +27943,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27250,6 +27971,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27326,6 +28048,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27353,6 +28076,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27394,6 +28118,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27421,6 +28146,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27462,6 +28188,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27552,6 +28279,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27579,6 +28307,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27606,6 +28335,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27633,6 +28363,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27660,6 +28391,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27687,6 +28419,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27714,6 +28447,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27741,6 +28475,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27768,6 +28503,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27795,6 +28531,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27822,6 +28559,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27849,6 +28587,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27876,6 +28615,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27903,6 +28643,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -28007,6 +28748,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -28062,6 +28804,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -28089,6 +28832,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -28116,6 +28860,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28143,6 +28888,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28170,6 +28916,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28197,6 +28944,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28252,6 +29000,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28279,6 +29028,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28306,6 +29056,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28340,6 +29091,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28395,6 +29147,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28422,6 +29175,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28449,6 +29203,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28518,6 +29273,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28545,6 +29301,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28572,6 +29329,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28599,6 +29357,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28626,6 +29385,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28653,6 +29413,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28680,6 +29441,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28707,6 +29469,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28762,6 +29525,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28789,6 +29553,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28816,6 +29581,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28850,6 +29616,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28877,6 +29644,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28911,6 +29679,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28938,6 +29707,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28965,6 +29735,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28992,6 +29763,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -29075,6 +29847,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29102,6 +29875,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29171,6 +29945,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29268,6 +30043,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29295,6 +30071,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29322,6 +30099,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29349,6 +30127,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29418,6 +30197,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29445,6 +30225,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29500,6 +30281,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29527,6 +30309,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29554,6 +30337,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29581,6 +30365,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29622,6 +30407,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29649,6 +30435,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29683,6 +30470,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29710,6 +30498,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29737,6 +30526,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29764,6 +30554,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29791,6 +30582,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29825,6 +30617,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29852,6 +30645,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29879,6 +30673,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29906,6 +30701,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29933,6 +30729,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29960,6 +30757,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -30057,6 +30855,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -30084,6 +30883,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -30111,6 +30911,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30138,6 +30939,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30165,6 +30967,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30192,6 +30995,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30219,6 +31023,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30246,6 +31051,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30287,6 +31093,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30314,6 +31121,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30341,6 +31149,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30396,6 +31205,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30423,6 +31233,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30450,6 +31261,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30477,6 +31289,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30504,6 +31317,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30531,6 +31345,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30558,6 +31373,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30613,6 +31429,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30640,6 +31457,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30674,6 +31492,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30736,6 +31555,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30763,6 +31583,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30790,6 +31611,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30817,6 +31639,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30844,6 +31667,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30871,6 +31695,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30898,6 +31723,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30925,6 +31751,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30952,6 +31779,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31007,6 +31835,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -31034,6 +31863,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -31061,6 +31891,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31088,6 +31919,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -31115,6 +31947,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31142,6 +31975,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31176,6 +32010,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31203,6 +32038,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31258,6 +32094,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31285,6 +32122,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31312,6 +32150,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31339,6 +32178,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31366,6 +32206,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31393,6 +32234,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31420,6 +32262,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31447,6 +32290,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31572,6 +32416,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31599,6 +32444,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31626,6 +32472,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31653,6 +32500,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31708,6 +32556,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31735,6 +32584,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31790,6 +32640,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31817,6 +32668,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31844,6 +32696,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31899,6 +32752,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31933,6 +32787,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32023,6 +32878,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32050,6 +32906,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -32133,6 +32990,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32174,6 +33032,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32201,6 +33060,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32256,6 +33116,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32283,6 +33144,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32310,6 +33172,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32344,6 +33207,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32371,6 +33235,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32398,6 +33263,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32425,6 +33291,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32452,6 +33319,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32479,6 +33347,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32506,6 +33375,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32533,6 +33403,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32560,6 +33431,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32615,6 +33487,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32642,6 +33515,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32669,6 +33543,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32696,6 +33571,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32723,6 +33599,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32750,6 +33627,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32777,6 +33655,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32832,6 +33711,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32880,6 +33760,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32921,6 +33802,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32948,6 +33830,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32975,6 +33858,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -33002,6 +33886,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33092,6 +33977,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33119,6 +34005,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33146,6 +34033,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33180,6 +34068,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33207,6 +34096,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33234,6 +34124,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33275,6 +34166,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33330,6 +34222,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33357,6 +34250,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33454,6 +34348,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33530,6 +34425,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33606,6 +34502,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33696,6 +34593,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33737,6 +34635,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33778,6 +34677,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33833,6 +34733,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33860,6 +34761,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33894,6 +34796,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33921,6 +34824,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -34004,6 +34908,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -34031,6 +34936,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -34058,6 +34964,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34085,6 +34992,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34112,6 +35020,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -34139,6 +35048,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34180,6 +35090,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34207,6 +35118,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34276,6 +35188,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34303,6 +35216,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34330,6 +35244,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34357,6 +35272,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34384,6 +35300,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34411,6 +35328,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34445,6 +35363,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34479,6 +35398,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34576,6 +35496,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34603,6 +35524,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34630,6 +35552,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34657,6 +35580,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34684,6 +35608,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34711,6 +35636,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34766,6 +35692,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34793,6 +35720,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34883,6 +35811,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34938,6 +35867,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34965,6 +35895,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34992,6 +35923,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35019,6 +35951,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -35067,6 +36000,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35094,6 +36028,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35121,6 +36056,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35253,6 +36189,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35280,6 +36217,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35307,6 +36245,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35334,6 +36273,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35361,6 +36301,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35388,6 +36329,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35415,6 +36357,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35442,6 +36385,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35469,6 +36413,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35496,6 +36441,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35558,6 +36504,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35606,6 +36553,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35633,6 +36581,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35660,6 +36609,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35687,6 +36637,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35714,6 +36665,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35748,6 +36700,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35775,6 +36728,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35802,6 +36756,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35829,6 +36784,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35856,6 +36812,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35904,6 +36861,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35959,6 +36917,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35986,6 +36945,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -36013,6 +36973,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36047,6 +37008,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -36074,6 +37036,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36143,6 +37106,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36191,6 +37155,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36246,6 +37211,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36287,6 +37253,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36314,6 +37281,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36383,6 +37351,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36410,6 +37379,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36437,6 +37407,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36464,6 +37435,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36568,6 +37540,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36595,6 +37568,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36622,6 +37596,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36719,6 +37694,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36746,6 +37722,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36773,6 +37750,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36800,6 +37778,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36827,6 +37806,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36854,6 +37834,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36881,6 +37862,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36908,6 +37890,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36935,6 +37918,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36962,6 +37946,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36989,6 +37974,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -37023,6 +38009,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -37050,6 +38037,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -37077,6 +38065,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37132,6 +38121,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37159,6 +38149,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37186,6 +38177,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37241,6 +38233,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37268,6 +38261,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37323,6 +38317,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37350,6 +38345,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37377,6 +38373,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37425,6 +38422,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37452,6 +38450,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37479,6 +38478,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37506,6 +38506,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37547,6 +38548,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37574,6 +38576,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37608,6 +38611,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37635,6 +38639,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37669,6 +38674,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37724,6 +38730,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37751,6 +38758,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37778,6 +38786,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37826,6 +38835,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37860,6 +38870,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37922,6 +38933,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37949,6 +38961,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37976,6 +38989,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38024,6 +39038,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -38051,6 +39066,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38078,6 +39094,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -38126,6 +39143,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38153,6 +39171,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38264,6 +39283,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38319,6 +39339,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38346,6 +39367,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38394,6 +39416,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38421,6 +39444,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38490,6 +39514,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38517,6 +39542,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38572,6 +39598,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38599,6 +39626,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38626,6 +39654,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38653,6 +39682,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38680,6 +39710,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38707,6 +39738,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38769,6 +39801,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38796,6 +39829,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38844,6 +39878,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38871,6 +39906,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38898,6 +39934,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38925,6 +39962,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38980,6 +40018,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39007,6 +40046,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -39034,6 +40074,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -39061,6 +40102,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -39130,6 +40172,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39157,6 +40200,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39184,6 +40228,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39260,6 +40305,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39287,6 +40333,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39321,6 +40368,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39355,6 +40403,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39389,6 +40438,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39416,6 +40466,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39443,6 +40494,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39470,6 +40522,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39504,6 +40557,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39531,6 +40585,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39558,6 +40613,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39585,6 +40641,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39619,6 +40676,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39653,6 +40711,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39680,6 +40739,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39707,6 +40767,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39818,6 +40879,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39845,6 +40907,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39872,6 +40935,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39899,6 +40963,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39954,6 +41019,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39981,6 +41047,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40015,6 +41082,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40042,6 +41110,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -40139,6 +41208,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40166,6 +41236,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40193,6 +41264,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40220,6 +41292,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40289,6 +41362,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x17497e9e5230493b79c19bad0dc165e06ac0aac3db8eaa4de441d44a70aa9a03.json
+++ b/test/testData/testPools/0x17497e9e5230493b79c19bad0dc165e06ac0aac3db8eaa4de441d44a70aa9a03.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -94,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -169,6 +174,7 @@
         {
             "id": "0x01223eb6b9cbe061f2f22e96f74936c0115ec6fb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4de9ab5dd20547b7334a295763dfd0a11b010e0a",
@@ -196,6 +202,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -223,6 +230,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -257,6 +265,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -284,6 +293,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -311,6 +321,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -338,6 +349,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -365,6 +377,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -392,6 +405,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -419,6 +433,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -446,6 +461,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -494,6 +510,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -535,6 +552,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -562,6 +580,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -589,6 +608,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +636,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -643,6 +664,7 @@
         {
             "id": "0x049c586132110f6551d758deb50a7c984fc0ec59",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x67c597624b17b16fb77959217360b7cd18284253",
@@ -670,6 +692,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -697,6 +720,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -745,6 +769,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -772,6 +797,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -799,6 +825,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -854,6 +881,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -902,6 +930,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -929,6 +958,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -956,6 +986,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -983,6 +1014,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -1010,6 +1042,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1051,6 +1084,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1092,6 +1126,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1119,6 +1154,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1188,6 +1224,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1257,6 +1294,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1284,6 +1322,7 @@
         {
             "id": "0x0895f4263343d12ce332f23e8678fa9fbfcd9eff",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x67b6d479c7bb412c54e03dca8e1bc6740ce6b99c",
@@ -1311,6 +1350,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1338,6 +1378,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1365,6 +1406,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1392,6 +1434,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1419,6 +1462,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1446,6 +1490,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1473,6 +1518,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1521,6 +1567,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1548,6 +1595,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1596,6 +1644,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1623,6 +1672,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1650,6 +1700,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1677,6 +1728,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1718,6 +1770,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1745,6 +1798,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1772,6 +1826,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1799,6 +1854,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1826,6 +1882,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1853,6 +1910,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1880,6 +1938,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1921,6 +1980,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1948,6 +2008,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +2043,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2030,6 +2092,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2057,6 +2120,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2105,6 +2169,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2160,6 +2225,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2208,6 +2274,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2235,6 +2302,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2262,6 +2330,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2317,6 +2386,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2344,6 +2414,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2371,6 +2442,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2470,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2432,6 +2505,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2459,6 +2533,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2486,6 +2562,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2520,6 +2597,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2547,6 +2625,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2574,6 +2653,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2601,6 +2681,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2723,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2690,6 +2772,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2717,6 +2800,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2751,6 +2835,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2778,6 +2863,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2805,6 +2891,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2832,6 +2919,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2859,6 +2947,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2893,6 +2982,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2920,6 +3010,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2947,6 +3038,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2974,6 +3066,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3008,6 +3101,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3077,6 +3171,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3111,6 +3206,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3138,6 +3234,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3165,6 +3262,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3192,6 +3290,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3233,6 +3332,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3260,6 +3360,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3287,6 +3388,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3314,6 +3416,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3341,6 +3444,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3368,6 +3472,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3409,6 +3514,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3457,6 +3563,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3484,6 +3591,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3511,6 +3619,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3538,6 +3647,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3565,6 +3675,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3634,6 +3745,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3661,6 +3773,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3688,6 +3801,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3715,6 +3829,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3742,6 +3857,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3769,6 +3885,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3796,6 +3913,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3823,6 +3941,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3857,6 +3976,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3884,6 +4004,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3911,6 +4032,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3938,6 +4060,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3972,6 +4095,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3999,6 +4123,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4026,6 +4151,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4053,6 +4179,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4080,6 +4207,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4121,6 +4249,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4148,6 +4277,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4196,6 +4326,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4223,6 +4354,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4271,6 +4403,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4298,6 +4431,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4325,6 +4459,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4352,6 +4487,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4379,6 +4515,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4406,6 +4543,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4461,6 +4599,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4502,6 +4641,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4529,6 +4669,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4556,6 +4697,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4583,6 +4725,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4610,6 +4753,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4637,6 +4781,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4664,6 +4809,7 @@
         {
             "id": "0x1e6c8c4d3a9a6f633f28c70c7c80a412df42956a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69af81e73a73b40adf4f3d4223cd9b1ece623074",
@@ -4691,6 +4837,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4718,6 +4865,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4745,6 +4893,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4772,6 +4921,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4799,6 +4949,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4868,6 +5019,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4895,6 +5047,7 @@
         {
             "id": "0x2201e7d0911b1bb990d2dca5ee40a58a3e43dbc5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x31c8eacbffdd875c74b94b077895bd78cf1e64a3",
@@ -4922,6 +5075,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4949,6 +5103,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4976,6 +5131,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5017,6 +5173,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5243,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5113,6 +5271,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5140,6 +5299,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5167,6 +5327,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5201,6 +5362,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5228,6 +5390,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5255,6 +5418,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5282,6 +5446,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5309,6 +5474,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5336,6 +5502,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5363,6 +5530,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5390,6 +5558,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5417,6 +5586,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5444,6 +5614,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5499,6 +5670,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5526,6 +5698,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5560,6 +5733,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5587,6 +5761,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5614,6 +5789,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5641,6 +5817,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5668,6 +5845,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5695,6 +5873,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5722,6 +5901,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5756,6 +5936,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5783,6 +5964,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5810,6 +5992,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5865,6 +6048,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5892,6 +6076,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5919,6 +6104,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5946,6 +6132,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -5973,6 +6161,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -6000,6 +6189,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6027,6 +6217,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6054,6 +6245,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6081,6 +6273,7 @@
         {
             "id": "0x298d859ec66f859046ad3966d58f4e88fcf6374c",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -6122,6 +6315,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6149,6 +6343,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6197,6 +6392,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6224,6 +6420,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6265,6 +6462,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6313,6 +6511,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6340,6 +6539,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6367,6 +6567,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6422,6 +6623,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6456,6 +6658,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6497,6 +6700,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6566,6 +6770,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6593,6 +6798,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6627,6 +6833,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6654,6 +6861,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6681,6 +6889,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6708,6 +6917,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6735,6 +6945,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6762,6 +6973,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6789,6 +7001,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6851,6 +7064,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6920,6 +7134,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6947,6 +7162,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6974,6 +7190,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7001,6 +7218,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7028,6 +7246,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7055,6 +7274,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7089,6 +7309,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7116,6 +7337,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7143,6 +7365,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7170,6 +7393,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7204,6 +7428,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7231,6 +7456,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7258,6 +7484,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7285,6 +7512,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7340,6 +7568,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7367,6 +7596,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7394,6 +7624,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7421,6 +7652,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7448,6 +7680,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7475,6 +7708,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7502,6 +7736,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7529,6 +7764,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7556,6 +7792,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7583,6 +7820,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7652,6 +7890,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7932,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7720,6 +7960,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7747,6 +7988,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7774,6 +8016,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7801,6 +8044,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7828,6 +8072,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7862,6 +8107,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7889,6 +8135,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7923,6 +8170,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7950,6 +8198,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7977,6 +8226,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -8025,6 +8275,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -8052,6 +8303,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8079,6 +8331,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8106,6 +8359,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8133,6 +8387,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8160,6 +8415,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8187,6 +8443,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8235,6 +8492,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8262,6 +8521,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8289,6 +8549,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8323,6 +8584,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8350,6 +8612,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8377,6 +8640,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8418,6 +8682,7 @@
         {
             "id": "0x371df92d8d2d0881587e5fb1cfbe831e40856768",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6a78a1788db6e2e668e4985565b0aadc94accbbd",
@@ -8445,6 +8710,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8472,6 +8738,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8506,6 +8773,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8575,6 +8843,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8602,6 +8871,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8629,6 +8899,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8656,6 +8927,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8725,6 +8997,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8752,6 +9025,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8779,6 +9053,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8806,6 +9081,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8840,6 +9116,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8867,6 +9144,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8915,6 +9193,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8963,6 +9242,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8990,6 +9270,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9017,6 +9298,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9044,6 +9326,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -9071,6 +9354,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9098,6 +9382,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9125,6 +9410,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9194,6 +9480,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9221,6 +9508,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9248,6 +9536,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9275,6 +9564,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9302,6 +9592,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9343,6 +9634,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9370,6 +9662,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -9439,6 +9732,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9487,6 +9781,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9514,6 +9809,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9583,6 +9879,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9631,6 +9928,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9658,6 +9956,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9685,6 +9984,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9712,6 +10012,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9739,6 +10040,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9766,6 +10068,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9793,6 +10096,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9820,6 +10124,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9847,6 +10152,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9874,6 +10180,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9901,6 +10208,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9928,6 +10236,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9955,6 +10264,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9982,6 +10292,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -10009,6 +10320,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -10036,6 +10348,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10063,6 +10376,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10090,6 +10404,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10117,6 +10432,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10172,6 +10488,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10199,6 +10516,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10226,6 +10544,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10260,6 +10579,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10287,6 +10607,7 @@
         {
             "id": "0x432a2ac91b1fbacfb9c0ee26ef26a42bc13fd2d9",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -10314,6 +10635,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10341,6 +10663,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10368,6 +10691,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10395,6 +10719,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10422,6 +10747,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10449,6 +10775,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10497,6 +10824,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10524,6 +10852,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10551,6 +10880,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10578,6 +10908,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10605,6 +10936,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10632,6 +10964,7 @@
         {
             "id": "0x44ed13fca4ce66caa29d03dde9a74a24802cd6be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10701,6 +11034,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10728,6 +11062,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10755,6 +11090,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10782,6 +11118,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10809,6 +11146,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10871,6 +11209,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10898,6 +11237,7 @@
         {
             "id": "0x4687d7377fe2cc3ac3ac5fa675f3f1ff974c999f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x821ade160d897bca542e78d6d07de48d5431ef8e",
@@ -10925,6 +11265,7 @@
         {
             "id": "0x4699c28f71c09bace0160a265ba403dcf513811a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x31c8eacbffdd875c74b94b077895bd78cf1e64a3",
@@ -10952,6 +11293,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10979,6 +11321,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -11006,6 +11349,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -11075,6 +11419,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -11109,6 +11454,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11136,6 +11482,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11510,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11190,6 +11538,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11217,6 +11566,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11265,6 +11615,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11292,6 +11643,7 @@
         {
             "id": "0x48c1d1d43f2a2267dacdd06bd6c63f3696073ed4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ea781fb85e88fd9ee1f66fa71dcf00c276b091c",
@@ -11319,6 +11671,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11367,6 +11720,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11394,6 +11748,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11421,6 +11776,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11483,6 +11839,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11524,6 +11881,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11551,6 +11909,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11578,6 +11937,7 @@
         {
             "id": "0x4abd7635e49de219d93f6c2f263da8db633d81cf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1cb5f1983329402e212203084067060250bbea25",
@@ -11605,6 +11965,7 @@
         {
             "id": "0x4afe271aa56b31744019f10b56a31238f7419367",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -11632,6 +11993,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11659,6 +12021,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11686,6 +12049,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11755,6 +12119,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11782,6 +12147,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11809,6 +12175,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11836,6 +12203,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11870,6 +12238,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11904,6 +12273,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11931,6 +12301,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11958,6 +12329,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11985,6 +12357,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -12012,6 +12385,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -12039,6 +12413,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -12066,6 +12441,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12093,6 +12469,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -12120,6 +12497,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12147,6 +12525,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12174,6 +12553,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12201,6 +12581,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12228,6 +12609,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12255,6 +12637,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12282,6 +12665,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12344,6 +12728,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12378,6 +12763,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12405,6 +12791,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12432,6 +12819,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12459,6 +12847,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12486,6 +12875,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12541,6 +12931,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12568,6 +12959,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12595,6 +12987,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12622,6 +13015,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12649,6 +13043,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12676,6 +13071,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12703,6 +13099,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12730,6 +13127,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12799,6 +13197,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12826,6 +13225,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12853,6 +13253,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12887,6 +13288,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12914,6 +13316,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +13344,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13393,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13016,6 +13421,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13463,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13112,6 +13519,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -13181,6 +13589,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13208,6 +13617,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13235,6 +13645,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13262,6 +13673,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13289,6 +13701,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13316,6 +13729,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13343,6 +13757,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13370,6 +13785,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13397,6 +13813,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13445,6 +13862,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13514,6 +13932,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13541,6 +13960,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13582,6 +14002,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13609,6 +14030,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13643,6 +14065,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +14107,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +14149,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13794,6 +14219,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13821,6 +14247,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13848,6 +14275,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13875,6 +14303,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13902,6 +14331,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13957,6 +14387,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13984,6 +14415,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -14011,6 +14443,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -14038,6 +14471,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14065,6 +14499,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -14092,6 +14527,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -14119,6 +14555,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14146,6 +14583,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -14173,6 +14611,7 @@
         {
             "id": "0x58378f5f8ca85144ebd8e1e5e2ad95b02d29d2bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x903bef1736cddf2a537176cf3c64579c3867a881",
@@ -14200,6 +14639,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -14227,6 +14667,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14289,6 +14730,7 @@
         {
             "id": "0x58ce2e98a050925d99b209799d10f413c729f6fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bead9a1bcc1b84d06e3f2df67e3549fd55ab054",
@@ -14316,6 +14758,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14343,6 +14786,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14370,6 +14814,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14397,6 +14842,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14870,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14940,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14520,6 +14968,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14547,6 +14996,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14574,6 +15024,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14601,6 +15052,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14642,6 +15094,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14669,6 +15122,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14696,6 +15150,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14723,6 +15178,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14750,6 +15206,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14777,6 +15234,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14804,6 +15262,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14831,6 +15290,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14900,6 +15360,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14927,6 +15388,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14954,6 +15416,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14981,6 +15444,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15008,6 +15472,7 @@
         {
             "id": "0x5bdb9e0e098c9c715c551863a2adfc9be37c4e83",
             "swapFee": "0.0178",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c6ec08cf3fc987c6c4beb03184d335a2dfc4042",
@@ -15042,6 +15507,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15069,6 +15535,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -15096,6 +15563,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15123,6 +15591,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15157,6 +15626,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -15184,6 +15654,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -15211,6 +15682,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -15238,6 +15710,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15265,6 +15738,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15292,6 +15766,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15319,6 +15794,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15346,6 +15822,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15415,6 +15892,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15442,6 +15920,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15469,6 +15948,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15496,6 +15976,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15523,6 +16004,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15550,6 +16032,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15577,6 +16060,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15618,6 +16102,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +16172,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15714,6 +16200,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15741,6 +16228,7 @@
         {
             "id": "0x60acad545aafefcbd5ec6f07386788473b1d0d9c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x126c121f99e1e211df2e5f8de2d96fa36647c855",
@@ -15775,6 +16263,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15802,6 +16291,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15829,6 +16319,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15856,6 +16347,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15897,6 +16389,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15924,6 +16417,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15951,6 +16445,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15978,6 +16473,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -16005,6 +16501,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16039,6 +16536,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -16066,6 +16564,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16093,6 +16592,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16120,6 +16620,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16189,6 +16690,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16216,6 +16718,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -16243,6 +16746,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -16270,6 +16774,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -16297,6 +16802,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16324,6 +16830,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16351,6 +16858,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16378,6 +16886,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16405,6 +16914,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16432,6 +16942,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16459,6 +16970,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16500,6 +17012,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16527,6 +17040,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16554,6 +17068,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16616,6 +17131,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16643,6 +17159,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16670,6 +17187,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16697,6 +17215,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16724,6 +17243,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16751,6 +17271,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16778,6 +17299,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16805,6 +17327,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16832,6 +17355,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16859,6 +17383,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16886,6 +17411,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16941,6 +17467,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16975,6 +17502,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -17002,6 +17530,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17029,6 +17558,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17056,6 +17586,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -17083,6 +17614,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17110,6 +17642,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -17137,6 +17670,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -17178,6 +17712,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17782,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17281,6 +17817,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17308,6 +17845,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17335,6 +17873,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17362,6 +17901,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17389,6 +17929,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17423,6 +17964,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17450,6 +17992,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17477,6 +18020,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17546,6 +18090,7 @@
         {
             "id": "0x6ca4732e385ea5475ac7cd1be3f4d0fb97a498ea",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17573,6 +18118,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17600,6 +18146,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17627,6 +18174,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17654,6 +18202,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17681,6 +18230,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17708,6 +18258,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17735,6 +18286,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17762,6 +18314,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17824,6 +18377,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17851,6 +18405,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17878,6 +18433,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17905,6 +18461,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17932,6 +18489,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17980,6 +18538,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18049,6 +18608,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18090,6 +18650,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -18117,6 +18678,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -18144,6 +18706,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -18171,6 +18734,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18198,6 +18762,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18239,6 +18804,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -18266,6 +18832,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -18300,6 +18867,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -18327,6 +18895,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -18354,6 +18923,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18381,6 +18951,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18408,6 +18979,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18435,6 +19007,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18462,6 +19035,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18531,6 +19105,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18558,6 +19133,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18585,6 +19161,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18612,6 +19189,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18639,6 +19217,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -18666,6 +19245,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18735,6 +19315,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18762,6 +19343,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18831,6 +19413,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18858,6 +19441,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18885,6 +19469,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18912,6 +19497,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18939,6 +19525,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18966,6 +19553,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18993,6 +19581,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19027,6 +19616,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -19061,6 +19651,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19088,6 +19679,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19115,6 +19707,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -19170,6 +19763,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19197,6 +19791,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19224,6 +19819,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -19251,6 +19847,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -19285,6 +19882,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -19312,6 +19910,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -19339,6 +19938,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19366,6 +19966,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19393,6 +19994,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19427,6 +20029,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19454,6 +20057,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19481,6 +20085,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19508,6 +20113,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19535,6 +20141,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19562,6 +20169,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +20197,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19616,6 +20225,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19650,6 +20260,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19677,6 +20288,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19704,6 +20316,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19731,6 +20344,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19758,6 +20372,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19785,6 +20400,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19819,6 +20435,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19846,6 +20463,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19873,6 +20491,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19900,6 +20519,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19927,6 +20547,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -19954,6 +20575,7 @@
         {
             "id": "0x7b7499fab431dee48174f8a775e799dd1542f487",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59e9261255644c411afdd00bd89162d09d862e38",
@@ -19981,6 +20603,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20008,6 +20631,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -20035,6 +20659,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -20083,6 +20708,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20110,6 +20736,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -20137,6 +20764,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -20164,6 +20792,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -20191,6 +20820,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -20218,6 +20848,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -20245,6 +20876,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -20272,6 +20904,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -20299,6 +20932,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -20368,6 +21002,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20395,6 +21030,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20422,6 +21058,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20449,6 +21086,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20483,6 +21121,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20510,6 +21149,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20537,6 +21177,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20564,6 +21205,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20591,6 +21233,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20632,6 +21275,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20659,6 +21303,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20700,6 +21345,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20727,6 +21373,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20796,6 +21443,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20858,6 +21506,8 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -20892,6 +21542,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20919,6 +21570,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20988,6 +21640,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21015,6 +21668,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21042,6 +21696,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -21069,6 +21724,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -21096,6 +21752,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -21123,6 +21780,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -21150,6 +21808,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -21177,6 +21836,7 @@
         {
             "id": "0x824603f89e27af953cab03a82017e4a74dd4df73",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x31c8eacbffdd875c74b94b077895bd78cf1e64a3",
@@ -21204,6 +21864,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -21238,6 +21899,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21265,6 +21927,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21327,6 +21990,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21354,6 +22018,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -21381,6 +22046,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -21415,6 +22081,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21449,6 +22116,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21490,6 +22158,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21545,6 +22214,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21572,6 +22242,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21599,6 +22270,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21668,6 +22340,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21695,6 +22368,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21736,6 +22410,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21763,6 +22438,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21790,6 +22466,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21817,6 +22494,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21844,6 +22522,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21878,6 +22557,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21905,6 +22585,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21932,6 +22613,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21959,6 +22641,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21986,6 +22669,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -22013,6 +22697,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -22054,6 +22739,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -22081,6 +22767,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22108,6 +22795,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -22135,6 +22823,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -22162,6 +22851,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22210,6 +22900,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22237,6 +22928,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22264,6 +22956,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -22291,6 +22984,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22318,6 +23012,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22345,6 +23040,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22393,6 +23089,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22427,6 +23124,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22454,6 +23152,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22481,6 +23180,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22508,6 +23208,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22535,6 +23236,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22562,6 +23264,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22589,6 +23292,7 @@
         {
             "id": "0x8d5bd8407a55110a346ea0c8ac54c9511764ee22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x67c597624b17b16fb77959217360b7cd18284253",
@@ -22616,6 +23320,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22657,6 +23362,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22684,6 +23390,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22711,6 +23418,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22738,6 +23446,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +23488,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22820,6 +23530,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22861,6 +23572,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22888,6 +23600,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22922,6 +23635,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22949,6 +23663,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -22976,6 +23691,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23003,6 +23719,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -23030,6 +23747,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -23078,6 +23796,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -23119,6 +23838,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23146,6 +23866,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23173,6 +23894,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23242,6 +23964,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -23276,6 +23999,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -23303,6 +24027,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23337,6 +24062,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +24111,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23419,6 +24146,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -23446,6 +24174,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -23473,6 +24202,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23500,6 +24230,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23527,6 +24258,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23554,6 +24286,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23581,6 +24314,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23608,6 +24342,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23635,6 +24370,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23662,6 +24398,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23717,6 +24454,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23744,6 +24482,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23778,6 +24517,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23805,6 +24545,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23846,6 +24587,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23873,6 +24615,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23900,6 +24643,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23927,6 +24671,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23954,6 +24699,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23981,6 +24727,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -24015,6 +24762,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24042,6 +24790,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24076,6 +24825,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24103,6 +24853,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24151,6 +24902,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -24178,6 +24930,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -24205,6 +24958,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24232,6 +24986,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -24259,6 +25014,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -24286,6 +25042,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24313,6 +25070,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -24340,6 +25098,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -24367,6 +25126,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -24394,6 +25154,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24421,6 +25182,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -24448,6 +25210,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24496,6 +25259,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24544,6 +25308,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24571,6 +25336,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24598,6 +25364,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24625,6 +25392,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24652,6 +25420,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24679,6 +25448,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24706,6 +25476,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24733,6 +25504,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24760,6 +25532,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24787,6 +25560,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24814,6 +25588,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24841,6 +25616,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24875,6 +25651,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24937,6 +25714,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24964,6 +25742,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24991,6 +25770,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25018,6 +25798,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25840,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25128,6 +25910,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -25197,6 +25980,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -25224,6 +26008,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25251,6 +26036,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -25320,6 +26106,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25347,6 +26134,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25374,6 +26162,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -25401,6 +26190,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -25435,6 +26225,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25476,6 +26267,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25503,6 +26295,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25530,6 +26323,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25557,6 +26351,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25584,6 +26379,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25611,6 +26407,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25638,6 +26435,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25665,6 +26463,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25692,6 +26491,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25733,6 +26533,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25760,6 +26561,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25787,6 +26589,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25821,6 +26624,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25848,6 +26652,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25896,6 +26701,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25930,6 +26736,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25957,6 +26764,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25984,6 +26792,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26011,6 +26820,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26038,6 +26848,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26065,6 +26876,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -26092,6 +26904,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -26119,6 +26932,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26153,6 +26967,7 @@
         {
             "id": "0xa2f0f547e6598b56c44ac6cc0e0c79c8075f39b5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26180,6 +26995,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26207,6 +27023,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26234,6 +27051,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -26268,6 +27086,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -26295,6 +27114,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -26322,6 +27142,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26370,6 +27191,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26397,6 +27219,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -26424,6 +27247,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26451,6 +27275,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26485,6 +27310,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26526,6 +27352,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +27380,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26580,6 +27408,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26607,6 +27436,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26669,6 +27499,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26696,6 +27527,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26723,6 +27555,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26750,6 +27583,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26777,6 +27611,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26804,6 +27639,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26831,6 +27667,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26865,6 +27702,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26892,6 +27730,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26961,6 +27800,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26988,6 +27828,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -27057,6 +27898,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27084,6 +27926,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -27111,6 +27954,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -27138,6 +27982,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -27165,6 +28010,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27192,6 +28038,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -27219,6 +28066,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -27246,6 +28094,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27273,6 +28122,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -27300,6 +28150,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27327,6 +28178,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +28241,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +28311,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27485,6 +28339,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27512,6 +28367,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27539,6 +28395,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27566,6 +28423,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27600,6 +28458,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27627,6 +28486,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27654,6 +28514,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27702,6 +28563,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27729,6 +28591,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27770,6 +28633,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27797,6 +28661,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27838,6 +28703,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27865,6 +28731,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28759,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27926,6 +28794,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27953,6 +28822,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27980,6 +28850,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28007,6 +28878,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -28034,6 +28906,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -28061,6 +28934,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -28088,6 +28962,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -28115,6 +28990,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28142,6 +29018,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -28169,6 +29046,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -28196,6 +29074,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -28223,6 +29102,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -28250,6 +29130,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28277,6 +29158,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -28304,6 +29186,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +29214,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28379,6 +29263,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -28406,6 +29291,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28433,6 +29319,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -28460,6 +29347,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -28487,6 +29375,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28514,6 +29403,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28541,6 +29431,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28568,6 +29459,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28595,6 +29487,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28622,6 +29515,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28649,6 +29543,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28676,6 +29571,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28710,6 +29606,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28737,6 +29634,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28764,6 +29662,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28791,6 +29690,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28818,6 +29718,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28887,6 +29788,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28914,6 +29816,7 @@
         {
             "id": "0xb60e8c3fed84ac332f58060730eff5a752845860",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28941,6 +29844,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28968,6 +29872,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28995,6 +29900,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29022,6 +29928,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29049,6 +29956,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -29076,6 +29984,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29103,6 +30012,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -29130,6 +30040,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29157,6 +30068,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -29184,6 +30096,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29211,6 +30124,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -29245,6 +30159,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -29272,6 +30187,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -29306,6 +30222,7 @@
         {
             "id": "0xb828e94ca3171953bab1953377309f8391c8329d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -29333,6 +30250,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -29360,6 +30278,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -29387,6 +30306,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -29414,6 +30334,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -29441,6 +30362,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29496,6 +30418,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29523,6 +30446,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29592,6 +30516,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29661,6 +30586,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29688,6 +30614,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29715,6 +30642,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29742,6 +30670,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29769,6 +30698,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29810,6 +30740,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29837,6 +30768,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29864,6 +30796,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29919,6 +30852,7 @@
         {
             "id": "0xbbae28f1841f3902a97815adb62f4795b0a09f8c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f17bc9a994b87b5225cfb6a2cd4d667adb4f20b",
@@ -29946,6 +30880,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29973,6 +30908,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -30000,6 +30936,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30027,6 +30964,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -30068,6 +31006,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -30095,6 +31034,8 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30122,6 +31063,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -30156,6 +31098,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -30183,6 +31126,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -30210,6 +31154,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -30237,6 +31182,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -30264,6 +31210,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -30298,6 +31245,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -30325,6 +31273,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -30352,6 +31301,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -30379,6 +31329,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30406,6 +31357,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30433,6 +31385,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -30460,6 +31413,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30529,6 +31483,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -30556,6 +31511,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -30583,6 +31539,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30610,6 +31567,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30637,6 +31595,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30664,6 +31623,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30691,6 +31651,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30718,6 +31679,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30759,6 +31721,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30786,6 +31749,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30813,6 +31777,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30840,6 +31805,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30867,6 +31833,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30894,6 +31861,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30921,6 +31889,7 @@
         {
             "id": "0xc34473ccac5e14a4b7bf558d41477a05976e670c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bead9a1bcc1b84d06e3f2df67e3549fd55ab054",
@@ -30948,6 +31917,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30975,6 +31945,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -31002,6 +31973,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -31029,6 +32001,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -31056,6 +32029,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -31083,6 +32057,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31110,6 +32085,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -31137,6 +32113,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31171,6 +32148,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31233,6 +32211,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -31260,6 +32239,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -31287,6 +32267,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -31314,6 +32295,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -31341,6 +32323,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -31368,6 +32351,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -31395,6 +32379,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -31422,6 +32407,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -31449,6 +32435,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31504,6 +32491,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -31531,6 +32519,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -31558,6 +32547,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31585,6 +32575,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -31612,6 +32603,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31639,6 +32631,7 @@
         {
             "id": "0xc786ab4704e6b79c6bfedfefd0e0d7f0b0abfa73",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31666,6 +32659,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31700,6 +32694,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31727,6 +32722,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31754,6 +32750,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31781,6 +32778,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31808,6 +32806,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31835,6 +32834,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31862,6 +32862,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31889,6 +32890,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31916,6 +32918,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31943,6 +32946,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31970,6 +32974,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -32011,6 +33016,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +33072,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32093,6 +33100,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32120,6 +33128,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -32147,6 +33156,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -32174,6 +33184,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -32201,6 +33212,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32228,6 +33240,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -32255,6 +33268,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -32310,6 +33324,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -32337,6 +33352,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32364,6 +33380,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32419,6 +33436,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -32453,6 +33471,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32508,6 +33527,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32542,6 +33562,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32569,6 +33590,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -32603,6 +33625,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32651,6 +33674,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32692,6 +33716,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32719,6 +33744,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32746,6 +33772,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32773,6 +33800,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32800,6 +33828,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32827,6 +33856,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32861,6 +33891,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32888,6 +33919,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32915,6 +33947,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32942,6 +33975,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32969,6 +34003,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32996,6 +34031,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33023,6 +34059,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33050,6 +34087,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -33077,6 +34115,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -33104,6 +34143,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33131,6 +34171,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33158,6 +34199,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -33185,6 +34227,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -33212,6 +34255,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -33239,6 +34283,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -33266,6 +34311,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33293,6 +34339,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33320,6 +34367,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33347,6 +34395,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -33395,6 +34444,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33436,6 +34486,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33463,6 +34514,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -33490,6 +34542,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -33517,6 +34570,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33579,6 +34633,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33606,6 +34661,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33633,6 +34689,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33660,6 +34717,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33694,6 +34752,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33721,6 +34780,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33748,6 +34808,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33775,6 +34836,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33802,6 +34864,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33829,6 +34892,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33856,6 +34920,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33925,6 +34990,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33952,6 +35018,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34000,6 +35067,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -34027,6 +35095,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34075,6 +35144,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +35172,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +35201,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34163,6 +35236,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -34204,6 +35278,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34245,6 +35320,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -34272,6 +35348,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34299,6 +35376,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -34326,6 +35404,7 @@
         {
             "id": "0xd8ff3c39caea60322a6737963f846d3e0a374b46",
             "swapFee": "0.01777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -34374,6 +35453,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -34408,6 +35488,7 @@
         {
             "id": "0xd938da53417b522d5a11f79ff17da3f0f9f5157e",
             "swapFee": "0.00499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -34477,6 +35558,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34504,6 +35586,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -34531,6 +35614,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +35642,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34585,6 +35670,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -34612,6 +35698,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -34639,6 +35726,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34666,6 +35754,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34693,6 +35782,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34734,6 +35824,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34761,6 +35852,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34830,6 +35922,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34857,6 +35950,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34884,6 +35978,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34911,6 +36006,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34938,6 +36034,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34965,6 +36062,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34999,6 +36097,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35033,6 +36132,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35060,6 +36160,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35129,6 +36230,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -35156,6 +36258,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -35183,6 +36286,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -35210,6 +36314,7 @@
         {
             "id": "0xddfc610a2b4968fa29e574fb3f4adb31de375a4c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x077ae156ed25bec1b49b81797de8312d15fae1f8",
@@ -35237,6 +36342,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35264,6 +36370,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35291,6 +36398,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -35346,6 +36454,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35373,6 +36482,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -35407,6 +36517,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +36545,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35461,6 +36573,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -35488,6 +36601,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35515,6 +36629,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -35542,6 +36657,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -35569,6 +36685,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35596,6 +36713,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -35644,6 +36762,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35671,6 +36790,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35698,6 +36818,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35725,6 +36846,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +36874,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +36923,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35827,6 +36951,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35854,6 +36979,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35881,6 +37007,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35908,6 +37035,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35935,6 +37063,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35962,6 +37091,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35989,6 +37119,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36016,6 +37147,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36043,6 +37175,7 @@
         {
             "id": "0xe28feb488a82bfddb59a3734c66561eabbedd921",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x31c8eacbffdd875c74b94b077895bd78cf1e64a3",
@@ -36070,6 +37203,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -36097,6 +37231,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36145,6 +37280,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36172,6 +37308,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36199,6 +37336,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36226,6 +37364,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -36253,6 +37392,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -36287,6 +37427,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -36314,6 +37455,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36341,6 +37483,7 @@
         {
             "id": "0xe4e4a4fba89d91f240920e089a8591d127f1c295",
             "swapFee": "0.0066",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -36375,6 +37518,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -36402,6 +37546,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -36429,6 +37574,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -36477,6 +37623,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -36504,6 +37651,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36531,6 +37679,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -36558,6 +37707,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -36585,6 +37735,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36619,6 +37770,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -36646,6 +37798,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36715,6 +37868,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36763,6 +37917,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36818,6 +37973,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36859,6 +38015,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36886,6 +38043,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36955,6 +38113,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36982,6 +38141,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37009,6 +38169,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -37036,6 +38197,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -37063,6 +38225,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +38253,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37138,6 +38302,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -37165,6 +38330,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -37192,6 +38358,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37219,6 +38386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37288,6 +38456,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37315,6 +38484,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -37342,6 +38512,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -37369,6 +38540,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37396,6 +38568,7 @@
         {
             "id": "0xe943560b36cbfd848c4733bf59aca0692f90c022",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37423,6 +38596,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37450,6 +38624,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37477,6 +38652,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37504,6 +38680,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -37531,6 +38708,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -37558,6 +38736,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -37585,6 +38764,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -37619,6 +38799,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -37646,6 +38827,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -37673,6 +38855,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37700,6 +38883,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37727,6 +38911,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37754,6 +38939,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37781,6 +38967,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37836,6 +39023,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37863,6 +39051,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37918,6 +39107,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37945,6 +39135,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37972,6 +39163,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -38020,6 +39212,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -38047,6 +39240,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -38074,6 +39268,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38101,6 +39296,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -38142,6 +39338,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38169,6 +39366,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38203,6 +39401,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38230,6 +39429,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -38264,6 +39464,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38291,6 +39492,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38318,6 +39520,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38345,6 +39548,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -38393,6 +39597,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38427,6 +39632,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -38454,6 +39660,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38488,6 +39695,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -38515,6 +39723,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -38542,6 +39751,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38590,6 +39800,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -38617,6 +39828,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38644,6 +39856,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -38692,6 +39905,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38719,6 +39933,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38746,6 +39961,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +40003,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38828,6 +40045,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38855,6 +40073,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38882,6 +40101,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38909,6 +40129,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38957,6 +40178,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38984,6 +40206,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -39025,6 +40248,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39052,6 +40276,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -39079,6 +40304,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39106,6 +40332,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39133,6 +40360,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -39160,6 +40388,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -39187,6 +40416,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -39214,6 +40444,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39241,6 +40472,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -39268,6 +40500,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -39302,6 +40535,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39329,6 +40563,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39356,6 +40591,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -39404,6 +40640,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -39431,6 +40668,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -39458,6 +40696,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39492,6 +40731,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39519,6 +40759,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -39546,6 +40787,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39573,6 +40815,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39600,6 +40843,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -39627,6 +40871,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -39654,6 +40899,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -39723,6 +40969,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39750,6 +40997,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39777,6 +41025,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39804,6 +41053,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39852,6 +41102,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39879,6 +41130,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39913,6 +41165,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39947,6 +41200,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39981,6 +41235,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -40008,6 +41263,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -40035,6 +41291,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40062,6 +41319,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -40096,6 +41354,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -40123,6 +41382,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -40150,6 +41410,7 @@
         {
             "id": "0xfb07fa808061d5cf17fc324a92f4e0eb753b9f67",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b40183efb4dd766f11bda7a7c3ad8982e998421",
@@ -40198,6 +41459,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -40225,6 +41487,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40259,6 +41522,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -40293,6 +41557,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40320,6 +41585,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40347,6 +41613,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -40388,6 +41655,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40457,6 +41725,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -40484,6 +41753,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -40511,6 +41781,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -40538,6 +41809,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -40565,6 +41837,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40592,6 +41865,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -40619,6 +41893,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40653,6 +41928,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40680,6 +41956,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40749,6 +42026,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40776,6 +42054,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40803,6 +42082,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40830,6 +42110,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40899,6 +42180,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x17497e9e5230493b79c19bad0dc165e06ac0aac3db8eaa4de441d44a70aa9a03.json
+++ b/test/testData/testPools/0x17497e9e5230493b79c19bad0dc165e06ac0aac3db8eaa4de441d44a70aa9a03.json
@@ -2534,7 +2534,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6133,7 +6132,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8492,7 +8490,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -21507,7 +21504,6 @@
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -31035,7 +31031,6 @@
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -35172,7 +35167,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0x18a934486971129d335b5a166e5d9dc2c271c8b7ff6c7ea079e2b97d45273403.json
+++ b/test/testData/testPools/0x18a934486971129d335b5a166e5d9dc2c271c8b7ff6c7ea079e2b97d45273403.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x19a742954302f2fee90e823696033c6758b119f17620806971d34e4cda4579af.json
+++ b/test/testData/testPools/0x19a742954302f2fee90e823696033c6758b119f17620806971d34e4cda4579af.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x1c140552d2362e4f361bad928f66f273ae188841934abd36c46a45cf981f7559.json
+++ b/test/testData/testPools/0x1c140552d2362e4f361bad928f66f273ae188841934abd36c46a45cf981f7559.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x1d003bffebf27ab36c69502da4d2aadbac99a1d794ad188bea0966ea15bf038c.json
+++ b/test/testData/testPools/0x1d003bffebf27ab36c69502da4d2aadbac99a1d794ad188bea0966ea15bf038c.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x21d5562b317f9d3b57b3406ee868ad882ab3c87cd67f7af2ff55042e59702bef.json
+++ b/test/testData/testPools/0x21d5562b317f9d3b57b3406ee868ad882ab3c87cd67f7af2ff55042e59702bef.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -94,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -169,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -196,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -230,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -257,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -284,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -311,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -338,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -365,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -392,6 +405,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -419,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -467,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -508,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -535,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -562,6 +580,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +608,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -616,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -643,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -691,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -718,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -745,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -800,6 +825,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -848,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -875,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -902,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -929,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -956,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -997,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1024,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1065,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1092,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1161,6 +1196,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1230,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1257,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1284,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1311,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1338,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1365,6 +1406,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1392,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1419,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1467,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1494,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1542,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1569,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1596,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1623,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1664,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1691,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1718,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1745,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1772,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1799,6 +1854,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1826,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1867,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1894,6 +1952,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1987,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -1976,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2004,6 +2065,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2051,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2169,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2168,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2216,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2243,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2270,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2325,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2352,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2379,6 +2449,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2477,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2440,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2467,6 +2540,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2494,6 +2569,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2528,6 +2604,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2555,6 +2632,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2582,6 +2660,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2609,6 +2688,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2657,6 +2737,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2684,6 +2765,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2718,6 +2800,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2745,6 +2828,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2772,6 +2856,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2799,6 +2884,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2826,6 +2912,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2860,6 +2947,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2887,6 +2975,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2914,6 +3003,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2941,6 +3031,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -2975,6 +3066,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3044,6 +3136,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3078,6 +3171,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3105,6 +3199,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3132,6 +3227,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3159,6 +3255,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3200,6 +3297,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3227,6 +3325,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3254,6 +3353,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3281,6 +3381,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3308,6 +3409,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3335,6 +3437,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3376,6 +3479,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3424,6 +3528,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3451,6 +3556,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3478,6 +3584,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3505,6 +3612,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3532,6 +3640,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3601,6 +3710,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3628,6 +3738,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3655,6 +3766,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3682,6 +3794,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3709,6 +3822,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3736,6 +3850,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3763,6 +3878,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3790,6 +3906,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3824,6 +3941,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3851,6 +3969,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3878,6 +3997,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3905,6 +4025,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3939,6 +4060,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3966,6 +4088,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -3993,6 +4116,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4020,6 +4144,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4047,6 +4172,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4088,6 +4214,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4115,6 +4242,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4163,6 +4291,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4190,6 +4319,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4238,6 +4368,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4265,6 +4396,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4292,6 +4424,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4319,6 +4452,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4346,6 +4480,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4373,6 +4508,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4428,6 +4564,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4469,6 +4606,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4496,6 +4634,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4523,6 +4662,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4550,6 +4690,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4577,6 +4718,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4604,6 +4746,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4774,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4658,6 +4802,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4685,6 +4830,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4712,6 +4858,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4739,6 +4886,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4808,6 +4956,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4835,6 +4984,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4862,6 +5012,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4889,6 +5040,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -4930,6 +5082,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5152,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5026,6 +5180,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5053,6 +5208,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5080,6 +5236,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5114,6 +5271,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5141,6 +5299,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5168,6 +5327,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5195,6 +5355,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5222,6 +5383,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5249,6 +5411,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5276,6 +5439,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5303,6 +5467,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5495,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5357,6 +5523,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5412,6 +5579,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5439,6 +5607,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5473,6 +5642,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5500,6 +5670,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5527,6 +5698,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5554,6 +5726,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5581,6 +5754,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5608,6 +5782,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5635,6 +5810,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5669,6 +5845,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5696,6 +5873,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5723,6 +5901,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5778,6 +5957,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5805,6 +5985,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5832,6 +6013,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5859,6 +6041,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -5886,6 +6070,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5913,6 +6098,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5940,6 +6126,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5967,6 +6154,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5994,6 +6182,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6021,6 +6210,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6069,6 +6259,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6096,6 +6287,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6137,6 +6329,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6185,6 +6378,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6212,6 +6406,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6239,6 +6434,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6294,6 +6490,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6328,6 +6525,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6369,6 +6567,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6438,6 +6637,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6465,6 +6665,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6499,6 +6700,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6526,6 +6728,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6553,6 +6756,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6580,6 +6784,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6607,6 +6812,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6634,6 +6840,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6661,6 +6868,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6688,6 +6896,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6750,6 +6959,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6819,6 +7029,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6846,6 +7057,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6873,6 +7085,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6900,6 +7113,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6927,6 +7141,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6954,6 +7169,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -6988,6 +7204,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7015,6 +7232,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7042,6 +7260,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7069,6 +7288,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7103,6 +7323,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7130,6 +7351,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7157,6 +7379,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7184,6 +7407,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7239,6 +7463,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7266,6 +7491,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7293,6 +7519,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7320,6 +7547,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7347,6 +7575,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7374,6 +7603,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7401,6 +7631,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7428,6 +7659,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7455,6 +7687,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7482,6 +7715,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7551,6 +7785,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7827,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7855,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7646,6 +7883,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7673,6 +7911,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7700,6 +7939,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7727,6 +7967,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7761,6 +8002,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7788,6 +8030,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7822,6 +8065,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7849,6 +8093,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7876,6 +8121,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7924,6 +8170,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7951,6 +8198,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -7978,6 +8226,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8005,6 +8254,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8032,6 +8282,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8059,6 +8310,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8086,6 +8338,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8134,6 +8387,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8161,6 +8416,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8188,6 +8444,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8222,6 +8479,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8249,6 +8507,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8276,6 +8535,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8317,6 +8577,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8344,6 +8605,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8378,6 +8640,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8447,6 +8710,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8474,6 +8738,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8501,6 +8766,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8528,6 +8794,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8597,6 +8864,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8624,6 +8892,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8651,6 +8920,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8678,6 +8948,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8712,6 +8983,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8739,6 +9011,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8787,6 +9060,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8835,6 +9109,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8862,6 +9137,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +9165,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8916,6 +9193,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8943,6 +9221,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -8970,6 +9249,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8997,6 +9277,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9066,6 +9347,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9093,6 +9375,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9120,6 +9403,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9147,6 +9431,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9174,6 +9459,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9215,6 +9501,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9242,6 +9529,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -9311,6 +9599,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9359,6 +9648,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9386,6 +9676,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9455,6 +9746,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9503,6 +9795,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9530,6 +9823,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9557,6 +9851,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9584,6 +9879,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9611,6 +9907,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9638,6 +9935,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9665,6 +9963,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9692,6 +9991,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9719,6 +10019,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9746,6 +10047,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9773,6 +10075,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9800,6 +10103,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9827,6 +10131,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9854,6 +10159,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9881,6 +10187,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9908,6 +10215,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9935,6 +10243,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -9962,6 +10271,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10003,6 +10313,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10030,6 +10341,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10057,6 +10369,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10112,6 +10425,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10139,6 +10453,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10166,6 +10481,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10200,6 +10516,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10227,6 +10544,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10254,6 +10572,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10281,6 +10600,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10308,6 +10628,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10335,6 +10656,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10362,6 +10684,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10389,6 +10712,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10437,6 +10761,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10464,6 +10789,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10491,6 +10817,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10518,6 +10845,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10545,6 +10873,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10572,6 +10901,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10599,6 +10929,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10626,6 +10957,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10653,6 +10985,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10715,6 +11048,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10742,6 +11076,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10769,6 +11104,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10796,6 +11132,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10865,6 +11202,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10899,6 +11237,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -10926,6 +11265,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11293,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -10980,6 +11321,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11007,6 +11349,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11055,6 +11398,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11082,6 +11426,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11130,6 +11475,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11157,6 +11503,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11184,6 +11531,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11246,6 +11594,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11287,6 +11636,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11314,6 +11664,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11341,6 +11692,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11368,6 +11720,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11395,6 +11748,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11464,6 +11818,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11491,6 +11846,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11518,6 +11874,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11545,6 +11902,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11579,6 +11937,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11613,6 +11972,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11640,6 +12000,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11667,6 +12028,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11694,6 +12056,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11721,6 +12084,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11748,6 +12112,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11775,6 +12140,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11802,6 +12168,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11829,6 +12196,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11856,6 +12224,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11883,6 +12252,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -11910,6 +12280,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -11937,6 +12308,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -11964,6 +12336,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -11991,6 +12364,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12053,6 +12427,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12087,6 +12462,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12114,6 +12490,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12141,6 +12518,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12168,6 +12546,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12195,6 +12574,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12250,6 +12630,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12277,6 +12658,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12304,6 +12686,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12331,6 +12714,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12358,6 +12742,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12385,6 +12770,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12412,6 +12798,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12439,6 +12826,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12508,6 +12896,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12535,6 +12924,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12562,6 +12952,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12596,6 +12987,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12623,6 +13015,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +13043,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +13092,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12725,6 +13120,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +13162,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12821,6 +13218,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12855,6 +13253,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12924,6 +13323,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -12951,6 +13351,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -12978,6 +13379,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13005,6 +13407,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13032,6 +13435,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13059,6 +13463,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13086,6 +13491,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13113,6 +13519,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13140,6 +13547,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13188,6 +13596,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13257,6 +13666,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13284,6 +13694,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13325,6 +13736,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13352,6 +13764,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13386,6 +13799,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13841,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13496,6 +13911,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13523,6 +13939,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13550,6 +13967,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13577,6 +13995,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13604,6 +14023,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13659,6 +14079,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13686,6 +14107,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13713,6 +14135,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13740,6 +14163,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13767,6 +14191,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13794,6 +14219,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13821,6 +14247,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13848,6 +14275,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13875,6 +14303,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -13902,6 +14331,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13964,6 +14394,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -13991,6 +14422,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14018,6 +14450,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14045,6 +14478,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14072,6 +14506,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14534,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14604,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14195,6 +14632,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14222,6 +14660,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14249,6 +14688,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14276,6 +14716,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14317,6 +14758,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14344,6 +14786,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14371,6 +14814,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14398,6 +14842,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14425,6 +14870,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14452,6 +14898,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14479,6 +14926,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14506,6 +14954,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14575,6 +15024,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14602,6 +15052,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14629,6 +15080,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14656,6 +15108,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14683,6 +15136,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14710,6 +15164,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14737,6 +15192,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14764,6 +15220,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14798,6 +15255,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14825,6 +15283,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14852,6 +15311,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14879,6 +15339,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14906,6 +15367,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -14933,6 +15395,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -14960,6 +15423,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -14987,6 +15451,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15056,6 +15521,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15083,6 +15549,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15110,6 +15577,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15137,6 +15605,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15164,6 +15633,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15191,6 +15661,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15218,6 +15689,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15259,6 +15731,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15801,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15355,6 +15829,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15382,6 +15857,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15409,6 +15885,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15436,6 +15913,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15463,6 +15941,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15504,6 +15983,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15531,6 +16011,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15558,6 +16039,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15585,6 +16067,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15612,6 +16095,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15646,6 +16130,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15673,6 +16158,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15700,6 +16186,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15727,6 +16214,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -15796,6 +16284,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15823,6 +16312,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15850,6 +16340,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15877,6 +16368,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15904,6 +16396,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -15931,6 +16424,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15958,6 +16452,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -15985,6 +16480,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16012,6 +16508,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16039,6 +16536,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16066,6 +16564,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16107,6 +16606,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16134,6 +16634,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16161,6 +16662,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16223,6 +16725,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16250,6 +16753,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16277,6 +16781,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16304,6 +16809,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16331,6 +16837,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16358,6 +16865,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16385,6 +16893,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16412,6 +16921,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16439,6 +16949,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16466,6 +16977,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16493,6 +17005,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16548,6 +17061,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16582,6 +17096,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16609,6 +17124,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16636,6 +17152,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16663,6 +17180,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16690,6 +17208,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16717,6 +17236,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16744,6 +17264,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16785,6 +17306,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +17376,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -16888,6 +17411,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16915,6 +17439,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -16942,6 +17467,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16969,6 +17495,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -16996,6 +17523,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17030,6 +17558,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17057,6 +17586,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17084,6 +17614,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17153,6 +17684,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17180,6 +17712,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17207,6 +17740,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17234,6 +17768,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17261,6 +17796,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17288,6 +17824,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17315,6 +17852,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17342,6 +17880,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17404,6 +17943,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17431,6 +17971,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17458,6 +17999,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17485,6 +18027,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17512,6 +18055,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17560,6 +18104,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17601,6 +18146,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17628,6 +18174,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17655,6 +18202,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17689,6 +18237,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17716,6 +18265,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17743,6 +18293,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17784,6 +18335,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17811,6 +18363,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17845,6 +18398,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17872,6 +18426,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17899,6 +18454,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17926,6 +18482,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17953,6 +18510,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -17980,6 +18538,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18007,6 +18566,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18076,6 +18636,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18103,6 +18664,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18130,6 +18692,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18157,6 +18720,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18184,6 +18748,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -18211,6 +18776,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18280,6 +18846,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18307,6 +18874,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18376,6 +18944,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18403,6 +18972,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18430,6 +19000,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18457,6 +19028,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18484,6 +19056,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18511,6 +19084,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18538,6 +19112,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18572,6 +19147,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18606,6 +19182,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18633,6 +19210,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18660,6 +19238,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18715,6 +19294,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18742,6 +19322,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18769,6 +19350,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18796,6 +19378,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18830,6 +19413,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18857,6 +19441,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18884,6 +19469,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18911,6 +19497,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18938,6 +19525,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -18972,6 +19560,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18999,6 +19588,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19026,6 +19616,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19053,6 +19644,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19080,6 +19672,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19107,6 +19700,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19728,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19161,6 +19756,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19195,6 +19791,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19222,6 +19819,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19249,6 +19847,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19276,6 +19875,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19303,6 +19903,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19330,6 +19931,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19364,6 +19966,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19398,6 +20001,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19425,6 +20029,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19452,6 +20057,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19479,6 +20085,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19506,6 +20113,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -19533,6 +20141,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19560,6 +20169,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19587,6 +20197,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19635,6 +20246,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19662,6 +20274,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19689,6 +20302,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19716,6 +20330,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19743,6 +20358,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19770,6 +20386,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19797,6 +20414,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19824,6 +20442,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19851,6 +20470,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -19920,6 +20540,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19947,6 +20568,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19974,6 +20596,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20001,6 +20624,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20035,6 +20659,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20062,6 +20687,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20089,6 +20715,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20116,6 +20743,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20143,6 +20771,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20184,6 +20813,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20211,6 +20841,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20252,6 +20883,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20279,6 +20911,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20348,6 +20981,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20410,6 +21044,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20437,6 +21072,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20506,6 +21142,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20533,6 +21170,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20560,6 +21198,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20587,6 +21226,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20614,6 +21254,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20641,6 +21282,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20668,6 +21310,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20695,6 +21338,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20729,6 +21373,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20756,6 +21401,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -20818,6 +21464,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20845,6 +21492,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20872,6 +21520,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -20906,6 +21555,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20940,6 +21590,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -20981,6 +21632,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21036,6 +21688,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21063,6 +21716,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21090,6 +21744,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21159,6 +21814,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21186,6 +21842,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21227,6 +21884,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21254,6 +21912,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21281,6 +21940,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21308,6 +21968,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21335,6 +21996,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21369,6 +22031,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21396,6 +22059,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21423,6 +22087,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21450,6 +22115,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21477,6 +22143,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21504,6 +22171,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21545,6 +22213,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21572,6 +22241,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21599,6 +22269,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21626,6 +22297,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21653,6 +22325,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -21701,6 +22374,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21728,6 +22402,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21755,6 +22430,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21782,6 +22458,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21809,6 +22486,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21836,6 +22514,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21884,6 +22563,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -21918,6 +22598,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21945,6 +22626,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -21972,6 +22654,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21999,6 +22682,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22026,6 +22710,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22053,6 +22738,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22080,6 +22766,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22121,6 +22808,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22148,6 +22836,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22175,6 +22864,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22202,6 +22892,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22920,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22962,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22311,6 +23004,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22352,6 +23046,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22379,6 +23074,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22413,6 +23109,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22440,6 +23137,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -22467,6 +23165,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22494,6 +23193,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22521,6 +23221,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22569,6 +23270,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22610,6 +23312,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22637,6 +23340,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22664,6 +23368,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22733,6 +23438,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22767,6 +23473,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22794,6 +23501,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22828,6 +23536,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22862,6 +23571,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22889,6 +23599,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22916,6 +23627,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -22943,6 +23655,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22970,6 +23683,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22997,6 +23711,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23024,6 +23739,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23051,6 +23767,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23078,6 +23795,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23105,6 +23823,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23160,6 +23879,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23187,6 +23907,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23221,6 +23942,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23248,6 +23970,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23275,6 +23998,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23316,6 +24040,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23343,6 +24068,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23370,6 +24096,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23397,6 +24124,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23424,6 +24152,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23451,6 +24180,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23485,6 +24215,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23512,6 +24243,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23546,6 +24278,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23573,6 +24306,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23621,6 +24355,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23648,6 +24383,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23675,6 +24411,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23702,6 +24439,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23729,6 +24467,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23756,6 +24495,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23783,6 +24523,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23810,6 +24551,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23837,6 +24579,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23864,6 +24607,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -23891,6 +24635,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -23918,6 +24663,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -23966,6 +24712,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24014,6 +24761,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24041,6 +24789,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24068,6 +24817,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24095,6 +24845,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24122,6 +24873,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24149,6 +24901,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24176,6 +24929,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24203,6 +24957,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24230,6 +24985,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24257,6 +25013,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24284,6 +25041,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24311,6 +25069,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24338,6 +25097,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24372,6 +25132,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24434,6 +25195,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24461,6 +25223,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24488,6 +25251,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24515,6 +25279,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +25321,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -24625,6 +25391,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24694,6 +25461,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24721,6 +25489,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24748,6 +25517,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24817,6 +25587,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24844,6 +25615,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24871,6 +25643,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24898,6 +25671,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -24932,6 +25706,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24973,6 +25748,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25000,6 +25776,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25027,6 +25804,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25054,6 +25832,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25081,6 +25860,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25108,6 +25888,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25135,6 +25916,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25162,6 +25944,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25189,6 +25972,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25230,6 +26014,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25257,6 +26042,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25284,6 +26070,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25318,6 +26105,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25345,6 +26133,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25393,6 +26182,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25427,6 +26217,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25454,6 +26245,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25481,6 +26273,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25508,6 +26301,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25535,6 +26329,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25562,6 +26357,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25589,6 +26385,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25616,6 +26413,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25650,6 +26448,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25677,6 +26476,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25704,6 +26504,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25738,6 +26539,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25765,6 +26567,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25792,6 +26595,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25840,6 +26644,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25867,6 +26672,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -25894,6 +26700,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25921,6 +26728,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25955,6 +26763,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25996,6 +26805,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26833,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26050,6 +26861,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26077,6 +26889,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26139,6 +26952,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26166,6 +26980,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26193,6 +27008,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26220,6 +27036,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26247,6 +27064,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26274,6 +27092,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26301,6 +27120,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26335,6 +27155,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26362,6 +27183,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26431,6 +27253,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26458,6 +27281,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26527,6 +27351,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26554,6 +27379,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26581,6 +27407,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26608,6 +27435,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26635,6 +27463,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26662,6 +27491,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26689,6 +27519,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26716,6 +27547,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26743,6 +27575,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26770,6 +27603,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26797,6 +27631,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +27694,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27764,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -26955,6 +27792,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -26982,6 +27820,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27009,6 +27848,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27036,6 +27876,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27070,6 +27911,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27097,6 +27939,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27124,6 +27967,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27172,6 +28016,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27199,6 +28044,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27240,6 +28086,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27267,6 +28114,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27308,6 +28156,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27335,6 +28184,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +28212,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27396,6 +28247,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27423,6 +28275,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27450,6 +28303,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27477,6 +28331,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27504,6 +28359,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27531,6 +28387,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27558,6 +28415,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27585,6 +28443,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27612,6 +28471,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27639,6 +28499,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27666,6 +28527,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27693,6 +28555,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27720,6 +28583,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27747,6 +28611,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27774,6 +28639,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +28667,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27849,6 +28716,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -27876,6 +28744,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27903,6 +28772,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -27930,6 +28800,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -27957,6 +28828,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27984,6 +28856,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28011,6 +28884,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28038,6 +28912,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28065,6 +28940,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28092,6 +28968,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28119,6 +28996,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28146,6 +29024,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28180,6 +29059,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28207,6 +29087,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28234,6 +29115,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28261,6 +29143,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28288,6 +29171,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28357,6 +29241,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28384,6 +29269,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28411,6 +29297,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28438,6 +29325,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28465,6 +29353,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28492,6 +29381,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28519,6 +29409,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28546,6 +29437,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28573,6 +29465,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28600,6 +29493,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28627,6 +29521,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28654,6 +29549,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28688,6 +29584,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28715,6 +29612,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28749,6 +29647,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28776,6 +29675,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28803,6 +29703,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28830,6 +29731,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -28857,6 +29759,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28912,6 +29815,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28939,6 +29843,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29008,6 +29913,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29077,6 +29983,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29104,6 +30011,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29131,6 +30039,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29158,6 +30067,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29185,6 +30095,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29226,6 +30137,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29253,6 +30165,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29280,6 +30193,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29335,6 +30249,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29362,6 +30277,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29389,6 +30305,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29416,6 +30333,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29457,6 +30375,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29484,6 +30403,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29518,6 +30438,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29545,6 +30466,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29572,6 +30494,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29599,6 +30522,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29626,6 +30550,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29660,6 +30585,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29687,6 +30613,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29714,6 +30641,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29741,6 +30669,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29768,6 +30697,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29795,6 +30725,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29822,6 +30753,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -29849,6 +30781,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29918,6 +30851,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -29945,6 +30879,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -29972,6 +30907,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -29999,6 +30935,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30026,6 +30963,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30053,6 +30991,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30080,6 +31019,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30107,6 +31047,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30148,6 +31089,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30175,6 +31117,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30202,6 +31145,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30229,6 +31173,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30256,6 +31201,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30283,6 +31229,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30310,6 +31257,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30337,6 +31285,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30364,6 +31313,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30391,6 +31341,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30418,6 +31369,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30445,6 +31397,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -30472,6 +31425,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30499,6 +31453,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30533,6 +31488,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30595,6 +31551,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30622,6 +31579,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30649,6 +31607,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30676,6 +31635,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30703,6 +31663,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30730,6 +31691,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30757,6 +31719,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30784,6 +31747,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30811,6 +31775,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30866,6 +31831,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -30893,6 +31859,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30920,6 +31887,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30947,6 +31915,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -30974,6 +31943,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31001,6 +31971,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31035,6 +32006,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31062,6 +32034,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31089,6 +32062,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31116,6 +32090,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31143,6 +32118,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31170,6 +32146,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31197,6 +32174,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31224,6 +32202,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31251,6 +32230,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31278,6 +32258,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31305,6 +32286,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31346,6 +32328,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +32384,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31428,6 +32412,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31455,6 +32440,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31482,6 +32468,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31509,6 +32496,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31536,6 +32524,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31563,6 +32552,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31590,6 +32580,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31645,6 +32636,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31672,6 +32664,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31699,6 +32692,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31754,6 +32748,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31788,6 +32783,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31843,6 +32839,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31877,6 +32874,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31904,6 +32902,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -31938,6 +32937,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31986,6 +32986,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32027,6 +33028,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32054,6 +33056,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32081,6 +33084,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32108,6 +33112,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32135,6 +33140,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32162,6 +33168,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32196,6 +33203,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32223,6 +33231,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32250,6 +33259,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32277,6 +33287,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32304,6 +33315,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32331,6 +33343,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32358,6 +33371,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32385,6 +33399,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32412,6 +33427,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32439,6 +33455,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32466,6 +33483,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32493,6 +33511,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32520,6 +33539,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32547,6 +33567,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32574,6 +33595,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32601,6 +33623,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32628,6 +33651,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32655,6 +33679,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32682,6 +33707,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32730,6 +33756,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32771,6 +33798,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32798,6 +33826,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32825,6 +33854,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32852,6 +33882,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32914,6 +33945,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -32941,6 +33973,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -32968,6 +34001,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32995,6 +34029,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33029,6 +34064,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33056,6 +34092,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33083,6 +34120,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33124,6 +34162,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33151,6 +34190,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33178,6 +34218,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33205,6 +34246,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33232,6 +34274,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33301,6 +34344,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33328,6 +34372,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33376,6 +34421,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33403,6 +34449,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33451,6 +34498,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +34526,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +34555,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33539,6 +34590,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33580,6 +34632,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33621,6 +34674,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33648,6 +34702,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33675,6 +34730,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33702,6 +34758,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33736,6 +34793,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33763,6 +34821,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33790,6 +34849,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +34877,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -33844,6 +34905,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -33871,6 +34933,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -33898,6 +34961,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33925,6 +34989,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +35017,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -33979,6 +35045,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34020,6 +35087,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34047,6 +35115,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34116,6 +35185,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34143,6 +35213,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34170,6 +35241,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34197,6 +35269,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34224,6 +35297,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34251,6 +35325,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34285,6 +35360,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34319,6 +35395,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34346,6 +35423,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34415,6 +35493,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34442,6 +35521,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34469,6 +35549,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34496,6 +35577,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34523,6 +35605,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34550,6 +35633,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34605,6 +35689,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34632,6 +35717,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34666,6 +35752,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +35780,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34720,6 +35808,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34747,6 +35836,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34774,6 +35864,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34801,6 +35892,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34828,6 +35920,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -34855,6 +35948,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -34903,6 +35997,7 @@
         {
             "id": "0xe02e8ddecbe302ba1a40107c726e3ee889b0ff10",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
@@ -34937,6 +36032,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34964,6 +36060,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34991,6 +36088,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35018,6 +36116,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +36144,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +36193,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35120,6 +36221,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35147,6 +36249,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35174,6 +36277,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35201,6 +36305,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35228,6 +36333,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35255,6 +36361,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35282,6 +36389,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35309,6 +36417,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35336,6 +36445,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35363,6 +36473,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35425,6 +36536,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35473,6 +36585,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35500,6 +36613,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35527,6 +36641,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35554,6 +36669,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35581,6 +36697,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35615,6 +36732,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35642,6 +36760,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35669,6 +36788,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35696,6 +36816,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35723,6 +36844,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35771,6 +36893,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35798,6 +36921,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -35825,6 +36949,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35852,6 +36977,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -35879,6 +37005,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35913,6 +37040,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -35940,6 +37068,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36009,6 +37138,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36057,6 +37187,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36112,6 +37243,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36153,6 +37285,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36180,6 +37313,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36249,6 +37383,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36276,6 +37411,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36303,6 +37439,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36330,6 +37467,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36357,6 +37495,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +37523,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36432,6 +37572,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36459,6 +37600,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36486,6 +37628,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36513,6 +37656,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36582,6 +37726,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36609,6 +37754,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36636,6 +37782,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36663,6 +37810,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36690,6 +37838,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36717,6 +37866,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36744,6 +37894,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36771,6 +37922,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36798,6 +37950,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36825,6 +37978,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36852,6 +38006,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -36886,6 +38041,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -36913,6 +38069,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -36940,6 +38097,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36967,6 +38125,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -36994,6 +38153,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37021,6 +38181,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37048,6 +38209,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37103,6 +38265,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37130,6 +38293,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37185,6 +38349,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37212,6 +38377,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37239,6 +38405,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37287,6 +38454,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37314,6 +38482,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37341,6 +38510,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37368,6 +38538,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37409,6 +38580,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37436,6 +38608,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37470,6 +38643,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37497,6 +38671,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37531,6 +38706,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37558,6 +38734,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37585,6 +38762,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37612,6 +38790,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37639,6 +38818,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37687,6 +38867,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37721,6 +38902,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37748,6 +38930,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -37782,6 +38965,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37809,6 +38993,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37836,6 +39021,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -37884,6 +39070,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37911,6 +39098,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37938,6 +39126,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -37986,6 +39175,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38013,6 +39203,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38040,6 +39231,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +39273,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38122,6 +39315,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38149,6 +39343,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38176,6 +39371,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38203,6 +39399,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38251,6 +39448,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38278,6 +39476,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38319,6 +39518,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38346,6 +39546,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38373,6 +39574,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38400,6 +39602,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38427,6 +39630,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38454,6 +39658,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38481,6 +39686,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38508,6 +39714,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38535,6 +39742,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38562,6 +39770,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38596,6 +39805,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38623,6 +39833,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38650,6 +39861,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38698,6 +39910,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38725,6 +39938,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38752,6 +39966,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38779,6 +39994,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38806,6 +40022,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -38833,6 +40050,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -38860,6 +40078,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -38887,6 +40106,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -38914,6 +40134,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38983,6 +40204,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39010,6 +40232,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39037,6 +40260,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39064,6 +40288,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39112,6 +40337,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39139,6 +40365,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39173,6 +40400,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39207,6 +40435,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39241,6 +40470,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39268,6 +40498,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39295,6 +40526,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39322,6 +40554,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39356,6 +40589,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39383,6 +40617,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39410,6 +40645,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39437,6 +40673,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39471,6 +40708,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39505,6 +40743,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39532,6 +40771,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39559,6 +40799,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39600,6 +40841,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39669,6 +40911,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39696,6 +40939,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39723,6 +40967,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39750,6 +40995,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39777,6 +41023,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39804,6 +41051,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39831,6 +41079,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39865,6 +41114,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39892,6 +41142,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -39919,6 +41170,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39988,6 +41240,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40015,6 +41268,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40042,6 +41296,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40069,6 +41324,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40138,6 +41394,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x21d5562b317f9d3b57b3406ee868ad882ab3c87cd67f7af2ff55042e59702bef.json
+++ b/test/testData/testPools/0x21d5562b317f9d3b57b3406ee868ad882ab3c87cd67f7af2ff55042e59702bef.json
@@ -2541,7 +2541,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6042,7 +6041,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8387,7 +8385,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -34526,7 +34523,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0x221c2f98afb75ae7ba165e70c647fc76c777b434eb84375d7261a0c951a0510c.json
+++ b/test/testData/testPools/0x221c2f98afb75ae7ba165e70c647fc76c777b434eb84375d7261a0c951a0510c.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x243f47a5c531b263b94ec2514aedd62ee45c43ec761c9d68bc27cfa3db0469dc.json
+++ b/test/testData/testPools/0x243f47a5c531b263b94ec2514aedd62ee45c43ec761c9d68bc27cfa3db0469dc.json
@@ -1161,6 +1161,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2468,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5859,6 +5861,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8134,6 +8137,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8451,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14644,6 +14649,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -20178,6 +20184,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -33486,6 +33493,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",

--- a/test/testData/testPools/0x25b8c910acd316601f5d8b4840b672e7d9c6a6c2ad9d6237ab50c0b090b97c92.json
+++ b/test/testData/testPools/0x25b8c910acd316601f5d8b4840b672e7d9c6a6c2ad9d6237ab50c0b090b97c92.json
@@ -990,6 +990,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1017,6 +1018,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1288,6 +1290,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -1458,6 +1461,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -1485,6 +1489,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -1696,6 +1701,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2057,6 +2063,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2261,6 +2268,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2695,6 +2703,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2790,6 +2799,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2824,6 +2834,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2900,6 +2911,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3002,6 +3014,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3275,6 +3288,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -3302,6 +3316,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3363,6 +3378,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3505,6 +3521,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3871,6 +3888,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -4231,6 +4249,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4916,6 +4935,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -5086,6 +5106,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5188,6 +5209,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5269,6 +5291,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5608,6 +5631,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5826,6 +5850,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5895,6 +5920,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5949,6 +5975,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6118,6 +6145,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6199,6 +6227,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6335,6 +6364,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6504,6 +6534,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6755,6 +6786,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -7224,6 +7256,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7769,6 +7802,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7850,6 +7884,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8026,6 +8061,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8189,6 +8225,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8324,6 +8361,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8447,6 +8485,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8488,6 +8527,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8657,6 +8697,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -9030,6 +9071,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9343,6 +9385,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9493,6 +9536,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9758,6 +9802,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10043,6 +10088,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10138,6 +10184,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11231,6 +11278,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11360,6 +11408,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11468,6 +11517,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11549,6 +11599,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11822,6 +11873,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11849,6 +11901,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12510,6 +12563,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12848,6 +12902,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13133,6 +13188,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13377,6 +13433,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13588,6 +13645,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13615,6 +13673,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13663,6 +13722,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13731,6 +13791,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14051,6 +14112,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14222,6 +14284,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14290,6 +14353,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14351,6 +14415,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14392,6 +14457,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14488,6 +14554,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14867,6 +14934,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15037,6 +15105,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15064,6 +15133,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15133,6 +15203,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15390,6 +15461,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15540,6 +15612,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15648,6 +15721,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15729,6 +15803,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15925,6 +16000,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16224,6 +16300,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16293,6 +16370,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16692,6 +16770,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17323,6 +17402,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17513,6 +17593,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17750,6 +17831,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17819,6 +17901,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18022,6 +18105,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18307,6 +18391,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18708,6 +18793,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18891,6 +18977,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18945,6 +19032,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19149,6 +19237,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19991,6 +20080,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20072,6 +20162,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20099,6 +20190,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20187,6 +20279,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20437,6 +20530,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21074,6 +21168,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21687,6 +21782,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22185,6 +22281,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22584,6 +22681,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23133,6 +23231,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -23160,6 +23259,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -23201,6 +23301,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -23371,6 +23472,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23982,6 +24084,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24118,6 +24221,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -24274,6 +24378,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24687,6 +24792,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24795,6 +24901,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25446,6 +25553,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25487,6 +25595,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26120,6 +26229,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26581,6 +26691,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26927,6 +27038,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26954,6 +27066,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +27571,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27647,6 +27761,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27728,6 +27843,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27790,6 +27906,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27859,6 +27976,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -28055,6 +28173,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28266,6 +28385,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -28293,6 +28413,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28705,6 +28826,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28732,6 +28854,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28807,6 +28930,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28996,6 +29120,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -29138,6 +29263,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29504,6 +29630,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29788,6 +29915,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30008,6 +30136,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30157,6 +30286,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30753,6 +30883,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31133,6 +31264,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31349,6 +31481,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31993,6 +32126,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32250,6 +32384,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32305,6 +32440,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32440,6 +32576,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32747,6 +32884,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32842,6 +32980,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32985,6 +33124,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33343,6 +33483,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33559,6 +33700,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33818,6 +33960,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -34055,6 +34198,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34136,6 +34280,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34232,6 +34377,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34307,6 +34453,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34382,6 +34529,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34409,6 +34557,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34552,6 +34701,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34694,6 +34844,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34721,6 +34872,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35250,6 +35402,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35570,6 +35723,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35597,6 +35751,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35651,6 +35806,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35888,6 +36044,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35915,6 +36072,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35963,6 +36121,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36668,6 +36827,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37227,6 +37387,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37254,6 +37415,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37383,6 +37545,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37837,6 +38000,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38428,6 +38592,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38618,6 +38783,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38910,6 +39076,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38951,6 +39118,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39019,6 +39187,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39189,6 +39358,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39270,6 +39440,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39466,6 +39637,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39676,6 +39848,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39934,6 +40107,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40470,6 +40644,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40647,6 +40822,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40789,6 +40965,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x269e99c9cedfba33d877019c3f6ebebbfbb04c3a2874292765972cdd9ee47b05.json
+++ b/test/testData/testPools/0x269e99c9cedfba33d877019c3f6ebebbfbb04c3a2874292765972cdd9ee47b05.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x2db088f092121c107a1bfe97984be190e5ab72fce044c9749c3611ce2365e4da.json
+++ b/test/testData/testPools/0x2db088f092121c107a1bfe97984be190e5ab72fce044c9749c3611ce2365e4da.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x2db088f092121c107a1bfe97984be190e5ab72fce044c9749c3611ce2365e4da.json
+++ b/test/testData/testPools/0x2db088f092121c107a1bfe97984be190e5ab72fce044c9749c3611ce2365e4da.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -171,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -198,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -232,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -259,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -286,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -313,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -340,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -367,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -422,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -470,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -511,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -538,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -621,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -648,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -696,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -723,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -750,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -854,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -881,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -908,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -935,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -962,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1003,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1030,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1071,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1098,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1237,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1264,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1291,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1318,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1345,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1400,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1427,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1475,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1502,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1550,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1577,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1604,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1631,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1672,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1699,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1726,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1753,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1780,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1835,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1876,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1987,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2063,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2181,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2229,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2256,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2283,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2338,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2365,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2455,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2510,6 +2568,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2544,6 +2603,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2571,6 +2631,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2598,6 +2659,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2674,6 +2736,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2701,6 +2764,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2735,6 +2799,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2762,6 +2827,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2789,6 +2855,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2816,6 +2883,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2843,6 +2911,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2877,6 +2946,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2904,6 +2974,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2931,6 +3002,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2958,6 +3030,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3062,6 +3135,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3096,6 +3170,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3123,6 +3198,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3150,6 +3226,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3177,6 +3254,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3218,6 +3296,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3245,6 +3324,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3272,6 +3352,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3299,6 +3380,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3326,6 +3408,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3395,6 +3478,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3443,6 +3527,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3470,6 +3555,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3497,6 +3583,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3524,6 +3611,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3551,6 +3639,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3620,6 +3709,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3647,6 +3737,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3674,6 +3765,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3701,6 +3793,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3728,6 +3821,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3755,6 +3849,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3782,6 +3877,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3809,6 +3905,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3843,6 +3940,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3870,6 +3968,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3897,6 +3996,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3924,6 +4024,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3958,6 +4059,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3985,6 +4087,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4012,6 +4115,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4067,6 +4171,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4108,6 +4213,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4135,6 +4241,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4183,6 +4290,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4259,6 +4367,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4286,6 +4395,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4341,6 +4451,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4368,6 +4479,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4451,6 +4563,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4492,6 +4605,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4519,6 +4633,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4546,6 +4661,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4573,6 +4689,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4600,6 +4717,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4627,6 +4745,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4654,6 +4773,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4681,6 +4801,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4708,6 +4829,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4763,6 +4885,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4832,6 +4955,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4859,6 +4983,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4886,6 +5011,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4913,6 +5039,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5052,6 +5179,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5107,6 +5235,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5141,6 +5270,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5168,6 +5298,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5195,6 +5326,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5222,6 +5354,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5277,6 +5410,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5304,6 +5438,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5359,6 +5494,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5386,6 +5522,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5441,6 +5578,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5503,6 +5641,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5530,6 +5669,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5557,6 +5697,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5584,6 +5725,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5611,6 +5753,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5666,6 +5809,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5700,6 +5844,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5727,6 +5872,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5754,6 +5900,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5809,6 +5956,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5836,6 +5984,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5863,6 +6012,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5918,6 +6068,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5945,6 +6096,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5972,6 +6124,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5999,6 +6152,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6026,6 +6180,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6053,6 +6208,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6101,6 +6257,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6128,6 +6285,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6169,6 +6327,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6217,6 +6376,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6244,6 +6404,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6271,6 +6432,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6326,6 +6488,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6402,6 +6565,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6471,6 +6635,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6498,6 +6663,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6532,6 +6698,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6559,6 +6726,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6586,6 +6754,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6613,6 +6782,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6640,6 +6810,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6667,6 +6838,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6694,6 +6866,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6721,6 +6894,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6783,6 +6957,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6852,6 +7027,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6879,6 +7055,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6934,6 +7111,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6961,6 +7139,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7023,6 +7202,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7050,6 +7230,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7077,6 +7258,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7104,6 +7286,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7138,6 +7321,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7193,6 +7377,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7220,6 +7405,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7275,6 +7461,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7302,6 +7489,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7357,6 +7545,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7384,6 +7573,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7411,6 +7601,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7438,6 +7629,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7493,6 +7685,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7520,6 +7713,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7659,6 +7853,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7686,6 +7881,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7713,6 +7909,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7740,6 +7937,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7767,6 +7965,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7829,6 +8028,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7863,6 +8063,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7890,6 +8091,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7917,6 +8119,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7965,6 +8168,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7992,6 +8196,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8019,6 +8224,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8046,6 +8252,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8073,6 +8280,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8100,6 +8308,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8127,6 +8336,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8203,6 +8413,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8230,6 +8441,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8264,6 +8476,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8291,6 +8504,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8318,6 +8532,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8359,6 +8574,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8386,6 +8602,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8420,6 +8637,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8517,6 +8735,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8544,6 +8763,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8571,6 +8791,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8668,6 +8889,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8695,6 +8917,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8722,6 +8945,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8756,6 +8980,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8783,6 +9008,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8831,6 +9057,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8879,6 +9106,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8934,6 +9162,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8961,6 +9190,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8988,6 +9218,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9015,6 +9246,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9042,6 +9274,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9111,6 +9344,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9138,6 +9372,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9165,6 +9400,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9220,6 +9456,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9261,6 +9498,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9358,6 +9596,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9406,6 +9645,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9433,6 +9673,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9502,6 +9743,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9550,6 +9792,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9577,6 +9820,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9604,6 +9848,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9631,6 +9876,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9658,6 +9904,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9685,6 +9932,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9712,6 +9960,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9739,6 +9988,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9766,6 +10016,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9793,6 +10044,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9820,6 +10072,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9847,6 +10100,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9874,6 +10128,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9901,6 +10156,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9928,6 +10184,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9955,6 +10212,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9982,6 +10240,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10009,6 +10268,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10050,6 +10310,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10077,6 +10338,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10104,6 +10366,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10159,6 +10422,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10186,6 +10450,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10213,6 +10478,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10247,6 +10513,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10274,6 +10541,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10301,6 +10569,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10328,6 +10597,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10355,6 +10625,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10410,6 +10681,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10437,6 +10709,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10485,6 +10758,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10540,6 +10814,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10567,6 +10842,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10594,6 +10870,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10649,6 +10926,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10676,6 +10954,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10766,6 +11045,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10793,6 +11073,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10820,6 +11101,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10847,6 +11129,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10916,6 +11199,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10950,6 +11234,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11033,6 +11318,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11060,6 +11346,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11108,6 +11395,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11135,6 +11423,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11183,6 +11472,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11210,6 +11500,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11237,6 +11528,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11299,6 +11591,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11340,6 +11633,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11367,6 +11661,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11394,6 +11689,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11421,6 +11717,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11448,6 +11745,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11517,6 +11815,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11544,6 +11843,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11571,6 +11871,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11633,6 +11934,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11667,6 +11969,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11694,6 +11997,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11721,6 +12025,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11748,6 +12053,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11775,6 +12081,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11802,6 +12109,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11829,6 +12137,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11856,6 +12165,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11883,6 +12193,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11910,6 +12221,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11965,6 +12277,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -11992,6 +12305,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12019,6 +12333,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12046,6 +12361,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12108,6 +12424,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12142,6 +12459,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12169,6 +12487,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12196,6 +12515,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12251,6 +12571,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12306,6 +12627,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12333,6 +12655,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12360,6 +12683,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12387,6 +12711,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12414,6 +12739,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12441,6 +12767,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12496,6 +12823,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12565,6 +12893,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12592,6 +12921,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12619,6 +12949,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12653,6 +12984,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12785,6 +13117,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12882,6 +13215,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12916,6 +13250,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12985,6 +13320,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13012,6 +13348,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13039,6 +13376,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13066,6 +13404,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13093,6 +13432,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13120,6 +13460,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13175,6 +13516,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13202,6 +13544,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13250,6 +13593,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13347,6 +13691,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13416,6 +13761,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13562,6 +13908,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13617,6 +13964,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13644,6 +13992,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13671,6 +14020,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13726,6 +14076,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13753,6 +14104,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13780,6 +14132,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13807,6 +14160,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13834,6 +14188,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13861,6 +14216,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13888,6 +14244,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13915,6 +14272,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13942,6 +14300,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -14032,6 +14391,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14059,6 +14419,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14086,6 +14447,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14113,6 +14475,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14266,6 +14629,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14293,6 +14657,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14320,6 +14685,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14347,6 +14713,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14388,6 +14755,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14415,6 +14783,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14442,6 +14811,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14469,6 +14839,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14524,6 +14895,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14551,6 +14923,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14578,6 +14951,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14675,6 +15049,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14702,6 +15077,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14729,6 +15105,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14784,6 +15161,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14811,6 +15189,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14873,6 +15252,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14900,6 +15280,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14927,6 +15308,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14954,6 +15336,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14981,6 +15364,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15008,6 +15392,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15063,6 +15448,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15132,6 +15518,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15159,6 +15546,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15186,6 +15574,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15213,6 +15602,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15240,6 +15630,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15267,6 +15658,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15294,6 +15686,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15433,6 +15826,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15460,6 +15854,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15487,6 +15882,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15514,6 +15910,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15541,6 +15938,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15582,6 +15980,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15609,6 +16008,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15636,6 +16036,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15663,6 +16064,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15690,6 +16092,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15724,6 +16127,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15751,6 +16155,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15778,6 +16183,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15875,6 +16281,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15902,6 +16309,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15929,6 +16337,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15956,6 +16365,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15983,6 +16393,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16010,6 +16421,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16037,6 +16449,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16064,6 +16477,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16091,6 +16505,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16118,6 +16533,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16145,6 +16561,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16186,6 +16603,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16213,6 +16631,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16240,6 +16659,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16302,6 +16722,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16329,6 +16750,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16356,6 +16778,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16383,6 +16806,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16410,6 +16834,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16465,6 +16890,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16492,6 +16918,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16519,6 +16946,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16546,6 +16974,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16573,6 +17002,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16663,6 +17093,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16690,6 +17121,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16717,6 +17149,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16744,6 +17177,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16771,6 +17205,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16798,6 +17233,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16825,6 +17261,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16971,6 +17408,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16998,6 +17436,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17025,6 +17464,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17052,6 +17492,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17079,6 +17520,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17113,6 +17555,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17168,6 +17611,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17237,6 +17681,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17264,6 +17709,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17291,6 +17737,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17318,6 +17765,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17345,6 +17793,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17372,6 +17821,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17399,6 +17849,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17489,6 +17940,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17516,6 +17968,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17543,6 +17996,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17570,6 +18024,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17597,6 +18052,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17645,6 +18101,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17686,6 +18143,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17713,6 +18171,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17740,6 +18199,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17774,6 +18234,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17801,6 +18262,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17870,6 +18332,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17897,6 +18360,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17931,6 +18395,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17958,6 +18423,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17985,6 +18451,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18040,6 +18507,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18095,6 +18563,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18164,6 +18633,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18191,6 +18661,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18218,6 +18689,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18245,6 +18717,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18300,6 +18773,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18369,6 +18843,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18396,6 +18871,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18465,6 +18941,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18492,6 +18969,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18519,6 +18997,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18546,6 +19025,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18573,6 +19053,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18600,6 +19081,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18627,6 +19109,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18661,6 +19144,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18695,6 +19179,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18722,6 +19207,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18749,6 +19235,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18804,6 +19291,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18831,6 +19319,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18858,6 +19347,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18885,6 +19375,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18919,6 +19410,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18946,6 +19438,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18973,6 +19466,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19000,6 +19494,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19027,6 +19522,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19061,6 +19557,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19088,6 +19585,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19143,6 +19641,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19170,6 +19669,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19253,6 +19753,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19287,6 +19788,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19342,6 +19844,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19369,6 +19872,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19396,6 +19900,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19423,6 +19928,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19457,6 +19963,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19491,6 +19998,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19518,6 +20026,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19545,6 +20054,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19572,6 +20082,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19627,6 +20138,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19654,6 +20166,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19681,6 +20194,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19729,6 +20243,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19756,6 +20271,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19783,6 +20299,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19810,6 +20327,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19837,6 +20355,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19864,6 +20383,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19891,6 +20411,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19918,6 +20439,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19945,6 +20467,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -20014,6 +20537,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20041,6 +20565,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20068,6 +20593,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20095,6 +20621,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20129,6 +20656,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20156,6 +20684,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20183,6 +20712,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20210,6 +20740,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20279,6 +20810,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20306,6 +20838,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20347,6 +20880,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20374,6 +20908,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20443,6 +20978,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20505,6 +21041,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20532,6 +21069,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20601,6 +21139,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20628,6 +21167,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20655,6 +21195,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20682,6 +21223,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20709,6 +21251,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20736,6 +21279,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20763,6 +21307,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20790,6 +21335,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20824,6 +21370,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20914,6 +21461,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20941,6 +21489,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20968,6 +21517,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -21002,6 +21552,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21036,6 +21587,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21077,6 +21629,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21132,6 +21685,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21159,6 +21713,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21186,6 +21741,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21255,6 +21811,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21282,6 +21839,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21323,6 +21881,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21378,6 +21937,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21405,6 +21965,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21432,6 +21993,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21466,6 +22028,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21493,6 +22056,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21520,6 +22084,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21547,6 +22112,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21574,6 +22140,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21601,6 +22168,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21642,6 +22210,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21669,6 +22238,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21696,6 +22266,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21723,6 +22294,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21799,6 +22371,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21826,6 +22399,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21853,6 +22427,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21880,6 +22455,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21907,6 +22483,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21934,6 +22511,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21982,6 +22560,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22016,6 +22595,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22043,6 +22623,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22070,6 +22651,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22097,6 +22679,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22124,6 +22707,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22151,6 +22735,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22178,6 +22763,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22219,6 +22805,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22246,6 +22833,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22273,6 +22861,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22412,6 +23001,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22453,6 +23043,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22480,6 +23071,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22514,6 +23106,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22569,6 +23162,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22596,6 +23190,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22623,6 +23218,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22671,6 +23267,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22712,6 +23309,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22739,6 +23337,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22766,6 +23365,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22835,6 +23435,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22869,6 +23470,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22896,6 +23498,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22930,6 +23533,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22964,6 +23568,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22991,6 +23596,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -23018,6 +23624,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23045,6 +23652,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23072,6 +23680,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23099,6 +23708,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23126,6 +23736,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23181,6 +23792,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23208,6 +23820,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23263,6 +23876,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23325,6 +23939,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23352,6 +23967,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23379,6 +23995,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23420,6 +24037,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23475,6 +24093,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23502,6 +24121,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23529,6 +24149,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23556,6 +24177,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23590,6 +24212,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23617,6 +24240,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23651,6 +24275,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23678,6 +24303,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23726,6 +24352,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23753,6 +24380,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23780,6 +24408,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23807,6 +24436,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23834,6 +24464,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23889,6 +24520,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23916,6 +24548,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23943,6 +24576,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23998,6 +24632,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -24025,6 +24660,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24073,6 +24709,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24121,6 +24758,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24148,6 +24786,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24175,6 +24814,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24202,6 +24842,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24229,6 +24870,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24256,6 +24898,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24283,6 +24926,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24310,6 +24954,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24337,6 +24982,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24364,6 +25010,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24391,6 +25038,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24418,6 +25066,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24445,6 +25094,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24479,6 +25129,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24541,6 +25192,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24568,6 +25220,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24595,6 +25248,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24734,6 +25388,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24803,6 +25458,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24830,6 +25486,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24857,6 +25514,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24926,6 +25584,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24953,6 +25612,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24980,6 +25640,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -25007,6 +25668,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -25041,6 +25703,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25082,6 +25745,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25109,6 +25773,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25136,6 +25801,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25163,6 +25829,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25190,6 +25857,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25217,6 +25885,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25244,6 +25913,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25271,6 +25941,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25340,6 +26011,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25367,6 +26039,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25394,6 +26067,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25428,6 +26102,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25455,6 +26130,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25503,6 +26179,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25537,6 +26214,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25564,6 +26242,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25591,6 +26270,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25618,6 +26298,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25645,6 +26326,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25672,6 +26354,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25699,6 +26382,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25726,6 +26410,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25788,6 +26473,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25815,6 +26501,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25849,6 +26536,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25876,6 +26564,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25903,6 +26592,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25951,6 +26641,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25978,6 +26669,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -26005,6 +26697,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26032,6 +26725,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26066,6 +26760,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26163,6 +26858,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26190,6 +26886,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26252,6 +26949,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26279,6 +26977,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26306,6 +27005,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26333,6 +27033,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26360,6 +27061,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26387,6 +27089,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26414,6 +27117,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26448,6 +27152,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26475,6 +27180,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26544,6 +27250,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26571,6 +27278,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26668,6 +27376,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26695,6 +27404,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26722,6 +27432,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26749,6 +27460,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26776,6 +27488,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26803,6 +27516,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26858,6 +27572,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26885,6 +27600,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27073,6 +27789,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27100,6 +27817,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27127,6 +27845,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27154,6 +27873,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27188,6 +27908,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27215,6 +27936,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27291,6 +28013,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27318,6 +28041,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27359,6 +28083,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27386,6 +28111,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27427,6 +28153,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27517,6 +28244,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27544,6 +28272,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27571,6 +28300,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27598,6 +28328,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27625,6 +28356,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27652,6 +28384,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27679,6 +28412,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27706,6 +28440,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27733,6 +28468,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27760,6 +28496,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27787,6 +28524,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27814,6 +28552,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27841,6 +28580,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27868,6 +28608,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27972,6 +28713,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -28027,6 +28769,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -28054,6 +28797,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -28081,6 +28825,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28108,6 +28853,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28135,6 +28881,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28162,6 +28909,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28217,6 +28965,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28244,6 +28993,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28271,6 +29021,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28305,6 +29056,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28360,6 +29112,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28387,6 +29140,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28414,6 +29168,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28483,6 +29238,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28510,6 +29266,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28537,6 +29294,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28564,6 +29322,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28591,6 +29350,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28618,6 +29378,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28645,6 +29406,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28672,6 +29434,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28727,6 +29490,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28754,6 +29518,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28781,6 +29546,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28815,6 +29581,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28842,6 +29609,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28876,6 +29644,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28903,6 +29672,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28930,6 +29700,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28957,6 +29728,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -29040,6 +29812,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29067,6 +29840,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29136,6 +29910,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29233,6 +30008,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29260,6 +30036,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29287,6 +30064,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29314,6 +30092,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29383,6 +30162,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29410,6 +30190,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29465,6 +30246,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29492,6 +30274,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29519,6 +30302,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29546,6 +30330,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29587,6 +30372,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29614,6 +30400,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29648,6 +30435,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29675,6 +30463,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29702,6 +30491,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29729,6 +30519,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29756,6 +30547,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29790,6 +30582,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29817,6 +30610,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29844,6 +30638,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29871,6 +30666,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29898,6 +30694,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29925,6 +30722,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29952,6 +30750,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -30049,6 +30848,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -30076,6 +30876,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -30103,6 +30904,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30130,6 +30932,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30157,6 +30960,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30184,6 +30988,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30211,6 +31016,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30238,6 +31044,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30279,6 +31086,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30306,6 +31114,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30333,6 +31142,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30388,6 +31198,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30415,6 +31226,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30442,6 +31254,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30469,6 +31282,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30496,6 +31310,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30523,6 +31338,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30550,6 +31366,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30605,6 +31422,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30632,6 +31450,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30666,6 +31485,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30728,6 +31548,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30755,6 +31576,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30782,6 +31604,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30809,6 +31632,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30836,6 +31660,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30863,6 +31688,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30890,6 +31716,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30917,6 +31744,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30944,6 +31772,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30999,6 +31828,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -31026,6 +31856,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -31053,6 +31884,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31080,6 +31912,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -31107,6 +31940,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31134,6 +31968,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31168,6 +32003,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31195,6 +32031,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31250,6 +32087,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31277,6 +32115,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31304,6 +32143,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31331,6 +32171,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31358,6 +32199,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31385,6 +32227,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31412,6 +32255,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31439,6 +32283,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31564,6 +32409,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31591,6 +32437,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31618,6 +32465,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31645,6 +32493,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31700,6 +32549,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31727,6 +32577,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31782,6 +32633,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31809,6 +32661,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31836,6 +32689,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31891,6 +32745,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31925,6 +32780,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32015,6 +32871,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32042,6 +32899,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -32125,6 +32983,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32166,6 +33025,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32193,6 +33053,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32248,6 +33109,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32275,6 +33137,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32302,6 +33165,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32336,6 +33200,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32363,6 +33228,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32390,6 +33256,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32417,6 +33284,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32444,6 +33312,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32471,6 +33340,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32498,6 +33368,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32525,6 +33396,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32552,6 +33424,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32607,6 +33480,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32634,6 +33508,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32661,6 +33536,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32688,6 +33564,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32715,6 +33592,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32742,6 +33620,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32769,6 +33648,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32824,6 +33704,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32872,6 +33753,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32913,6 +33795,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32940,6 +33823,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32967,6 +33851,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32994,6 +33879,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33084,6 +33970,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33111,6 +33998,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33138,6 +34026,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33172,6 +34061,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33199,6 +34089,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33226,6 +34117,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33267,6 +34159,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33322,6 +34215,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33349,6 +34243,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33446,6 +34341,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33522,6 +34418,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33598,6 +34495,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33688,6 +34586,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33729,6 +34628,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33770,6 +34670,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33825,6 +34726,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33852,6 +34754,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33886,6 +34789,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33913,6 +34817,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33996,6 +34901,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -34023,6 +34929,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -34050,6 +34957,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34077,6 +34985,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34104,6 +35013,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -34131,6 +35041,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34172,6 +35083,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34199,6 +35111,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34268,6 +35181,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34295,6 +35209,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34322,6 +35237,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34349,6 +35265,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34376,6 +35293,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34403,6 +35321,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34437,6 +35356,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34471,6 +35391,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34568,6 +35489,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34595,6 +35517,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34622,6 +35545,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34649,6 +35573,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34676,6 +35601,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34703,6 +35629,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34758,6 +35685,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34785,6 +35713,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34875,6 +35804,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34930,6 +35860,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34957,6 +35888,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34984,6 +35916,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35011,6 +35944,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -35059,6 +35993,7 @@
         {
             "id": "0xe02e8ddecbe302ba1a40107c726e3ee889b0ff10",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
@@ -35093,6 +36028,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35120,6 +36056,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35147,6 +36084,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35279,6 +36217,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35306,6 +36245,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35333,6 +36273,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35360,6 +36301,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35387,6 +36329,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35414,6 +36357,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35441,6 +36385,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35468,6 +36413,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35495,6 +36441,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35522,6 +36469,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35584,6 +36532,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35632,6 +36581,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35659,6 +36609,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35686,6 +36637,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35713,6 +36665,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35740,6 +36693,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35774,6 +36728,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35801,6 +36756,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35828,6 +36784,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35855,6 +36812,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35882,6 +36840,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35930,6 +36889,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35985,6 +36945,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -36012,6 +36973,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -36039,6 +37001,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36073,6 +37036,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -36100,6 +37064,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36169,6 +37134,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36217,6 +37183,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36272,6 +37239,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36313,6 +37281,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36340,6 +37309,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36409,6 +37379,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36436,6 +37407,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36463,6 +37435,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36490,6 +37463,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36594,6 +37568,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36621,6 +37596,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36648,6 +37624,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36745,6 +37722,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36772,6 +37750,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36799,6 +37778,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36826,6 +37806,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36853,6 +37834,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36880,6 +37862,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36907,6 +37890,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36934,6 +37918,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36961,6 +37946,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36988,6 +37974,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -37015,6 +38002,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -37049,6 +38037,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -37076,6 +38065,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -37103,6 +38093,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37158,6 +38149,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37185,6 +38177,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37212,6 +38205,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37267,6 +38261,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37294,6 +38289,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37349,6 +38345,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37376,6 +38373,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37403,6 +38401,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37451,6 +38450,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37478,6 +38478,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37505,6 +38506,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37532,6 +38534,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37573,6 +38576,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37600,6 +38604,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37634,6 +38639,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37661,6 +38667,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37695,6 +38702,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37750,6 +38758,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37777,6 +38786,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37804,6 +38814,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37852,6 +38863,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37886,6 +38898,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37948,6 +38961,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37975,6 +38989,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -38002,6 +39017,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38050,6 +39066,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -38077,6 +39094,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38104,6 +39122,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -38152,6 +39171,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38179,6 +39199,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38290,6 +39311,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38345,6 +39367,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38372,6 +39395,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38420,6 +39444,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38447,6 +39472,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38516,6 +39542,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38543,6 +39570,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38598,6 +39626,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38625,6 +39654,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38652,6 +39682,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38679,6 +39710,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38706,6 +39738,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38733,6 +39766,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38795,6 +39829,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38822,6 +39857,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38870,6 +39906,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38897,6 +39934,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38924,6 +39962,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38951,6 +39990,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -39006,6 +40046,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39033,6 +40074,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -39060,6 +40102,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -39087,6 +40130,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -39156,6 +40200,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39183,6 +40228,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39210,6 +40256,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39286,6 +40333,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39313,6 +40361,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39347,6 +40396,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39381,6 +40431,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39415,6 +40466,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39442,6 +40494,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39469,6 +40522,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39496,6 +40550,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39530,6 +40585,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39557,6 +40613,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39584,6 +40641,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39611,6 +40669,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39645,6 +40704,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39679,6 +40739,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39706,6 +40767,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39733,6 +40795,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39844,6 +40907,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39871,6 +40935,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39898,6 +40963,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39925,6 +40991,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39980,6 +41047,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -40007,6 +41075,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40041,6 +41110,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40068,6 +41138,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -40165,6 +41236,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40192,6 +41264,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40219,6 +41292,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40246,6 +41320,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40315,6 +41390,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x2f455a0e72ad4a2f6be9a5969a2e646ec8c1c2f4cc19adfffa53ba5ba468f02e.json
+++ b/test/testData/testPools/0x2f455a0e72ad4a2f6be9a5969a2e646ec8c1c2f4cc19adfffa53ba5ba468f02e.json
@@ -990,6 +990,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1017,6 +1018,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1288,6 +1290,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -1458,6 +1461,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -1485,6 +1489,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -1696,6 +1701,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2057,6 +2063,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2261,6 +2268,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2695,6 +2703,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2790,6 +2799,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2824,6 +2834,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2900,6 +2911,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3002,6 +3014,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3275,6 +3288,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -3302,6 +3316,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3363,6 +3378,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3505,6 +3521,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3871,6 +3888,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -4231,6 +4249,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4916,6 +4935,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -5086,6 +5106,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5188,6 +5209,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5269,6 +5291,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5608,6 +5631,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5826,6 +5850,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5895,6 +5920,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5949,6 +5975,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6118,6 +6145,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6199,6 +6227,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6335,6 +6364,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6504,6 +6534,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6755,6 +6786,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -7224,6 +7256,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7769,6 +7802,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7850,6 +7884,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8026,6 +8061,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8189,6 +8225,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8324,6 +8361,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8447,6 +8485,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8488,6 +8527,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8657,6 +8697,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -9030,6 +9071,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9343,6 +9385,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9493,6 +9536,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9758,6 +9802,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10043,6 +10088,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10138,6 +10184,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11231,6 +11278,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11360,6 +11408,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11468,6 +11517,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11549,6 +11599,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11822,6 +11873,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11849,6 +11901,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12510,6 +12563,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12848,6 +12902,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13133,6 +13188,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13377,6 +13433,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13588,6 +13645,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13615,6 +13673,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13663,6 +13722,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13731,6 +13791,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14051,6 +14112,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14222,6 +14284,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14290,6 +14353,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14351,6 +14415,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14392,6 +14457,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14488,6 +14554,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14867,6 +14934,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15037,6 +15105,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15064,6 +15133,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15133,6 +15203,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15390,6 +15461,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15540,6 +15612,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15648,6 +15721,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15729,6 +15803,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15925,6 +16000,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16224,6 +16300,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16293,6 +16370,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16692,6 +16770,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17323,6 +17402,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17513,6 +17593,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17750,6 +17831,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17819,6 +17901,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18022,6 +18105,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18307,6 +18391,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18708,6 +18793,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18891,6 +18977,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18945,6 +19032,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19149,6 +19237,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19991,6 +20080,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20072,6 +20162,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20099,6 +20190,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20187,6 +20279,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20437,6 +20530,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21074,6 +21168,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21687,6 +21782,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22185,6 +22281,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22584,6 +22681,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23133,6 +23231,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -23160,6 +23259,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -23201,6 +23301,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -23371,6 +23472,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23982,6 +24084,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24118,6 +24221,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -24274,6 +24378,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24687,6 +24792,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24795,6 +24901,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25446,6 +25553,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25487,6 +25595,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26120,6 +26229,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26581,6 +26691,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26927,6 +27038,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26954,6 +27066,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +27571,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27647,6 +27761,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27728,6 +27843,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27790,6 +27906,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27859,6 +27976,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -28055,6 +28173,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28266,6 +28385,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -28293,6 +28413,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28705,6 +28826,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28732,6 +28854,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28807,6 +28930,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28996,6 +29120,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -29138,6 +29263,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29504,6 +29630,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29788,6 +29915,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30008,6 +30136,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30157,6 +30286,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30753,6 +30883,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31133,6 +31264,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31349,6 +31481,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31993,6 +32126,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32250,6 +32384,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32305,6 +32440,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32440,6 +32576,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32747,6 +32884,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32842,6 +32980,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32985,6 +33124,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33343,6 +33483,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33559,6 +33700,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33818,6 +33960,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -34055,6 +34198,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34136,6 +34280,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34232,6 +34377,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34307,6 +34453,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34382,6 +34529,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34409,6 +34557,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34552,6 +34701,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34694,6 +34844,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34721,6 +34872,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35250,6 +35402,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35570,6 +35723,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35597,6 +35751,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35651,6 +35806,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35888,6 +36044,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35915,6 +36072,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35963,6 +36121,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36668,6 +36827,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37227,6 +37387,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37254,6 +37415,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37383,6 +37545,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37837,6 +38000,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38428,6 +38592,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38618,6 +38783,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38910,6 +39076,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38951,6 +39118,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39019,6 +39187,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39189,6 +39358,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39270,6 +39440,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39466,6 +39637,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39676,6 +39848,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39934,6 +40107,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40470,6 +40644,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40647,6 +40822,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40789,6 +40965,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x319c2887b117c9a555cb1f3c8b82f135cb9a576222934a3c23eedb4fb8f2d8bb.json
+++ b/test/testData/testPools/0x319c2887b117c9a555cb1f3c8b82f135cb9a576222934a3c23eedb4fb8f2d8bb.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x322749d6fee92b32d01f43d9d9e7cba98a3423194bc4d0e8cc1d724540f20aa2.json
+++ b/test/testData/testPools/0x322749d6fee92b32d01f43d9d9e7cba98a3423194bc4d0e8cc1d724540f20aa2.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x32286e13c9dbfe92f4d9527bfe2ff18edf10dedb55e08b11710bf84cebf4de6d.json
+++ b/test/testData/testPools/0x32286e13c9dbfe92f4d9527bfe2ff18edf10dedb55e08b11710bf84cebf4de6d.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x32c912f8f82952f631c39be6c69bd72a1da978d8d0704a7d32b8310431375bfa.json
+++ b/test/testData/testPools/0x32c912f8f82952f631c39be6c69bd72a1da978d8d0704a7d32b8310431375bfa.json
@@ -13,6 +13,7 @@
         {
             "id": "0x6c3f90f043a72fa612cbac8115ee7e52bde6e490",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "600",
             "tokens": [
                 {
@@ -48,6 +49,7 @@
         {
             "id": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "500",
             "tokens": [
                 {
@@ -90,6 +92,7 @@
         {
             "id": "0x845838df265dcd2c412a1dc9e959c7d08537f8a2",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "450",
             "tokens": [
                 {
@@ -118,6 +121,7 @@
         {
             "id": "0xd2967f45c4f384deea880f807be904762a3dea07",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -146,6 +150,7 @@
         {
             "id": "0xb19059ebb43466c323583928285a49f558e572fd",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "300",
             "tokens": [
                 {
@@ -174,6 +179,7 @@
         {
             "id": "0x5b5cfe992adac0c9d48e05854b2d91c73a003858",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -202,6 +208,7 @@
         {
             "id": "0x6d65b498cb23deaba52db31c93da9bffb340fb8f",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "5",
             "tokens": [
                 {
@@ -230,6 +237,7 @@
         {
             "id": "0x1aef73d49dedc4b1778d0706583995958dc862e6",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -258,6 +266,7 @@
         {
             "id": "0xd905e2eaebe188fc92179b6350807d8bd91db0d8",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -300,6 +309,7 @@
         {
             "id": "0x49849c98ae39fff122806c06791fa73784fb3675",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -328,6 +338,7 @@
         {
             "id": "0xc2ee6b0334c261ed60c72f6054450b61b8f18e35",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -356,6 +367,7 @@
         {
             "id": "0x075b1bb99792c9e1041ba13afef80c91a1e70fb3",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -391,6 +403,7 @@
         {
             "id": "0xc25a3a3b969415c80451098fa907ec722572917f",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -433,6 +446,7 @@
         {
             "id": "0x64eda51d3ad40d56b9dfc5554e06f94e1dd786fd",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "150",
             "tokens": [
                 {
@@ -461,6 +475,7 @@
         {
             "id": "0x97e2768e8e73511ca874545dc5ff8067eb19b787",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -489,6 +504,7 @@
         {
             "id": "0x4f3e8f405cf5afc05d68142f3783bdfe13811522",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "50",
             "tokens": [
                 {
@@ -517,6 +533,7 @@
         {
             "id": "0x9fc689ccada600b6df723d9e47d84d76664a1f23",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "2000",
             "tokens": [
                 {
@@ -552,6 +569,7 @@
         {
             "id": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "1000",
             "tokens": [
                 {
@@ -594,6 +612,7 @@
         {
             "id": "0x3a664ab939fd8482048609f652f9a0b0677337b9",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -622,6 +641,7 @@
         {
             "id": "0x410e3e86ef427e30b9235497143881f717d93c2a",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -650,6 +670,7 @@
         {
             "id": "0x2fe94ea3d5d4a175184081439753de15aef9d614",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -678,6 +699,7 @@
         {
             "id": "0xde5331ac4b3630f94853ff322b66407e0d6331e8",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -706,6 +728,7 @@
         {
             "id": "0x94e131324b6054c0d789b190b2dac504e4361b53",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -734,6 +757,7 @@
         {
             "id": "0x194ebd173f6cdace046c53eacce9b953f28411d1",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -762,6 +786,7 @@
         {
             "id": "0xa3d87fffce63b53e0d54faa1cc983b7eb0b74a9c",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -790,6 +815,7 @@
         {
             "id": "0x06325440d014e39736583c165c2963ba99faf14e",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "10",
             "tokens": [
                 {
@@ -818,6 +844,7 @@
         {
             "id": "0xaa17a236f2badc98ddc0cf999abb47d47fc0a6cf",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "10",
             "tokens": [
                 {
@@ -846,6 +873,7 @@
         {
             "id": "0x5282a4ef67d9c33135340fb3289cc1711c13638c",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "600",
             "tokens": [
                 {
@@ -881,6 +909,7 @@
         {
             "id": "0xcee60cfa923170e4f8204ae08b4fa6a3f5656f3a",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -909,6 +938,7 @@
         {
             "id": "0x7eb40e450b9655f4b3cc4259bcc731c63ff55ae6",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {

--- a/test/testData/testPools/0x3571f6490274bfdfea808e0b13c9ddae3f344fc361b6f46166b524665e287aac.json
+++ b/test/testData/testPools/0x3571f6490274bfdfea808e0b13c9ddae3f344fc361b6f46166b524665e287aac.json
@@ -2057,6 +2057,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3363,6 +3364,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6755,6 +6757,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -9030,6 +9033,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9343,6 +9347,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -15540,6 +15545,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -21074,6 +21080,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -34382,6 +34389,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",

--- a/test/testData/testPools/0x362e00b25d6105d89d164b10a685178c87b52137152adc941d96a90f0ff9157e.json
+++ b/test/testData/testPools/0x362e00b25d6105d89d164b10a685178c87b52137152adc941d96a90f0ff9157e.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x38b0898f94ce7cb0621adc763d1cfc73cd91545842c2a587b6a7828be498dc5d.json
+++ b/test/testData/testPools/0x38b0898f94ce7cb0621adc763d1cfc73cd91545842c2a587b6a7828be498dc5d.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x39fbeeaacdffc7186135ad169c0bbdbdddb42901a3c12cac2081af603f52ccda.json
+++ b/test/testData/testPools/0x39fbeeaacdffc7186135ad169c0bbdbdddb42901a3c12cac2081af603f52ccda.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x39fbeeaacdffc7186135ad169c0bbdbdddb42901a3c12cac2081af603f52ccda.json
+++ b/test/testData/testPools/0x39fbeeaacdffc7186135ad169c0bbdbdddb42901a3c12cac2081af603f52ccda.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -171,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -198,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -232,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -259,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -286,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -313,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -340,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -367,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -422,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -470,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -511,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -538,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -621,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -648,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -696,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -723,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -750,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -854,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -881,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -908,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -935,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -962,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1003,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1030,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1071,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1098,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1237,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1264,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1291,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1318,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1345,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1400,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1427,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1475,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1502,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1550,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1577,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1604,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1631,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1672,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1699,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1726,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1753,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1780,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1835,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1876,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1987,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2063,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2181,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2229,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2256,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2283,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2338,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2365,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2455,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2510,6 +2568,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2544,6 +2603,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2571,6 +2631,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2598,6 +2659,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2674,6 +2736,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2701,6 +2764,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2735,6 +2799,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2762,6 +2827,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2789,6 +2855,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2816,6 +2883,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2843,6 +2911,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2877,6 +2946,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2904,6 +2974,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2931,6 +3002,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2958,6 +3030,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3062,6 +3135,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3096,6 +3170,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3123,6 +3198,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3150,6 +3226,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3177,6 +3254,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3218,6 +3296,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3245,6 +3324,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3272,6 +3352,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3299,6 +3380,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3326,6 +3408,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3395,6 +3478,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3443,6 +3527,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3470,6 +3555,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3497,6 +3583,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3524,6 +3611,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3551,6 +3639,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3620,6 +3709,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3647,6 +3737,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3674,6 +3765,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3701,6 +3793,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3728,6 +3821,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3755,6 +3849,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3782,6 +3877,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3809,6 +3905,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3843,6 +3940,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3870,6 +3968,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3897,6 +3996,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3924,6 +4024,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3958,6 +4059,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3985,6 +4087,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4012,6 +4115,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4067,6 +4171,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4108,6 +4213,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4135,6 +4241,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4183,6 +4290,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4259,6 +4367,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4286,6 +4395,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4341,6 +4451,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4368,6 +4479,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4451,6 +4563,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4492,6 +4605,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4519,6 +4633,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4546,6 +4661,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4573,6 +4689,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4600,6 +4717,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4627,6 +4745,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4654,6 +4773,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4681,6 +4801,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4708,6 +4829,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4763,6 +4885,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4832,6 +4955,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4859,6 +4983,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4886,6 +5011,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4913,6 +5039,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5052,6 +5179,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5107,6 +5235,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5141,6 +5270,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5168,6 +5298,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5195,6 +5326,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5222,6 +5354,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5277,6 +5410,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5304,6 +5438,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5359,6 +5494,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5386,6 +5522,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5441,6 +5578,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5503,6 +5641,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5530,6 +5669,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5557,6 +5697,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5584,6 +5725,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5611,6 +5753,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5666,6 +5809,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5700,6 +5844,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5727,6 +5872,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5754,6 +5900,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5809,6 +5956,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5836,6 +5984,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5863,6 +6012,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5918,6 +6068,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5945,6 +6096,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5972,6 +6124,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5999,6 +6152,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6026,6 +6180,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6053,6 +6208,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6101,6 +6257,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6128,6 +6285,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6169,6 +6327,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6217,6 +6376,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6244,6 +6404,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6271,6 +6432,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6326,6 +6488,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6402,6 +6565,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6471,6 +6635,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6498,6 +6663,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6532,6 +6698,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6559,6 +6726,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6586,6 +6754,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6613,6 +6782,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6640,6 +6810,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6667,6 +6838,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6694,6 +6866,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6721,6 +6894,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6783,6 +6957,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6852,6 +7027,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6879,6 +7055,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6934,6 +7111,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6961,6 +7139,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7023,6 +7202,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7050,6 +7230,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7077,6 +7258,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7104,6 +7286,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7138,6 +7321,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7193,6 +7377,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7220,6 +7405,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7275,6 +7461,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7302,6 +7489,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7357,6 +7545,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7384,6 +7573,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7411,6 +7601,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7438,6 +7629,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7493,6 +7685,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7520,6 +7713,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7659,6 +7853,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7686,6 +7881,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7713,6 +7909,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7740,6 +7937,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7767,6 +7965,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7829,6 +8028,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7863,6 +8063,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7890,6 +8091,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7917,6 +8119,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7965,6 +8168,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7992,6 +8196,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8019,6 +8224,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8046,6 +8252,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8073,6 +8280,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8100,6 +8308,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8127,6 +8336,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8203,6 +8413,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8230,6 +8441,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8264,6 +8476,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8291,6 +8504,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8318,6 +8532,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8359,6 +8574,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8386,6 +8602,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8420,6 +8637,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8517,6 +8735,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8544,6 +8763,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8571,6 +8791,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8668,6 +8889,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8695,6 +8917,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8722,6 +8945,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8756,6 +8980,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8783,6 +9008,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8831,6 +9057,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8879,6 +9106,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8934,6 +9162,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8961,6 +9190,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8988,6 +9218,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9015,6 +9246,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9042,6 +9274,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9111,6 +9344,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9138,6 +9372,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9165,6 +9400,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9220,6 +9456,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9261,6 +9498,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9358,6 +9596,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9406,6 +9645,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9433,6 +9673,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9502,6 +9743,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9550,6 +9792,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9577,6 +9820,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9604,6 +9848,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9631,6 +9876,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9658,6 +9904,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9685,6 +9932,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9712,6 +9960,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9739,6 +9988,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9766,6 +10016,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9793,6 +10044,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9820,6 +10072,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9847,6 +10100,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9874,6 +10128,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9901,6 +10156,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9928,6 +10184,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9955,6 +10212,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9982,6 +10240,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10009,6 +10268,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10050,6 +10310,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10077,6 +10338,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10104,6 +10366,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10159,6 +10422,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10186,6 +10450,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10213,6 +10478,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10247,6 +10513,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10274,6 +10541,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10301,6 +10569,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10328,6 +10597,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10355,6 +10625,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10410,6 +10681,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10437,6 +10709,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10485,6 +10758,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10540,6 +10814,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10567,6 +10842,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10594,6 +10870,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10649,6 +10926,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10676,6 +10954,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10766,6 +11045,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10793,6 +11073,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10820,6 +11101,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10847,6 +11129,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10916,6 +11199,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10950,6 +11234,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11033,6 +11318,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11060,6 +11346,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11108,6 +11395,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11135,6 +11423,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11183,6 +11472,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11210,6 +11500,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11237,6 +11528,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11299,6 +11591,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11340,6 +11633,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11367,6 +11661,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11394,6 +11689,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11421,6 +11717,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11448,6 +11745,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11517,6 +11815,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11544,6 +11843,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11571,6 +11871,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11633,6 +11934,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11667,6 +11969,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11694,6 +11997,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11721,6 +12025,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11748,6 +12053,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11775,6 +12081,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11802,6 +12109,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11829,6 +12137,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11856,6 +12165,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11883,6 +12193,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11910,6 +12221,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11965,6 +12277,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -11992,6 +12305,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12019,6 +12333,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12046,6 +12361,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12108,6 +12424,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12142,6 +12459,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12169,6 +12487,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12196,6 +12515,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12251,6 +12571,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12306,6 +12627,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12333,6 +12655,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12360,6 +12683,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12387,6 +12711,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12414,6 +12739,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12441,6 +12767,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12496,6 +12823,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12565,6 +12893,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12592,6 +12921,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12619,6 +12949,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12653,6 +12984,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12785,6 +13117,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12882,6 +13215,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12916,6 +13250,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12985,6 +13320,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13012,6 +13348,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13039,6 +13376,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13066,6 +13404,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13093,6 +13432,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13120,6 +13460,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13175,6 +13516,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13202,6 +13544,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13250,6 +13593,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13347,6 +13691,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13416,6 +13761,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13562,6 +13908,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13617,6 +13964,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13644,6 +13992,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13671,6 +14020,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13726,6 +14076,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13753,6 +14104,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13780,6 +14132,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13807,6 +14160,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13834,6 +14188,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13861,6 +14216,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13888,6 +14244,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13915,6 +14272,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13942,6 +14300,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -14032,6 +14391,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14059,6 +14419,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14086,6 +14447,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14113,6 +14475,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14266,6 +14629,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14293,6 +14657,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14320,6 +14685,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14347,6 +14713,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14388,6 +14755,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14415,6 +14783,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14442,6 +14811,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14469,6 +14839,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14524,6 +14895,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14551,6 +14923,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14578,6 +14951,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14675,6 +15049,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14702,6 +15077,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14729,6 +15105,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14784,6 +15161,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14811,6 +15189,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14873,6 +15252,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14900,6 +15280,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14927,6 +15308,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14954,6 +15336,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14981,6 +15364,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15008,6 +15392,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15063,6 +15448,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15132,6 +15518,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15159,6 +15546,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15186,6 +15574,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15213,6 +15602,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15240,6 +15630,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15267,6 +15658,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15294,6 +15686,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15433,6 +15826,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15460,6 +15854,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15487,6 +15882,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15514,6 +15910,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15541,6 +15938,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15582,6 +15980,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15609,6 +16008,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15636,6 +16036,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15663,6 +16064,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15690,6 +16092,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15724,6 +16127,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15751,6 +16155,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15778,6 +16183,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15875,6 +16281,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15902,6 +16309,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15929,6 +16337,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15956,6 +16365,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15983,6 +16393,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16010,6 +16421,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16037,6 +16449,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16064,6 +16477,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16091,6 +16505,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16118,6 +16533,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16145,6 +16561,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16186,6 +16603,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16213,6 +16631,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16240,6 +16659,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16302,6 +16722,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16329,6 +16750,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16356,6 +16778,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16383,6 +16806,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16410,6 +16834,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16465,6 +16890,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16492,6 +16918,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16519,6 +16946,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16546,6 +16974,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16573,6 +17002,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16663,6 +17093,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16690,6 +17121,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16717,6 +17149,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16744,6 +17177,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16771,6 +17205,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16798,6 +17233,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16825,6 +17261,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16971,6 +17408,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16998,6 +17436,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17025,6 +17464,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17052,6 +17492,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17079,6 +17520,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17113,6 +17555,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17168,6 +17611,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17237,6 +17681,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17264,6 +17709,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17291,6 +17737,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17318,6 +17765,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17345,6 +17793,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17372,6 +17821,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17399,6 +17849,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17489,6 +17940,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17516,6 +17968,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17543,6 +17996,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17570,6 +18024,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17597,6 +18052,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17645,6 +18101,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17686,6 +18143,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17713,6 +18171,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17740,6 +18199,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17774,6 +18234,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17801,6 +18262,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17870,6 +18332,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17897,6 +18360,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17931,6 +18395,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17958,6 +18423,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17985,6 +18451,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18040,6 +18507,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18095,6 +18563,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18164,6 +18633,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18191,6 +18661,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18218,6 +18689,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18245,6 +18717,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18300,6 +18773,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18369,6 +18843,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18396,6 +18871,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18465,6 +18941,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18492,6 +18969,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18519,6 +18997,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18546,6 +19025,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18573,6 +19053,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18600,6 +19081,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18627,6 +19109,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18661,6 +19144,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18695,6 +19179,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18722,6 +19207,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18749,6 +19235,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18804,6 +19291,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18831,6 +19319,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18858,6 +19347,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18885,6 +19375,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18919,6 +19410,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18946,6 +19438,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18973,6 +19466,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19000,6 +19494,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19027,6 +19522,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19061,6 +19557,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19088,6 +19585,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19143,6 +19641,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19170,6 +19669,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19253,6 +19753,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19287,6 +19788,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19342,6 +19844,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19369,6 +19872,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19396,6 +19900,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19423,6 +19928,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19457,6 +19963,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19491,6 +19998,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19518,6 +20026,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19545,6 +20054,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19572,6 +20082,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19627,6 +20138,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19654,6 +20166,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19681,6 +20194,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19729,6 +20243,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19756,6 +20271,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19783,6 +20299,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19810,6 +20327,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19837,6 +20355,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19864,6 +20383,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19891,6 +20411,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19918,6 +20439,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19945,6 +20467,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -20014,6 +20537,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20041,6 +20565,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20068,6 +20593,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20095,6 +20621,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20129,6 +20656,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20156,6 +20684,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20183,6 +20712,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20210,6 +20740,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20279,6 +20810,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20306,6 +20838,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20347,6 +20880,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20374,6 +20908,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20443,6 +20978,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20505,6 +21041,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20532,6 +21069,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20601,6 +21139,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20628,6 +21167,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20655,6 +21195,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20682,6 +21223,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20709,6 +21251,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20736,6 +21279,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20763,6 +21307,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20790,6 +21335,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20824,6 +21370,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20914,6 +21461,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20941,6 +21489,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20968,6 +21517,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -21002,6 +21552,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21036,6 +21587,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21077,6 +21629,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21132,6 +21685,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21159,6 +21713,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21186,6 +21741,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21255,6 +21811,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21282,6 +21839,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21323,6 +21881,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21378,6 +21937,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21405,6 +21965,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21432,6 +21993,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21466,6 +22028,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21493,6 +22056,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21520,6 +22084,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21547,6 +22112,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21574,6 +22140,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21601,6 +22168,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21642,6 +22210,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21669,6 +22238,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21696,6 +22266,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21723,6 +22294,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21799,6 +22371,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21826,6 +22399,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21853,6 +22427,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21880,6 +22455,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21907,6 +22483,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21934,6 +22511,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21982,6 +22560,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22016,6 +22595,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22043,6 +22623,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22070,6 +22651,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22097,6 +22679,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22124,6 +22707,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22151,6 +22735,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22178,6 +22763,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22219,6 +22805,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22246,6 +22833,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22273,6 +22861,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22412,6 +23001,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22453,6 +23043,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22480,6 +23071,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22514,6 +23106,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22569,6 +23162,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22596,6 +23190,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22623,6 +23218,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22671,6 +23267,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22712,6 +23309,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22739,6 +23337,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22766,6 +23365,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22835,6 +23435,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22869,6 +23470,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22896,6 +23498,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22930,6 +23533,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22964,6 +23568,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22991,6 +23596,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -23018,6 +23624,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23045,6 +23652,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23072,6 +23680,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23099,6 +23708,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23126,6 +23736,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23181,6 +23792,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23208,6 +23820,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23263,6 +23876,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23325,6 +23939,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23352,6 +23967,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23379,6 +23995,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23420,6 +24037,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23475,6 +24093,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23502,6 +24121,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23529,6 +24149,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23556,6 +24177,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23590,6 +24212,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23617,6 +24240,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23651,6 +24275,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23678,6 +24303,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23726,6 +24352,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23753,6 +24380,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23780,6 +24408,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23807,6 +24436,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23834,6 +24464,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23889,6 +24520,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23916,6 +24548,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23943,6 +24576,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23998,6 +24632,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -24025,6 +24660,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24073,6 +24709,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24121,6 +24758,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24148,6 +24786,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24175,6 +24814,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24202,6 +24842,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24229,6 +24870,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24256,6 +24898,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24283,6 +24926,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24310,6 +24954,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24337,6 +24982,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24364,6 +25010,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24391,6 +25038,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24418,6 +25066,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24445,6 +25094,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24479,6 +25129,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24541,6 +25192,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24568,6 +25220,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24595,6 +25248,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24734,6 +25388,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24803,6 +25458,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24830,6 +25486,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24857,6 +25514,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24926,6 +25584,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24953,6 +25612,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24980,6 +25640,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -25007,6 +25668,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -25041,6 +25703,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25082,6 +25745,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25109,6 +25773,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25136,6 +25801,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25163,6 +25829,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25190,6 +25857,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25217,6 +25885,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25244,6 +25913,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25271,6 +25941,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25340,6 +26011,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25367,6 +26039,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25394,6 +26067,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25428,6 +26102,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25455,6 +26130,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25503,6 +26179,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25537,6 +26214,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25564,6 +26242,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25591,6 +26270,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25618,6 +26298,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25645,6 +26326,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25672,6 +26354,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25699,6 +26382,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25726,6 +26410,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25788,6 +26473,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25815,6 +26501,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25849,6 +26536,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25876,6 +26564,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25903,6 +26592,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25951,6 +26641,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25978,6 +26669,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -26005,6 +26697,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26032,6 +26725,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26066,6 +26760,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26163,6 +26858,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26190,6 +26886,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26252,6 +26949,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26279,6 +26977,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26306,6 +27005,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26333,6 +27033,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26360,6 +27061,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26387,6 +27089,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26414,6 +27117,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26448,6 +27152,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26475,6 +27180,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26544,6 +27250,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26571,6 +27278,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26668,6 +27376,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26695,6 +27404,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26722,6 +27432,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26749,6 +27460,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26776,6 +27488,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26803,6 +27516,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26858,6 +27572,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26885,6 +27600,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27073,6 +27789,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27100,6 +27817,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27127,6 +27845,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27154,6 +27873,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27188,6 +27908,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27215,6 +27936,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27291,6 +28013,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27318,6 +28041,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27359,6 +28083,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27386,6 +28111,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27427,6 +28153,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27517,6 +28244,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27544,6 +28272,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27571,6 +28300,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27598,6 +28328,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27625,6 +28356,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27652,6 +28384,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27679,6 +28412,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27706,6 +28440,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27733,6 +28468,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27760,6 +28496,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27787,6 +28524,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27814,6 +28552,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27841,6 +28580,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27868,6 +28608,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27972,6 +28713,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -28027,6 +28769,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -28054,6 +28797,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -28081,6 +28825,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28108,6 +28853,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28135,6 +28881,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28162,6 +28909,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28217,6 +28965,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28244,6 +28993,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28271,6 +29021,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28305,6 +29056,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28360,6 +29112,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28387,6 +29140,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28414,6 +29168,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28483,6 +29238,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28510,6 +29266,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28537,6 +29294,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28564,6 +29322,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28591,6 +29350,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28618,6 +29378,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28645,6 +29406,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28672,6 +29434,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28727,6 +29490,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28754,6 +29518,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28781,6 +29546,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28815,6 +29581,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28842,6 +29609,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28876,6 +29644,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28903,6 +29672,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28930,6 +29700,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28957,6 +29728,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -29040,6 +29812,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29067,6 +29840,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29136,6 +29910,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29233,6 +30008,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29260,6 +30036,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29287,6 +30064,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29314,6 +30092,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29383,6 +30162,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29410,6 +30190,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29465,6 +30246,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29492,6 +30274,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29519,6 +30302,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29546,6 +30330,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29587,6 +30372,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29614,6 +30400,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29648,6 +30435,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29675,6 +30463,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29702,6 +30491,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29729,6 +30519,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29756,6 +30547,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29790,6 +30582,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29817,6 +30610,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29844,6 +30638,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29871,6 +30666,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29898,6 +30694,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29925,6 +30722,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29952,6 +30750,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -30049,6 +30848,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -30076,6 +30876,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -30103,6 +30904,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30130,6 +30932,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30157,6 +30960,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30184,6 +30988,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30211,6 +31016,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30238,6 +31044,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30279,6 +31086,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30306,6 +31114,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30333,6 +31142,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30388,6 +31198,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30415,6 +31226,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30442,6 +31254,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30469,6 +31282,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30496,6 +31310,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30523,6 +31338,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30550,6 +31366,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30605,6 +31422,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30632,6 +31450,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30666,6 +31485,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30728,6 +31548,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30755,6 +31576,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30782,6 +31604,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30809,6 +31632,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30836,6 +31660,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30863,6 +31688,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30890,6 +31716,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30917,6 +31744,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30944,6 +31772,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30999,6 +31828,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -31026,6 +31856,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -31053,6 +31884,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31080,6 +31912,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -31107,6 +31940,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31134,6 +31968,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31168,6 +32003,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31195,6 +32031,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31250,6 +32087,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31277,6 +32115,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31304,6 +32143,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31331,6 +32171,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31358,6 +32199,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31385,6 +32227,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31412,6 +32255,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31439,6 +32283,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31564,6 +32409,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31591,6 +32437,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31618,6 +32465,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31645,6 +32493,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31700,6 +32549,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31727,6 +32577,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31782,6 +32633,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31809,6 +32661,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31836,6 +32689,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31891,6 +32745,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31925,6 +32780,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32015,6 +32871,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32042,6 +32899,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -32125,6 +32983,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32166,6 +33025,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32193,6 +33053,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32248,6 +33109,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32275,6 +33137,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32302,6 +33165,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32336,6 +33200,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32363,6 +33228,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32390,6 +33256,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32417,6 +33284,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32444,6 +33312,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32471,6 +33340,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32498,6 +33368,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32525,6 +33396,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32552,6 +33424,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32607,6 +33480,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32634,6 +33508,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32661,6 +33536,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32688,6 +33564,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32715,6 +33592,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32742,6 +33620,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32769,6 +33648,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32824,6 +33704,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32872,6 +33753,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32913,6 +33795,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32940,6 +33823,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32967,6 +33851,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32994,6 +33879,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33084,6 +33970,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33111,6 +33998,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33138,6 +34026,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33172,6 +34061,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33199,6 +34089,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33226,6 +34117,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33267,6 +34159,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33322,6 +34215,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33349,6 +34243,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33446,6 +34341,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33522,6 +34418,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33598,6 +34495,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33688,6 +34586,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33729,6 +34628,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33770,6 +34670,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33825,6 +34726,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33852,6 +34754,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33886,6 +34789,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33913,6 +34817,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33996,6 +34901,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -34023,6 +34929,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -34050,6 +34957,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34077,6 +34985,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34104,6 +35013,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -34131,6 +35041,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34172,6 +35083,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34199,6 +35111,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34268,6 +35181,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34295,6 +35209,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34322,6 +35237,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34349,6 +35265,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34376,6 +35293,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34403,6 +35321,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34437,6 +35356,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34471,6 +35391,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34568,6 +35489,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34595,6 +35517,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34622,6 +35545,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34649,6 +35573,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34676,6 +35601,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34703,6 +35629,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34758,6 +35685,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34785,6 +35713,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34875,6 +35804,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34930,6 +35860,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34957,6 +35888,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34984,6 +35916,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35011,6 +35944,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -35059,6 +35993,7 @@
         {
             "id": "0xe02e8ddecbe302ba1a40107c726e3ee889b0ff10",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
@@ -35093,6 +36028,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35120,6 +36056,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35147,6 +36084,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35279,6 +36217,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35306,6 +36245,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35333,6 +36273,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35360,6 +36301,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35387,6 +36329,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35414,6 +36357,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35441,6 +36385,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35468,6 +36413,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35495,6 +36441,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35522,6 +36469,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35584,6 +36532,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35632,6 +36581,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35659,6 +36609,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35686,6 +36637,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35713,6 +36665,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35740,6 +36693,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35774,6 +36728,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35801,6 +36756,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35828,6 +36784,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35855,6 +36812,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35882,6 +36840,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35930,6 +36889,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35985,6 +36945,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -36012,6 +36973,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -36039,6 +37001,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36073,6 +37036,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -36100,6 +37064,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36169,6 +37134,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36217,6 +37183,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36272,6 +37239,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36313,6 +37281,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36340,6 +37309,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36409,6 +37379,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36436,6 +37407,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36463,6 +37435,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36490,6 +37463,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36594,6 +37568,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36621,6 +37596,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36648,6 +37624,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36745,6 +37722,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36772,6 +37750,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36799,6 +37778,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36826,6 +37806,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36853,6 +37834,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36880,6 +37862,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36907,6 +37890,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36934,6 +37918,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36961,6 +37946,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36988,6 +37974,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -37015,6 +38002,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -37049,6 +38037,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -37076,6 +38065,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -37103,6 +38093,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37158,6 +38149,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37185,6 +38177,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37212,6 +38205,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37267,6 +38261,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37294,6 +38289,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37349,6 +38345,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37376,6 +38373,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37403,6 +38401,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37451,6 +38450,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37478,6 +38478,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37505,6 +38506,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37532,6 +38534,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37573,6 +38576,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37600,6 +38604,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37634,6 +38639,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37661,6 +38667,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37695,6 +38702,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37750,6 +38758,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37777,6 +38786,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37804,6 +38814,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37852,6 +38863,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37886,6 +38898,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37948,6 +38961,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37975,6 +38989,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -38002,6 +39017,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38050,6 +39066,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -38077,6 +39094,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38104,6 +39122,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -38152,6 +39171,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38179,6 +39199,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38290,6 +39311,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38345,6 +39367,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38372,6 +39395,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38420,6 +39444,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38447,6 +39472,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38516,6 +39542,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38543,6 +39570,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38598,6 +39626,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38625,6 +39654,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38652,6 +39682,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38679,6 +39710,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38706,6 +39738,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38733,6 +39766,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38795,6 +39829,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38822,6 +39857,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38870,6 +39906,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38897,6 +39934,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38924,6 +39962,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38951,6 +39990,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -39006,6 +40046,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39033,6 +40074,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -39060,6 +40102,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -39087,6 +40130,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -39156,6 +40200,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39183,6 +40228,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39210,6 +40256,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39286,6 +40333,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39313,6 +40361,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39347,6 +40396,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39381,6 +40431,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39415,6 +40466,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39442,6 +40494,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39469,6 +40522,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39496,6 +40550,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39530,6 +40585,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39557,6 +40613,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39584,6 +40641,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39611,6 +40669,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39645,6 +40704,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39679,6 +40739,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39706,6 +40767,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39733,6 +40795,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39844,6 +40907,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39871,6 +40935,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39898,6 +40963,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39925,6 +40991,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39980,6 +41047,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -40007,6 +41075,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40041,6 +41110,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40068,6 +41138,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -40165,6 +41236,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40192,6 +41264,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40219,6 +41292,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40246,6 +41320,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40315,6 +41390,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x3b2d665943c0ac011d97a3fe29ed5ea388acb38aa43289774c75adaf61c078a9.json
+++ b/test/testData/testPools/0x3b2d665943c0ac011d97a3fe29ed5ea388acb38aa43289774c75adaf61c078a9.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -42,6 +43,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -71,6 +73,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -100,6 +103,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -129,6 +133,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -182,6 +187,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -211,6 +217,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -248,6 +255,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -277,6 +285,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -306,6 +315,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -335,6 +345,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -364,6 +375,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -393,6 +405,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -422,6 +435,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -451,6 +465,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -504,6 +519,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -549,6 +565,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -578,6 +595,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -607,6 +625,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -636,6 +655,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -665,6 +685,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -694,6 +715,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -747,6 +769,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -776,6 +799,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -805,6 +829,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -866,6 +891,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -919,6 +945,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -948,6 +975,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -977,6 +1005,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -1006,6 +1035,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -1035,6 +1065,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1080,6 +1111,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1109,6 +1141,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1154,6 +1187,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1183,6 +1217,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1260,6 +1295,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1337,6 +1373,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1366,6 +1403,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1395,6 +1433,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1424,6 +1463,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1453,6 +1493,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1482,6 +1523,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1511,6 +1553,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1540,6 +1583,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1593,6 +1637,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1622,6 +1667,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1675,6 +1721,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1704,6 +1751,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1733,6 +1781,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1762,6 +1811,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1807,6 +1857,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1836,6 +1887,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1865,6 +1917,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1894,6 +1947,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1923,6 +1977,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1952,6 +2007,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1981,6 +2037,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -2026,6 +2083,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -2055,6 +2113,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2092,6 +2151,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2145,6 +2205,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2175,6 +2236,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2227,6 +2289,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2288,6 +2351,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2357,6 +2421,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2410,6 +2475,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2439,6 +2505,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2468,6 +2535,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2529,6 +2597,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2558,6 +2627,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2587,6 +2657,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2616,6 +2687,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2653,6 +2725,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2682,6 +2755,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2711,6 +2786,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2748,6 +2824,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2777,6 +2854,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2806,6 +2884,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2835,6 +2914,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2888,6 +2968,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2917,6 +2998,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2954,6 +3036,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2983,6 +3066,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -3012,6 +3096,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3041,6 +3126,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -3070,6 +3156,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3107,6 +3194,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -3136,6 +3224,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -3165,6 +3254,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -3194,6 +3284,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3231,6 +3322,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3308,6 +3400,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3345,6 +3438,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3374,6 +3468,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3403,6 +3498,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3432,6 +3528,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3477,6 +3574,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3506,6 +3604,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3535,6 +3634,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3564,6 +3664,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3593,6 +3694,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3622,6 +3724,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3667,6 +3770,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3720,6 +3824,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3749,6 +3854,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3778,6 +3884,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3807,6 +3914,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3836,6 +3944,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3913,6 +4022,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3942,6 +4052,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3971,6 +4082,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4000,6 +4112,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -4029,6 +4142,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -4058,6 +4172,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -4087,6 +4202,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -4116,6 +4232,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -4153,6 +4270,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -4182,6 +4300,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4211,6 +4330,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -4240,6 +4360,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4277,6 +4398,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4306,6 +4428,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4335,6 +4458,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4364,6 +4488,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4393,6 +4518,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4438,6 +4564,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4467,6 +4594,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4520,6 +4648,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4549,6 +4678,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4602,6 +4732,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4762,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4660,6 +4792,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4689,6 +4822,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4718,6 +4852,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4747,6 +4882,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4808,6 +4944,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4853,6 +4990,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4882,6 +5020,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4911,6 +5050,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4940,6 +5080,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4969,6 +5110,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4998,6 +5140,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5027,6 +5170,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5056,6 +5200,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -5085,6 +5230,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5114,6 +5260,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5143,6 +5290,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -5220,6 +5368,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -5249,6 +5398,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5278,6 +5428,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5307,6 +5458,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5352,6 +5504,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5429,6 +5582,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5458,6 +5612,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5487,6 +5642,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5516,6 +5672,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5553,6 +5710,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5582,6 +5740,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5611,6 +5770,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5640,6 +5800,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5669,6 +5830,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5698,6 +5860,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5727,6 +5890,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5756,6 +5920,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5785,6 +5950,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5814,6 +5980,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5875,6 +6042,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5904,6 +6072,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5941,6 +6110,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5970,6 +6140,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5999,6 +6170,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -6028,6 +6200,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -6057,6 +6230,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -6086,6 +6260,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6115,6 +6290,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -6152,6 +6328,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6181,6 +6358,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -6210,6 +6388,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -6271,6 +6450,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -6300,6 +6480,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -6329,6 +6510,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -6358,6 +6540,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6387,6 +6571,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -6416,6 +6601,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6445,6 +6631,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6474,6 +6661,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6503,6 +6691,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6532,6 +6721,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6585,6 +6775,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6614,6 +6805,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6659,6 +6851,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6712,6 +6905,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6741,6 +6935,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6770,6 +6965,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6831,6 +7027,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6868,6 +7065,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6913,6 +7111,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6990,6 +7189,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7019,6 +7219,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -7056,6 +7257,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -7085,6 +7287,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -7114,6 +7317,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7143,6 +7347,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7172,6 +7377,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -7201,6 +7407,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -7230,6 +7437,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7259,6 +7467,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -7328,6 +7537,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -7405,6 +7615,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -7434,6 +7645,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7463,6 +7675,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7492,6 +7705,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7521,6 +7735,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7550,6 +7765,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7587,6 +7803,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7616,6 +7833,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7645,6 +7863,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7674,6 +7893,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7711,6 +7931,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7740,6 +7961,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7769,6 +7991,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7798,6 +8021,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7859,6 +8083,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7888,6 +8113,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7917,6 +8143,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7946,6 +8173,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7975,6 +8203,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -8004,6 +8233,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -8033,6 +8263,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -8062,6 +8293,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8091,6 +8323,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -8120,6 +8353,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -8197,6 +8431,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8242,6 +8477,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8271,6 +8507,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -8300,6 +8537,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -8329,6 +8567,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -8358,6 +8597,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8387,6 +8627,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -8424,6 +8665,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8453,6 +8695,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -8490,6 +8733,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8519,6 +8763,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -8548,6 +8793,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -8601,6 +8847,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -8630,6 +8877,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8659,6 +8907,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8688,6 +8937,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8717,6 +8967,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8746,6 +8997,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8775,6 +9027,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8828,6 +9081,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8857,6 +9112,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8886,6 +9142,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8923,6 +9180,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8952,6 +9210,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8981,6 +9240,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9026,6 +9286,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9055,6 +9316,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9092,6 +9354,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -9169,6 +9432,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9198,6 +9462,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9227,6 +9492,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9256,6 +9522,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -9333,6 +9600,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9362,6 +9630,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -9391,6 +9660,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -9420,6 +9690,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -9457,6 +9728,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9486,6 +9758,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -9539,6 +9812,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -9592,6 +9866,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9621,6 +9896,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9650,6 +9926,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9679,6 +9956,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -9708,6 +9986,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9737,6 +10016,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9766,6 +10046,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9843,6 +10124,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9872,6 +10154,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9901,6 +10184,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9930,6 +10214,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9959,6 +10244,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -10004,6 +10290,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -10033,6 +10320,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10110,6 +10398,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -10163,6 +10452,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -10192,6 +10482,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -10269,6 +10560,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -10322,6 +10614,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -10351,6 +10644,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -10380,6 +10674,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -10409,6 +10704,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -10438,6 +10734,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -10467,6 +10764,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10496,6 +10794,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -10525,6 +10824,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -10554,6 +10854,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -10583,6 +10884,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10612,6 +10914,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -10641,6 +10944,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10670,6 +10974,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -10699,6 +11004,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +11034,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -10757,6 +11064,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -10786,6 +11094,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10815,6 +11124,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10860,6 +11170,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10889,6 +11200,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10918,6 +11230,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10979,6 +11292,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -11008,6 +11322,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -11037,6 +11352,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -11074,6 +11390,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -11103,6 +11420,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11132,6 +11450,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11161,6 +11480,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -11190,6 +11510,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -11219,6 +11540,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11248,6 +11570,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11277,6 +11600,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11330,6 +11654,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11359,6 +11684,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11388,6 +11714,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11417,6 +11744,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -11446,6 +11774,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -11475,6 +11804,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11504,6 +11834,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -11533,6 +11864,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -11562,6 +11894,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11631,6 +11964,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -11660,6 +11994,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -11689,6 +12024,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -11718,6 +12054,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -11795,6 +12132,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -11832,6 +12170,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11861,6 +12200,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11890,6 +12230,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11919,6 +12260,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11948,6 +12290,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -12001,6 +12344,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -12030,6 +12374,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12083,6 +12428,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12112,6 +12458,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12141,6 +12488,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12210,6 +12558,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -12255,6 +12604,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -12284,6 +12634,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -12313,6 +12664,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -12342,6 +12694,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12371,6 +12724,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12448,6 +12802,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12477,6 +12832,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12506,6 +12862,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -12535,6 +12892,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12572,6 +12930,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -12609,6 +12968,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -12638,6 +12998,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12667,6 +13028,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12696,6 +13058,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -12725,6 +13088,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -12754,6 +13118,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -12783,6 +13148,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12812,6 +13178,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -12841,6 +13208,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12870,6 +13238,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12899,6 +13268,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12928,6 +13298,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12957,6 +13328,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12986,6 +13358,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -13015,6 +13388,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13084,6 +13458,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13121,6 +13496,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -13150,6 +13526,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13179,6 +13556,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13208,6 +13586,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13237,6 +13616,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13298,6 +13678,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13327,6 +13708,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -13356,6 +13738,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13385,6 +13768,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13414,6 +13798,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13443,6 +13828,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13472,6 +13858,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13501,6 +13888,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13578,6 +13966,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -13607,6 +13996,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -13636,6 +14026,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -13673,6 +14064,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -13702,6 +14094,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13731,6 +14124,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13784,6 +14178,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13813,6 +14208,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13858,6 +14254,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13919,6 +14316,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -13956,6 +14354,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -14033,6 +14432,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -14062,6 +14462,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -14091,6 +14492,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14120,6 +14522,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -14149,6 +14552,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14178,6 +14582,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14207,6 +14612,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14236,6 +14642,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -14265,6 +14672,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -14318,6 +14726,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14395,6 +14804,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14424,6 +14834,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14469,6 +14880,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14498,6 +14910,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -14535,6 +14948,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14580,6 +14994,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14657,6 +15072,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -14686,6 +15102,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14715,6 +15132,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14744,6 +15162,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -14773,6 +15192,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -14834,6 +15254,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14863,6 +15284,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -14892,6 +15314,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -14921,6 +15344,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14950,6 +15374,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -14979,6 +15404,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -15008,6 +15434,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15037,6 +15464,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -15066,6 +15494,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -15095,6 +15524,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15164,6 +15594,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -15193,6 +15624,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -15222,6 +15654,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15251,6 +15684,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -15280,6 +15714,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15309,6 +15744,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15386,6 +15822,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15415,6 +15852,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -15444,6 +15882,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -15473,6 +15912,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -15502,6 +15942,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15547,6 +15988,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -15576,6 +16018,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -15605,6 +16048,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -15634,6 +16078,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -15663,6 +16108,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15692,6 +16138,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15721,6 +16168,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15750,6 +16198,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -15827,6 +16276,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15856,6 +16306,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15885,6 +16336,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15914,6 +16366,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15943,6 +16396,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15972,6 +16426,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -16001,6 +16456,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16030,6 +16486,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16067,6 +16524,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -16096,6 +16554,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -16125,6 +16584,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -16154,6 +16614,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16183,6 +16644,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -16212,6 +16674,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -16241,6 +16704,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16270,6 +16734,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -16347,6 +16812,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -16376,6 +16842,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -16405,6 +16872,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16434,6 +16902,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -16463,6 +16932,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -16492,6 +16962,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16521,6 +16992,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -16566,6 +17038,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16643,6 +17116,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16672,6 +17146,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -16701,6 +17176,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16730,6 +17206,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -16759,6 +17236,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16788,6 +17266,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -16833,6 +17312,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16862,6 +17342,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -16891,6 +17372,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -16920,6 +17402,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -16949,6 +17432,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16986,6 +17470,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -17015,6 +17500,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17044,6 +17530,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -17073,6 +17560,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17150,6 +17638,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17179,6 +17668,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -17208,6 +17698,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -17237,6 +17728,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -17266,6 +17758,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -17295,6 +17788,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17324,6 +17818,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -17353,6 +17848,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17382,6 +17878,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -17411,6 +17908,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -17440,6 +17938,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17485,6 +17984,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17514,6 +18014,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17543,6 +18044,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -17612,6 +18114,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17641,6 +18144,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17670,6 +18174,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17699,6 +18204,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -17728,6 +18234,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -17757,6 +18264,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17786,6 +18294,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -17815,6 +18324,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17844,6 +18354,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -17873,6 +18384,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -17902,6 +18414,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17963,6 +18476,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -18000,6 +18514,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -18029,6 +18544,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18058,6 +18574,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18087,6 +18604,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18116,6 +18634,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -18145,6 +18664,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -18174,6 +18694,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -18219,6 +18740,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -18296,6 +18818,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18333,6 +18856,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -18362,6 +18886,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -18391,6 +18916,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -18420,6 +18946,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -18449,6 +18976,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -18486,6 +19014,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18515,6 +19044,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18544,6 +19074,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18621,6 +19152,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -18650,6 +19182,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -18679,6 +19212,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18708,6 +19242,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18737,6 +19272,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -18766,6 +19302,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18795,6 +19332,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18824,6 +19362,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18893,6 +19432,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -18922,6 +19462,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -18951,6 +19492,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -18980,6 +19522,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -19009,6 +19552,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -19062,6 +19606,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19107,6 +19652,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -19136,6 +19682,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19165,6 +19712,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -19202,6 +19750,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -19231,6 +19780,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19260,6 +19810,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19305,6 +19856,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -19334,6 +19886,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -19371,6 +19924,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -19400,6 +19954,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -19429,6 +19984,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19458,6 +20014,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -19487,6 +20044,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -19516,6 +20074,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19545,6 +20104,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -19622,6 +20182,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19651,6 +20212,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -19680,6 +20242,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19709,6 +20272,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19738,6 +20302,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19767,6 +20332,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -19844,6 +20410,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -19873,6 +20440,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -19950,6 +20518,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -19979,6 +20548,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -20008,6 +20578,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20037,6 +20608,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -20066,6 +20638,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20095,6 +20668,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -20124,6 +20698,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -20161,6 +20736,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -20198,6 +20774,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20227,6 +20804,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -20256,6 +20834,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20317,6 +20896,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20346,6 +20926,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20375,6 +20956,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -20404,6 +20986,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -20441,6 +21024,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -20470,6 +21054,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -20499,6 +21084,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20528,6 +21114,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -20557,6 +21144,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -20594,6 +21182,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20623,6 +21212,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -20652,6 +21242,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20681,6 +21272,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -20710,6 +21302,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -20739,6 +21332,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20768,6 +21362,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20797,6 +21392,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20834,6 +21430,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20863,6 +21460,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20892,6 +21490,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -20921,6 +21520,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20950,6 +21550,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -20979,6 +21580,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -21016,6 +21618,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21053,6 +21656,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -21082,6 +21686,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -21111,6 +21716,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -21140,6 +21746,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21169,6 +21776,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21198,6 +21806,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21227,6 +21836,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -21256,6 +21866,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21309,6 +21920,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21338,6 +21950,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -21367,6 +21980,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -21396,6 +22010,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -21425,6 +22040,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -21454,6 +22070,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -21483,6 +22100,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -21512,6 +22130,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -21541,6 +22160,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -21618,6 +22238,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21647,6 +22268,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21676,6 +22298,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21705,6 +22328,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -21742,6 +22366,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21771,6 +22396,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -21800,6 +22426,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -21829,6 +22456,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21858,6 +22486,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21903,6 +22532,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21932,6 +22562,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21977,6 +22608,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22006,6 +22638,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -22083,6 +22716,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -22152,6 +22786,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -22181,6 +22816,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22258,6 +22894,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22287,6 +22924,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22316,6 +22954,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -22345,6 +22984,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -22374,6 +23014,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22403,6 +23044,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -22432,6 +23074,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -22461,6 +23104,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -22498,6 +23142,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22527,6 +23172,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22596,6 +23242,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22625,6 +23272,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -22654,6 +23302,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -22691,6 +23340,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22728,6 +23378,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -22773,6 +23424,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -22834,6 +23486,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -22863,6 +23516,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -22892,6 +23546,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -22969,6 +23624,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -22998,6 +23654,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -23043,6 +23700,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23072,6 +23730,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23101,6 +23760,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23130,6 +23790,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23159,6 +23820,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -23196,6 +23858,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23225,6 +23888,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23254,6 +23918,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -23283,6 +23948,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -23312,6 +23978,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -23341,6 +24008,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -23386,6 +24054,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -23415,6 +24084,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23444,6 +24114,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -23473,6 +24144,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -23502,6 +24174,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23555,6 +24228,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23584,6 +24258,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23613,6 +24288,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -23642,6 +24318,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23671,6 +24348,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -23700,6 +24378,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -23753,6 +24432,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23790,6 +24470,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23819,6 +24500,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23848,6 +24530,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23877,6 +24560,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23906,6 +24590,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -23935,6 +24620,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23964,6 +24650,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -24009,6 +24696,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -24038,6 +24726,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -24067,6 +24756,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -24096,6 +24786,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -24125,6 +24816,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -24170,6 +24862,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -24215,6 +24908,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -24260,6 +24954,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24289,6 +24984,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -24326,6 +25022,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -24355,6 +25052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -24384,6 +25082,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24413,6 +25112,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -24442,6 +25142,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -24495,6 +25196,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -24540,6 +25242,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24569,6 +25272,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24598,6 +25302,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24675,6 +25380,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -24712,6 +25418,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -24741,6 +25448,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24778,6 +25486,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -24815,6 +25524,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -24844,6 +25554,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -24873,6 +25584,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -24902,6 +25614,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24931,6 +25644,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -24960,6 +25674,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -24989,6 +25704,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25018,6 +25734,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25047,6 +25764,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -25076,6 +25794,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -25137,6 +25856,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -25166,6 +25886,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -25203,6 +25924,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25232,6 +25954,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25261,6 +25984,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -25306,6 +26030,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -25335,6 +26060,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25364,6 +26090,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25393,6 +26120,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25422,6 +26150,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -25451,6 +26180,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -25488,6 +26218,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25517,6 +26248,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -25554,6 +26286,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25583,6 +26316,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25636,6 +26370,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -25665,6 +26400,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -25694,6 +26430,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -25723,6 +26460,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -25752,6 +26490,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -25781,6 +26520,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -25810,6 +26550,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -25839,6 +26580,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -25868,6 +26610,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -25897,6 +26640,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25926,6 +26670,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -25955,6 +26700,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -26008,6 +26754,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -26061,6 +26808,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -26090,6 +26838,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -26119,6 +26868,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -26148,6 +26898,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26177,6 +26928,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -26206,6 +26958,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26235,6 +26988,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -26264,6 +27018,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -26293,6 +27048,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -26322,6 +27078,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -26351,6 +27108,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -26380,6 +27138,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -26409,6 +27168,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26446,6 +27206,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -26515,6 +27276,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26544,6 +27306,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -26573,6 +27336,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26602,6 +27366,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26647,6 +27412,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26724,6 +27490,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -26801,6 +27568,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -26830,6 +27598,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -26859,6 +27628,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26936,6 +27706,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26965,6 +27736,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -26994,6 +27766,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -27023,6 +27796,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27060,6 +27834,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27105,6 +27880,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27134,6 +27910,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -27163,6 +27940,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -27192,6 +27970,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -27221,6 +28000,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27250,6 +28030,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -27279,6 +28060,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27308,6 +28090,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27337,6 +28120,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -27382,6 +28166,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -27411,6 +28196,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -27440,6 +28226,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -27477,6 +28264,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27506,6 +28294,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -27559,6 +28348,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27596,6 +28386,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -27625,6 +28416,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27654,6 +28446,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -27683,6 +28476,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -27712,6 +28506,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -27741,6 +28536,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -27770,6 +28566,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -27799,6 +28596,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -27836,6 +28634,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -27865,6 +28664,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27894,6 +28694,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -27931,6 +28732,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27960,6 +28762,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -27989,6 +28792,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28042,6 +28846,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28071,6 +28876,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -28100,6 +28906,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28129,6 +28936,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28166,6 +28974,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28211,6 +29020,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -28240,6 +29050,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28269,6 +29080,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28298,6 +29110,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -28367,6 +29180,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -28396,6 +29210,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -28425,6 +29240,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28454,6 +29270,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -28483,6 +29300,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28512,6 +29330,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -28541,6 +29360,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -28578,6 +29398,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -28607,6 +29428,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -28684,6 +29506,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -28713,6 +29536,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -28790,6 +29614,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -28819,6 +29644,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28848,6 +29674,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -28877,6 +29704,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -28906,6 +29734,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28935,6 +29764,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -28964,6 +29794,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -28993,6 +29824,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29022,6 +29854,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -29051,6 +29884,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -29080,6 +29914,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29149,6 +29984,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -29226,6 +30062,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -29255,6 +30092,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -29284,6 +30122,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -29313,6 +30152,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -29342,6 +30182,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29379,6 +30220,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -29408,6 +30250,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -29437,6 +30280,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -29490,6 +30334,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29519,6 +30364,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -29564,6 +30410,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -29593,6 +30440,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -29638,6 +30486,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -29667,6 +30516,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -29696,6 +30546,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -29733,6 +30584,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29762,6 +30614,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29791,6 +30644,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29820,6 +30674,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -29849,6 +30704,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -29878,6 +30734,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -29907,6 +30764,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -29936,6 +30794,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29965,6 +30824,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -29994,6 +30854,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -30023,6 +30884,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -30052,6 +30914,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30081,6 +30944,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30110,6 +30974,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -30139,6 +31004,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30168,6 +31034,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30221,6 +31088,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -30250,6 +31118,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30279,6 +31148,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -30308,6 +31178,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -30337,6 +31208,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30366,6 +31238,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -30395,6 +31268,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -30424,6 +31298,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -30453,6 +31328,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -30482,6 +31358,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -30511,6 +31388,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -30540,6 +31418,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -30577,6 +31456,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -30606,6 +31486,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30635,6 +31516,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -30664,6 +31546,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -30693,6 +31576,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -30770,6 +31654,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30799,6 +31684,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -30828,6 +31714,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30857,6 +31744,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30886,6 +31774,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30915,6 +31804,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -30944,6 +31834,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30973,6 +31864,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -31002,6 +31894,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31031,6 +31924,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31060,6 +31954,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31089,6 +31984,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -31126,6 +32022,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -31155,6 +32052,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31192,6 +32090,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -31221,6 +32120,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -31250,6 +32150,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -31279,6 +32180,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -31308,6 +32210,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31369,6 +32272,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31398,6 +32302,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31475,6 +32380,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -31552,6 +32458,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31581,6 +32488,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31610,6 +32518,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31639,6 +32548,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31668,6 +32578,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -31713,6 +32624,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -31742,6 +32654,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -31771,6 +32684,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -31832,6 +32746,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -31861,6 +32776,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -31890,6 +32806,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31919,6 +32836,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31964,6 +32882,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -31993,6 +32912,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -32030,6 +32950,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -32059,6 +32980,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -32088,6 +33010,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -32117,6 +33040,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -32146,6 +33070,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -32183,6 +33108,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32212,6 +33138,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -32241,6 +33168,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -32270,6 +33198,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -32299,6 +33228,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -32328,6 +33258,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -32357,6 +33288,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -32386,6 +33318,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32463,6 +33396,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -32492,6 +33426,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -32521,6 +33456,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -32550,6 +33486,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -32579,6 +33516,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32608,6 +33546,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -32637,6 +33576,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -32666,6 +33606,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32711,6 +33652,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -32740,6 +33682,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -32769,6 +33712,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -32798,6 +33742,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -32827,6 +33772,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -32856,6 +33802,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -32885,6 +33832,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -32914,6 +33862,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -32943,6 +33892,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -32972,6 +33922,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -33001,6 +33952,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -33030,6 +33982,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -33059,6 +34012,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -33088,6 +34042,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33125,6 +34080,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -33194,6 +34150,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -33223,6 +34180,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -33252,6 +34210,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -33281,6 +34240,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -33310,6 +34270,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -33339,6 +34300,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -33368,6 +34330,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -33397,6 +34360,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -33426,6 +34390,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -33487,6 +34452,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -33516,6 +34482,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -33545,6 +34512,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -33574,6 +34542,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -33603,6 +34572,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33632,6 +34602,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33669,6 +34640,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -33698,6 +34670,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -33727,6 +34700,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -33756,6 +34730,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -33785,6 +34760,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -33814,6 +34790,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -33843,6 +34820,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33872,6 +34850,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -33901,6 +34880,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -33930,6 +34910,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -33959,6 +34940,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -34004,6 +34986,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -34065,6 +35048,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34094,6 +35078,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34123,6 +35108,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34152,6 +35138,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34181,6 +35168,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -34210,6 +35198,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -34239,6 +35228,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -34268,6 +35258,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -34329,6 +35320,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -34358,6 +35350,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34387,6 +35380,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34448,6 +35442,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -34485,6 +35480,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34546,6 +35542,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34583,6 +35580,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34612,6 +35610,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -34649,6 +35648,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34702,6 +35702,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -34747,6 +35748,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -34776,6 +35778,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -34805,6 +35808,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -34834,6 +35838,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -34863,6 +35868,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -34892,6 +35898,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -34929,6 +35936,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -34958,6 +35966,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -34987,6 +35996,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -35016,6 +36026,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -35045,6 +36056,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35074,6 +36086,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35103,6 +36116,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35132,6 +36146,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -35161,6 +36176,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -35190,6 +36206,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -35219,6 +36236,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35248,6 +36266,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -35277,6 +36296,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35306,6 +36326,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -35335,6 +36356,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -35364,6 +36386,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35393,6 +36416,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -35422,6 +36446,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35451,6 +36476,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -35504,6 +36530,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35549,6 +36576,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35578,6 +36606,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -35607,6 +36636,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -35636,6 +36666,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35705,6 +36736,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -35734,6 +36766,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -35763,6 +36796,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35792,6 +36826,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -35829,6 +36864,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -35858,6 +36894,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -35887,6 +36924,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35932,6 +36970,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -35961,6 +37000,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35990,6 +37030,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -36019,6 +37060,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -36048,6 +37090,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36125,6 +37168,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -36154,6 +37198,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -36207,6 +37252,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -36236,6 +37282,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36289,6 +37336,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36318,6 +37366,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -36347,6 +37397,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -36384,6 +37435,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -36429,6 +37481,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36474,6 +37527,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -36503,6 +37557,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36532,6 +37587,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -36561,6 +37617,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -36598,6 +37655,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -36627,6 +37685,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -36656,6 +37715,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -36685,6 +37745,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -36714,6 +37775,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -36743,6 +37805,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -36772,6 +37835,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36801,6 +37865,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36830,6 +37895,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -36859,6 +37925,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -36904,6 +37971,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36933,6 +38001,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37010,6 +38079,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -37039,6 +38109,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37068,6 +38139,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37097,6 +38169,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37126,6 +38199,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -37155,6 +38229,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -37192,6 +38267,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37229,6 +38305,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -37258,6 +38335,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37335,6 +38413,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37364,6 +38443,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -37393,6 +38473,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -37422,6 +38503,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37451,6 +38533,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37480,6 +38563,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -37541,6 +38625,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -37570,6 +38655,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -37607,6 +38693,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -37636,6 +38723,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -37665,6 +38753,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -37694,6 +38783,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -37723,6 +38813,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -37752,6 +38843,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37781,6 +38873,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37810,6 +38903,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -37863,6 +38957,7 @@
         {
             "id": "0xe02e8ddecbe302ba1a40107c726e3ee889b0ff10",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
@@ -37900,6 +38995,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -37929,6 +39025,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -37958,6 +39055,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37987,6 +39085,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38016,6 +39115,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38069,6 +39169,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -38098,6 +39199,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -38127,6 +39229,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -38156,6 +39259,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38185,6 +39289,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38214,6 +39319,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38243,6 +39349,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -38272,6 +39379,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38301,6 +39409,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38330,6 +39439,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38359,6 +39469,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38428,6 +39539,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38481,6 +39593,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38510,6 +39623,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38539,6 +39653,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38568,6 +39683,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -38597,6 +39713,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -38634,6 +39751,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -38663,6 +39781,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38692,6 +39811,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38721,6 +39841,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -38750,6 +39871,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38803,6 +39925,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -38832,6 +39955,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -38861,6 +39985,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -38890,6 +40015,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -38919,6 +40045,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38956,6 +40083,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -38985,6 +40113,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -39062,6 +40191,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39115,6 +40245,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39176,6 +40307,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39221,6 +40353,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39250,6 +40383,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -39327,6 +40461,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -39356,6 +40491,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39385,6 +40521,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -39414,6 +40551,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -39443,6 +40581,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39472,6 +40611,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39525,6 +40665,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -39554,6 +40695,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -39583,6 +40725,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39612,6 +40755,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39689,6 +40833,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -39718,6 +40863,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -39747,6 +40893,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -39776,6 +40923,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39805,6 +40953,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39834,6 +40983,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -39863,6 +41013,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39892,6 +41043,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -39921,6 +41073,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -39950,6 +41103,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -39979,6 +41133,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -40016,6 +41171,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -40045,6 +41201,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -40074,6 +41231,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40103,6 +41261,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -40132,6 +41291,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -40161,6 +41321,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -40190,6 +41351,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -40251,6 +41413,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -40280,6 +41443,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -40341,6 +41505,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -40370,6 +41535,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -40399,6 +41565,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40452,6 +41619,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -40481,6 +41649,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -40510,6 +41679,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40539,6 +41709,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -40584,6 +41755,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40613,6 +41785,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40650,6 +41823,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -40679,6 +41853,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -40716,6 +41891,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40745,6 +41921,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40774,6 +41951,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40803,6 +41981,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -40832,6 +42011,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -40885,6 +42065,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -40922,6 +42103,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -40951,6 +42133,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -40988,6 +42171,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -41017,6 +42201,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -41046,6 +42231,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -41099,6 +42285,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -41128,6 +42315,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -41157,6 +42345,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -41210,6 +42399,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -41239,6 +42429,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41268,6 +42459,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -41313,6 +42505,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -41358,6 +42551,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -41387,6 +42581,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -41416,6 +42611,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -41445,6 +42641,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41498,6 +42695,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -41527,6 +42725,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -41572,6 +42771,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -41601,6 +42801,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -41630,6 +42831,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41659,6 +42861,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -41688,6 +42891,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -41717,6 +42921,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -41746,6 +42951,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -41775,6 +42981,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41804,6 +43011,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -41833,6 +43041,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -41870,6 +43079,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -41899,6 +43109,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -41928,6 +43139,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -41981,6 +43193,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -42010,6 +43223,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -42039,6 +43253,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -42068,6 +43283,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -42097,6 +43313,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -42126,6 +43343,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -42155,6 +43373,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -42184,6 +43403,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -42213,6 +43433,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -42290,6 +43511,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -42319,6 +43541,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -42348,6 +43571,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -42377,6 +43601,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -42430,6 +43655,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -42459,6 +43685,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -42496,6 +43723,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -42533,6 +43761,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -42570,6 +43799,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -42599,6 +43829,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -42628,6 +43859,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -42657,6 +43889,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -42694,6 +43927,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -42723,6 +43957,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -42752,6 +43987,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -42781,6 +44017,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -42818,6 +44055,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -42855,6 +44093,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -42884,6 +44123,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -42913,6 +44153,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -42958,6 +44199,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -43035,6 +44277,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -43064,6 +44307,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -43093,6 +44337,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -43122,6 +44367,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -43151,6 +44397,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -43180,6 +44427,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -43209,6 +44457,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -43246,6 +44495,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -43275,6 +44525,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -43304,6 +44555,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -43381,6 +44633,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -43410,6 +44663,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -43439,6 +44693,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -43468,6 +44723,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -43545,6 +44801,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x3b2d665943c0ac011d97a3fe29ed5ea388acb38aa43289774c75adaf61c078a9.json
+++ b/test/testData/testPools/0x3b2d665943c0ac011d97a3fe29ed5ea388acb38aa43289774c75adaf61c078a9.json
@@ -2756,7 +2756,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6541,7 +6540,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -9081,7 +9079,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -37366,7 +37363,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0x3eb871a70e05bff87dd17b426e80cae10d44b62b198b8c3e3576c31f09de116c.json
+++ b/test/testData/testPools/0x3eb871a70e05bff87dd17b426e80cae10d44b62b198b8c3e3576c31f09de116c.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x3f319e935f56ff76be555f6c7b6e9f410bd425a97c867b848fc8162bb6bd54f1.json
+++ b/test/testData/testPools/0x3f319e935f56ff76be555f6c7b6e9f410bd425a97c867b848fc8162bb6bd54f1.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x4049450e9cc2b947409cec9b8fb795e5e8defc6ae5dabae0856b90928082680a.json
+++ b/test/testData/testPools/0x4049450e9cc2b947409cec9b8fb795e5e8defc6ae5dabae0856b90928082680a.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x4141bc25373f3cd1893e3b29455996f5f459a698b90cb1745d2962bfb7dae891.json
+++ b/test/testData/testPools/0x4141bc25373f3cd1893e3b29455996f5f459a698b90cb1745d2962bfb7dae891.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -94,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -169,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -196,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -230,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -257,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -284,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -311,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -338,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -365,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -392,6 +405,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -419,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -467,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -508,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -535,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -562,6 +580,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +608,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -616,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -643,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -691,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -718,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -745,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -800,6 +825,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -848,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -875,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -902,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -929,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -956,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -997,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1024,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1065,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1092,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1161,6 +1196,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1230,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1257,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1284,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1311,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1338,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1365,6 +1406,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1392,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1419,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1467,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1494,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1542,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1569,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1596,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1623,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1664,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1691,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1718,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1745,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1772,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1799,6 +1854,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1826,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1867,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1894,6 +1952,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1987,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -1976,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2004,6 +2065,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2051,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2169,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2168,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2216,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2243,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2270,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2325,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2352,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2379,6 +2449,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2477,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2440,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2467,6 +2540,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2494,6 +2569,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2528,6 +2604,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2555,6 +2632,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2582,6 +2660,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2609,6 +2688,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2657,6 +2737,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2684,6 +2765,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2718,6 +2800,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2745,6 +2828,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2772,6 +2856,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2799,6 +2884,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2826,6 +2912,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2860,6 +2947,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2887,6 +2975,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2914,6 +3003,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2941,6 +3031,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -2975,6 +3066,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3044,6 +3136,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3078,6 +3171,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3105,6 +3199,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3132,6 +3227,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3159,6 +3255,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3200,6 +3297,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3227,6 +3325,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3254,6 +3353,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3281,6 +3381,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3308,6 +3409,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3335,6 +3437,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3376,6 +3479,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3424,6 +3528,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3451,6 +3556,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3478,6 +3584,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3505,6 +3612,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3532,6 +3640,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3601,6 +3710,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3628,6 +3738,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3655,6 +3766,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3682,6 +3794,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3709,6 +3822,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3736,6 +3850,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3763,6 +3878,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3790,6 +3906,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3824,6 +3941,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3851,6 +3969,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3878,6 +3997,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3905,6 +4025,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3939,6 +4060,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3966,6 +4088,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -3993,6 +4116,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4020,6 +4144,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4047,6 +4172,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4088,6 +4214,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4115,6 +4242,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4163,6 +4291,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4190,6 +4319,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4238,6 +4368,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4265,6 +4396,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4292,6 +4424,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4319,6 +4452,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4346,6 +4480,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4373,6 +4508,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4428,6 +4564,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4469,6 +4606,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4496,6 +4634,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4523,6 +4662,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4550,6 +4690,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4577,6 +4718,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4604,6 +4746,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4774,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4658,6 +4802,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4685,6 +4830,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4712,6 +4858,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4739,6 +4886,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4808,6 +4956,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4835,6 +4984,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4862,6 +5012,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4889,6 +5040,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -4930,6 +5082,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5152,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5026,6 +5180,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5053,6 +5208,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5080,6 +5236,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5114,6 +5271,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5141,6 +5299,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5168,6 +5327,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5195,6 +5355,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5222,6 +5383,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5249,6 +5411,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5276,6 +5439,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5303,6 +5467,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5495,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5357,6 +5523,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5412,6 +5579,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5439,6 +5607,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5473,6 +5642,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5500,6 +5670,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5527,6 +5698,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5554,6 +5726,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5581,6 +5754,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5608,6 +5782,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5635,6 +5810,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5669,6 +5845,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5696,6 +5873,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5723,6 +5901,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5778,6 +5957,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5805,6 +5985,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5832,6 +6013,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5859,6 +6041,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -5886,6 +6070,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5913,6 +6098,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5940,6 +6126,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5967,6 +6154,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5994,6 +6182,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6021,6 +6210,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6069,6 +6259,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6096,6 +6287,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6137,6 +6329,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6185,6 +6378,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6212,6 +6406,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6239,6 +6434,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6294,6 +6490,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6328,6 +6525,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6369,6 +6567,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6438,6 +6637,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6465,6 +6665,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6499,6 +6700,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6526,6 +6728,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6553,6 +6756,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6580,6 +6784,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6607,6 +6812,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6634,6 +6840,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6661,6 +6868,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6688,6 +6896,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6750,6 +6959,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6819,6 +7029,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6846,6 +7057,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6873,6 +7085,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6900,6 +7113,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6927,6 +7141,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6954,6 +7169,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -6988,6 +7204,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7015,6 +7232,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7042,6 +7260,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7069,6 +7288,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7103,6 +7323,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7130,6 +7351,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7157,6 +7379,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7184,6 +7407,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7239,6 +7463,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7266,6 +7491,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7293,6 +7519,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7320,6 +7547,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7347,6 +7575,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7374,6 +7603,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7401,6 +7631,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7428,6 +7659,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7455,6 +7687,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7482,6 +7715,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7551,6 +7785,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7827,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7855,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7646,6 +7883,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7673,6 +7911,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7700,6 +7939,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7727,6 +7967,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7761,6 +8002,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7788,6 +8030,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7822,6 +8065,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7849,6 +8093,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7876,6 +8121,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7924,6 +8170,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7951,6 +8198,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -7978,6 +8226,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8005,6 +8254,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8032,6 +8282,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8059,6 +8310,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8086,6 +8338,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8134,6 +8387,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8161,6 +8416,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8188,6 +8444,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8222,6 +8479,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8249,6 +8507,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8276,6 +8535,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8317,6 +8577,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8344,6 +8605,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8378,6 +8640,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8447,6 +8710,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8474,6 +8738,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8501,6 +8766,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8528,6 +8794,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8597,6 +8864,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8624,6 +8892,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8651,6 +8920,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8678,6 +8948,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8712,6 +8983,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8739,6 +9011,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8787,6 +9060,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8835,6 +9109,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8862,6 +9137,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +9165,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8916,6 +9193,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8943,6 +9221,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -8970,6 +9249,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8997,6 +9277,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9066,6 +9347,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9093,6 +9375,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9120,6 +9403,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9147,6 +9431,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9174,6 +9459,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9215,6 +9501,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9242,6 +9529,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -9311,6 +9599,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9359,6 +9648,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9386,6 +9676,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9455,6 +9746,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9503,6 +9795,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9530,6 +9823,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9557,6 +9851,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9584,6 +9879,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9611,6 +9907,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9638,6 +9935,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9665,6 +9963,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9692,6 +9991,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9719,6 +10019,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9746,6 +10047,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9773,6 +10075,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9800,6 +10103,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9827,6 +10131,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9854,6 +10159,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9881,6 +10187,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9908,6 +10215,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9935,6 +10243,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -9962,6 +10271,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10003,6 +10313,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10030,6 +10341,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10057,6 +10369,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10112,6 +10425,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10139,6 +10453,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10166,6 +10481,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10200,6 +10516,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10227,6 +10544,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10254,6 +10572,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10281,6 +10600,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10308,6 +10628,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10335,6 +10656,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10362,6 +10684,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10389,6 +10712,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10437,6 +10761,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10464,6 +10789,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10491,6 +10817,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10518,6 +10845,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10545,6 +10873,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10572,6 +10901,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10599,6 +10929,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10626,6 +10957,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10653,6 +10985,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10715,6 +11048,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10742,6 +11076,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10769,6 +11104,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10796,6 +11132,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10865,6 +11202,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10899,6 +11237,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -10926,6 +11265,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11293,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -10980,6 +11321,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11007,6 +11349,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11055,6 +11398,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11082,6 +11426,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11130,6 +11475,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11157,6 +11503,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11184,6 +11531,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11246,6 +11594,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11287,6 +11636,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11314,6 +11664,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11341,6 +11692,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11368,6 +11720,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11395,6 +11748,7 @@
         {
             "id": "0x4b3fa856cef9aa85ed9bbfa8992d6138c5f150e6",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -11464,6 +11818,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11533,6 +11888,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11560,6 +11916,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11587,6 +11944,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11614,6 +11972,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11648,6 +12007,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11682,6 +12042,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11709,6 +12070,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11736,6 +12098,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11763,6 +12126,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11790,6 +12154,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11817,6 +12182,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11844,6 +12210,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11871,6 +12238,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11898,6 +12266,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11925,6 +12294,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11952,6 +12322,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -11979,6 +12350,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12006,6 +12378,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12033,6 +12406,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12060,6 +12434,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12122,6 +12497,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12156,6 +12532,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12183,6 +12560,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12210,6 +12588,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12237,6 +12616,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12264,6 +12644,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12319,6 +12700,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12346,6 +12728,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12373,6 +12756,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12400,6 +12784,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12427,6 +12812,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12454,6 +12840,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12481,6 +12868,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12508,6 +12896,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12577,6 +12966,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12604,6 +12994,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12631,6 +13022,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12665,6 +13057,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12692,6 +13085,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +13113,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +13162,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12794,6 +13190,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +13232,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12890,6 +13288,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12924,6 +13323,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12993,6 +13393,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13020,6 +13421,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13047,6 +13449,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13074,6 +13477,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13101,6 +13505,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13128,6 +13533,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13155,6 +13561,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13182,6 +13589,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13209,6 +13617,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13257,6 +13666,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13326,6 +13736,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13353,6 +13764,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13394,6 +13806,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13421,6 +13834,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13455,6 +13869,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13911,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13565,6 +13981,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13592,6 +14009,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13619,6 +14037,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13646,6 +14065,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13673,6 +14093,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13728,6 +14149,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13755,6 +14177,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13782,6 +14205,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13809,6 +14233,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13836,6 +14261,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13863,6 +14289,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13890,6 +14317,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13917,6 +14345,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13944,6 +14373,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -13971,6 +14401,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14033,6 +14464,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14060,6 +14492,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14087,6 +14520,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14114,6 +14548,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14141,6 +14576,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14604,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14674,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14264,6 +14702,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14291,6 +14730,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14318,6 +14758,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14345,6 +14786,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14386,6 +14828,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14413,6 +14856,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14440,6 +14884,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14467,6 +14912,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14494,6 +14940,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14521,6 +14968,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14548,6 +14996,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14575,6 +15024,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14644,6 +15094,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14671,6 +15122,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14698,6 +15150,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14725,6 +15178,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14752,6 +15206,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14779,6 +15234,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14806,6 +15262,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14833,6 +15290,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14867,6 +15325,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14894,6 +15353,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14921,6 +15381,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14948,6 +15409,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14975,6 +15437,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15002,6 +15465,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15029,6 +15493,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15056,6 +15521,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15125,6 +15591,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15152,6 +15619,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15179,6 +15647,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15206,6 +15675,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15233,6 +15703,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15260,6 +15731,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15287,6 +15759,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15328,6 +15801,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15871,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15424,6 +15899,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15451,6 +15927,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15478,6 +15955,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15505,6 +15983,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15532,6 +16011,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15573,6 +16053,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15600,6 +16081,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15627,6 +16109,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15654,6 +16137,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15681,6 +16165,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15715,6 +16200,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15742,6 +16228,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15769,6 +16256,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15796,6 +16284,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -15865,6 +16354,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15892,6 +16382,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15919,6 +16410,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15946,6 +16438,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15973,6 +16466,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16000,6 +16494,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16027,6 +16522,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16054,6 +16550,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16081,6 +16578,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16108,6 +16606,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16135,6 +16634,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16176,6 +16676,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16203,6 +16704,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16230,6 +16732,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16292,6 +16795,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16319,6 +16823,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16346,6 +16851,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16373,6 +16879,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16400,6 +16907,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16427,6 +16935,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16454,6 +16963,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16481,6 +16991,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16508,6 +17019,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16535,6 +17047,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16562,6 +17075,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16617,6 +17131,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16651,6 +17166,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16678,6 +17194,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16705,6 +17222,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16732,6 +17250,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16759,6 +17278,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16786,6 +17306,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16813,6 +17334,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16854,6 +17376,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17446,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -16957,6 +17481,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16984,6 +17509,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17011,6 +17537,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17038,6 +17565,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17065,6 +17593,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17099,6 +17628,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17126,6 +17656,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17153,6 +17684,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17222,6 +17754,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17249,6 +17782,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17276,6 +17810,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17303,6 +17838,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17330,6 +17866,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17357,6 +17894,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17384,6 +17922,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17411,6 +17950,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17473,6 +18013,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17500,6 +18041,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17527,6 +18069,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17554,6 +18097,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17581,6 +18125,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17629,6 +18174,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17670,6 +18216,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17697,6 +18244,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17724,6 +18272,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17758,6 +18307,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17785,6 +18335,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17812,6 +18363,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17853,6 +18405,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17880,6 +18433,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17914,6 +18468,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17941,6 +18496,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17968,6 +18524,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17995,6 +18552,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18022,6 +18580,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18049,6 +18608,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18076,6 +18636,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18145,6 +18706,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18172,6 +18734,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18199,6 +18762,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18226,6 +18790,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18253,6 +18818,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -18280,6 +18846,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18349,6 +18916,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18376,6 +18944,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18445,6 +19014,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18472,6 +19042,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18499,6 +19070,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18526,6 +19098,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18553,6 +19126,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18580,6 +19154,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18607,6 +19182,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18641,6 +19217,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18675,6 +19252,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18702,6 +19280,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18729,6 +19308,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18784,6 +19364,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18811,6 +19392,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18838,6 +19420,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18865,6 +19448,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18899,6 +19483,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18926,6 +19511,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18953,6 +19539,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18980,6 +19567,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19007,6 +19595,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19041,6 +19630,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19068,6 +19658,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19095,6 +19686,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19122,6 +19714,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19149,6 +19742,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19176,6 +19770,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19798,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19230,6 +19826,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19264,6 +19861,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19291,6 +19889,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19318,6 +19917,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19345,6 +19945,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19372,6 +19973,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19399,6 +20001,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19433,6 +20036,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19460,6 +20064,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19487,6 +20092,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19514,6 +20120,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19541,6 +20148,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -19568,6 +20176,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19595,6 +20204,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19622,6 +20232,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19670,6 +20281,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19697,6 +20309,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19724,6 +20337,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19751,6 +20365,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19778,6 +20393,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19805,6 +20421,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19832,6 +20449,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19859,6 +20477,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19886,6 +20505,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -19955,6 +20575,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19982,6 +20603,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20009,6 +20631,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20036,6 +20659,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20070,6 +20694,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20097,6 +20722,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20124,6 +20750,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20151,6 +20778,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20178,6 +20806,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20219,6 +20848,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20246,6 +20876,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20287,6 +20918,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20314,6 +20946,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20383,6 +21016,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20445,6 +21079,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20472,6 +21107,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20541,6 +21177,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20568,6 +21205,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20595,6 +21233,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20622,6 +21261,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20649,6 +21289,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20676,6 +21317,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20703,6 +21345,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20730,6 +21373,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20764,6 +21408,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20791,6 +21436,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -20853,6 +21499,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20880,6 +21527,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20907,6 +21555,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -20941,6 +21590,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20975,6 +21625,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21016,6 +21667,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21071,6 +21723,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21098,6 +21751,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21125,6 +21779,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21194,6 +21849,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21221,6 +21877,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21262,6 +21919,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21289,6 +21947,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21316,6 +21975,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21343,6 +22003,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21370,6 +22031,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21404,6 +22066,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21431,6 +22094,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21458,6 +22122,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21485,6 +22150,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21512,6 +22178,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21539,6 +22206,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21580,6 +22248,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21607,6 +22276,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21634,6 +22304,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21661,6 +22332,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21688,6 +22360,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -21736,6 +22409,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21763,6 +22437,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21790,6 +22465,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21817,6 +22493,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21844,6 +22521,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21871,6 +22549,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21919,6 +22598,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -21953,6 +22633,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21980,6 +22661,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22007,6 +22689,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22034,6 +22717,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22061,6 +22745,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22088,6 +22773,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22115,6 +22801,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22156,6 +22843,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22183,6 +22871,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22210,6 +22899,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22237,6 +22927,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22955,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22997,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22346,6 +23039,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22387,6 +23081,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22414,6 +23109,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22448,6 +23144,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22475,6 +23172,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -22502,6 +23200,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22529,6 +23228,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22556,6 +23256,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22604,6 +23305,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22645,6 +23347,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22672,6 +23375,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22699,6 +23403,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22768,6 +23473,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22802,6 +23508,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22829,6 +23536,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22863,6 +23571,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22897,6 +23606,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22924,6 +23634,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22951,6 +23662,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -22978,6 +23690,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23005,6 +23718,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23032,6 +23746,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23059,6 +23774,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23086,6 +23802,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23113,6 +23830,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23140,6 +23858,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23195,6 +23914,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23222,6 +23942,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23256,6 +23977,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23283,6 +24005,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23310,6 +24033,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23351,6 +24075,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23378,6 +24103,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23405,6 +24131,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23432,6 +24159,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23459,6 +24187,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23486,6 +24215,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23520,6 +24250,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23547,6 +24278,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23581,6 +24313,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23608,6 +24341,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23656,6 +24390,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23683,6 +24418,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23710,6 +24446,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23737,6 +24474,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23764,6 +24502,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23791,6 +24530,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23818,6 +24558,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23845,6 +24586,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23872,6 +24614,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23899,6 +24642,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -23926,6 +24670,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -23953,6 +24698,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24001,6 +24747,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24049,6 +24796,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24076,6 +24824,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24103,6 +24852,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24130,6 +24880,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24157,6 +24908,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24184,6 +24936,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24211,6 +24964,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24238,6 +24992,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24265,6 +25020,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24292,6 +25048,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24319,6 +25076,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24346,6 +25104,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24373,6 +25132,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24407,6 +25167,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24469,6 +25230,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24496,6 +25258,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24523,6 +25286,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24550,6 +25314,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +25356,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -24660,6 +25426,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24729,6 +25496,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24756,6 +25524,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24783,6 +25552,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24852,6 +25622,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24879,6 +25650,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24906,6 +25678,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24933,6 +25706,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -24967,6 +25741,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25008,6 +25783,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25035,6 +25811,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25062,6 +25839,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25089,6 +25867,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25116,6 +25895,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25143,6 +25923,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25170,6 +25951,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25197,6 +25979,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25224,6 +26007,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25265,6 +26049,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25292,6 +26077,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25319,6 +26105,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25353,6 +26140,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25380,6 +26168,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25428,6 +26217,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25462,6 +26252,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25489,6 +26280,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25516,6 +26308,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25543,6 +26336,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25570,6 +26364,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25597,6 +26392,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25624,6 +26420,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25651,6 +26448,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25685,6 +26483,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25712,6 +26511,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25739,6 +26539,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25773,6 +26574,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25800,6 +26602,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25827,6 +26630,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25875,6 +26679,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25902,6 +26707,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -25929,6 +26735,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25956,6 +26763,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25990,6 +26798,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26031,6 +26840,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26868,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26085,6 +26896,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26112,6 +26924,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26174,6 +26987,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26201,6 +27015,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26228,6 +27043,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26255,6 +27071,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26282,6 +27099,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26309,6 +27127,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26336,6 +27155,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26370,6 +27190,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26397,6 +27218,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26466,6 +27288,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26493,6 +27316,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26562,6 +27386,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26589,6 +27414,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26616,6 +27442,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26643,6 +27470,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26670,6 +27498,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26697,6 +27526,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26724,6 +27554,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26751,6 +27582,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26778,6 +27610,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26805,6 +27638,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26832,6 +27666,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27729,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27799,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -26990,6 +27827,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27017,6 +27855,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27044,6 +27883,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27071,6 +27911,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27105,6 +27946,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27132,6 +27974,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27159,6 +28002,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27207,6 +28051,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27234,6 +28079,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27275,6 +28121,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27302,6 +28149,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27343,6 +28191,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27370,6 +28219,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +28247,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27431,6 +28282,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +28310,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27485,6 +28338,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27512,6 +28366,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27539,6 +28394,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27566,6 +28422,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27593,6 +28450,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27620,6 +28478,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27647,6 +28506,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27674,6 +28534,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27701,6 +28562,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27728,6 +28590,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27755,6 +28618,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27782,6 +28646,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27809,6 +28674,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +28702,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27884,6 +28751,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -27911,6 +28779,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27938,6 +28807,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -27965,6 +28835,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -27992,6 +28863,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28019,6 +28891,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28046,6 +28919,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28073,6 +28947,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28100,6 +28975,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28127,6 +29003,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28154,6 +29031,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28181,6 +29059,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28215,6 +29094,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28242,6 +29122,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28269,6 +29150,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28296,6 +29178,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28323,6 +29206,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28392,6 +29276,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28419,6 +29304,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28446,6 +29332,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28473,6 +29360,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28500,6 +29388,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28527,6 +29416,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28554,6 +29444,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28581,6 +29472,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28608,6 +29500,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28635,6 +29528,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28662,6 +29556,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28689,6 +29584,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28723,6 +29619,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28750,6 +29647,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28784,6 +29682,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28811,6 +29710,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28838,6 +29738,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28865,6 +29766,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -28892,6 +29794,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28947,6 +29850,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28974,6 +29878,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29043,6 +29948,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29112,6 +30018,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29139,6 +30046,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29166,6 +30074,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29193,6 +30102,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29220,6 +30130,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29261,6 +30172,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29288,6 +30200,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29315,6 +30228,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29370,6 +30284,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29397,6 +30312,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29424,6 +30340,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29451,6 +30368,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29492,6 +30410,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29519,6 +30438,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29553,6 +30473,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29580,6 +30501,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29607,6 +30529,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29634,6 +30557,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29661,6 +30585,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29695,6 +30620,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29722,6 +30648,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29749,6 +30676,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29776,6 +30704,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29803,6 +30732,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29830,6 +30760,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29857,6 +30788,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29926,6 +30858,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -29953,6 +30886,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -29980,6 +30914,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30007,6 +30942,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30034,6 +30970,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30061,6 +30998,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30088,6 +31026,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30115,6 +31054,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30156,6 +31096,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30183,6 +31124,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30210,6 +31152,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30237,6 +31180,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30264,6 +31208,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30291,6 +31236,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30318,6 +31264,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30345,6 +31292,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30372,6 +31320,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30399,6 +31348,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30426,6 +31376,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30453,6 +31404,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -30480,6 +31432,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30507,6 +31460,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30541,6 +31495,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30603,6 +31558,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30630,6 +31586,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30657,6 +31614,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30684,6 +31642,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30711,6 +31670,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30738,6 +31698,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30765,6 +31726,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30792,6 +31754,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30819,6 +31782,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30874,6 +31838,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -30901,6 +31866,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30928,6 +31894,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30955,6 +31922,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -30982,6 +31950,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31009,6 +31978,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31043,6 +32013,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31070,6 +32041,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31097,6 +32069,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31124,6 +32097,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31151,6 +32125,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31178,6 +32153,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31205,6 +32181,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31232,6 +32209,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31259,6 +32237,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31286,6 +32265,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31313,6 +32293,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31354,6 +32335,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +32391,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31436,6 +32419,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31463,6 +32447,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31490,6 +32475,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31517,6 +32503,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31544,6 +32531,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31571,6 +32559,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31598,6 +32587,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31653,6 +32643,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31680,6 +32671,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31707,6 +32699,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31762,6 +32755,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31796,6 +32790,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31851,6 +32846,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31885,6 +32881,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31912,6 +32909,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -31946,6 +32944,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31994,6 +32993,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32035,6 +33035,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32062,6 +33063,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32089,6 +33091,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32116,6 +33119,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32143,6 +33147,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32170,6 +33175,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32204,6 +33210,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32231,6 +33238,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32258,6 +33266,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32285,6 +33294,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32312,6 +33322,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32339,6 +33350,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32366,6 +33378,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32393,6 +33406,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32420,6 +33434,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32447,6 +33462,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32474,6 +33490,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32501,6 +33518,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32528,6 +33546,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32555,6 +33574,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32582,6 +33602,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32609,6 +33630,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32636,6 +33658,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32663,6 +33686,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32690,6 +33714,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32738,6 +33763,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32779,6 +33805,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32806,6 +33833,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32833,6 +33861,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32860,6 +33889,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32922,6 +33952,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -32949,6 +33980,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -32976,6 +34008,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33003,6 +34036,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33037,6 +34071,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33064,6 +34099,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33091,6 +34127,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33132,6 +34169,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33159,6 +34197,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33186,6 +34225,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33213,6 +34253,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33240,6 +34281,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33309,6 +34351,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33336,6 +34379,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33384,6 +34428,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33411,6 +34456,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33459,6 +34505,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +34533,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +34562,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33547,6 +34597,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33588,6 +34639,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33629,6 +34681,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33656,6 +34709,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33683,6 +34737,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33710,6 +34765,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33744,6 +34800,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33771,6 +34828,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33798,6 +34856,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +34884,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -33852,6 +34912,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -33879,6 +34940,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -33906,6 +34968,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33933,6 +34996,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33960,6 +35024,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -33987,6 +35052,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34028,6 +35094,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34055,6 +35122,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34124,6 +35192,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34151,6 +35220,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34178,6 +35248,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34205,6 +35276,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34232,6 +35304,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34259,6 +35332,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34293,6 +35367,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34327,6 +35402,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34354,6 +35430,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34423,6 +35500,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34450,6 +35528,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34477,6 +35556,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34504,6 +35584,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +35612,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34558,6 +35640,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34613,6 +35696,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34640,6 +35724,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34674,6 +35759,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +35787,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34728,6 +35815,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34755,6 +35843,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34782,6 +35871,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34809,6 +35899,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34836,6 +35927,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -34863,6 +35955,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -34911,6 +36004,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34938,6 +36032,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34965,6 +36060,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34992,6 +36088,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +36116,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +36165,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35094,6 +36193,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35121,6 +36221,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35148,6 +36249,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35175,6 +36277,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35202,6 +36305,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35229,6 +36333,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35256,6 +36361,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35283,6 +36389,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35310,6 +36417,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35337,6 +36445,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35399,6 +36508,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35447,6 +36557,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35474,6 +36585,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35501,6 +36613,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35528,6 +36641,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35555,6 +36669,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35589,6 +36704,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35616,6 +36732,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35643,6 +36760,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35670,6 +36788,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35697,6 +36816,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35745,6 +36865,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35772,6 +36893,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -35799,6 +36921,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35826,6 +36949,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -35853,6 +36977,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35887,6 +37012,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -35914,6 +37040,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -35983,6 +37110,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36031,6 +37159,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36086,6 +37215,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36127,6 +37257,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36154,6 +37285,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36223,6 +37355,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36250,6 +37383,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36277,6 +37411,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36304,6 +37439,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36331,6 +37467,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +37495,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36406,6 +37544,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36433,6 +37572,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36460,6 +37600,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36487,6 +37628,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36556,6 +37698,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36583,6 +37726,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36610,6 +37754,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36637,6 +37782,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36664,6 +37810,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36691,6 +37838,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36718,6 +37866,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36745,6 +37894,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36772,6 +37922,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36799,6 +37950,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36826,6 +37978,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -36860,6 +38013,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -36887,6 +38041,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -36914,6 +38069,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36941,6 +38097,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -36968,6 +38125,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -36995,6 +38153,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37022,6 +38181,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37077,6 +38237,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37104,6 +38265,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37159,6 +38321,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37186,6 +38349,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37213,6 +38377,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37261,6 +38426,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37288,6 +38454,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37315,6 +38482,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37342,6 +38510,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37383,6 +38552,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37410,6 +38580,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37444,6 +38615,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37471,6 +38643,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37505,6 +38678,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37532,6 +38706,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37559,6 +38734,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37586,6 +38762,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37613,6 +38790,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37661,6 +38839,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37695,6 +38874,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37722,6 +38902,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -37756,6 +38937,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37783,6 +38965,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37810,6 +38993,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -37858,6 +39042,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37885,6 +39070,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37912,6 +39098,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -37960,6 +39147,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -37987,6 +39175,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38014,6 +39203,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +39245,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38096,6 +39287,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38123,6 +39315,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38150,6 +39343,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38177,6 +39371,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38225,6 +39420,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38252,6 +39448,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38293,6 +39490,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38320,6 +39518,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38347,6 +39546,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38374,6 +39574,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38401,6 +39602,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38428,6 +39630,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38455,6 +39658,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38482,6 +39686,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38509,6 +39714,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38536,6 +39742,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38570,6 +39777,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38597,6 +39805,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38624,6 +39833,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38672,6 +39882,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38699,6 +39910,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38726,6 +39938,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38753,6 +39966,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38780,6 +39994,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -38807,6 +40022,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -38834,6 +40050,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -38861,6 +40078,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -38888,6 +40106,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38957,6 +40176,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38984,6 +40204,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39011,6 +40232,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39038,6 +40260,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39086,6 +40309,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39113,6 +40337,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39147,6 +40372,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39181,6 +40407,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39215,6 +40442,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39242,6 +40470,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39269,6 +40498,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39296,6 +40526,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39330,6 +40561,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39357,6 +40589,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39384,6 +40617,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39411,6 +40645,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39445,6 +40680,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39479,6 +40715,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39506,6 +40743,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39533,6 +40771,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39574,6 +40813,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39643,6 +40883,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39670,6 +40911,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39697,6 +40939,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39724,6 +40967,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39751,6 +40995,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39778,6 +41023,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39805,6 +41051,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39839,6 +41086,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39866,6 +41114,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -39893,6 +41142,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39962,6 +41212,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -39989,6 +41240,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40016,6 +41268,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40043,6 +41296,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40112,6 +41366,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x4141bc25373f3cd1893e3b29455996f5f459a698b90cb1745d2962bfb7dae891.json
+++ b/test/testData/testPools/0x4141bc25373f3cd1893e3b29455996f5f459a698b90cb1745d2962bfb7dae891.json
@@ -2541,7 +2541,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6042,7 +6041,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8387,7 +8385,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -34533,7 +34530,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0x4190309f9453fc3784f13731171f1d4cf0f873dbc6d594dc9a6bb3819727bf6c.json
+++ b/test/testData/testPools/0x4190309f9453fc3784f13731171f1d4cf0f873dbc6d594dc9a6bb3819727bf6c.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -827,6 +832,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1392,6 +1399,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1826,6 +1834,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1921,6 +1930,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1955,6 +1965,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2031,6 +2042,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2133,6 +2145,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2406,6 +2419,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2433,6 +2447,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2494,6 +2509,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2636,6 +2652,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3002,6 +3019,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3362,6 +3380,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4047,6 +4066,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4217,6 +4237,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4319,6 +4340,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4400,6 +4422,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4739,6 +4762,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4957,6 +4981,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5026,6 +5051,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5080,6 +5106,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5249,6 +5276,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5358,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5466,6 +5495,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5635,6 +5665,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5886,6 +5917,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6355,6 +6387,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6900,6 +6933,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6981,6 +7015,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7157,6 +7192,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7320,6 +7356,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7455,6 +7492,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7578,6 +7616,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7658,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7788,6 +7828,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8161,6 +8202,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8474,6 +8516,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8624,6 +8667,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +8933,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9174,6 +9219,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9269,6 +9315,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10362,6 +10409,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10491,6 +10539,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10599,6 +10648,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10680,6 +10730,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10953,6 +11004,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10980,6 +11032,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11641,6 +11694,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11979,6 +12033,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12264,6 +12319,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12508,6 +12564,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12719,6 +12776,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12746,6 +12804,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12794,6 +12853,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12862,6 +12922,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13182,6 +13243,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13353,6 +13415,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13421,6 +13484,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13482,6 +13546,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13523,6 +13588,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13619,6 +13685,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13998,6 +14065,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14195,6 +14263,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14222,6 +14291,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14291,6 +14361,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14548,6 +14619,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14698,6 +14770,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14806,6 +14879,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14887,6 +14961,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15083,6 +15158,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15382,6 +15458,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15451,6 +15528,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15850,6 +15928,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16481,6 +16560,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16671,6 +16751,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16908,6 +16989,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16977,6 +17059,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17180,6 +17263,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17465,6 +17549,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17866,6 +17951,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18049,6 +18135,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18103,6 +18190,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18307,6 +18395,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19149,6 +19238,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19230,6 +19320,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19257,6 +19348,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19345,6 +19437,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19595,6 +19688,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20232,6 +20326,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20845,6 +20940,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21343,6 +21439,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21742,6 +21839,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22291,6 +22389,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22318,6 +22417,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22359,6 +22459,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22529,6 +22630,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23140,6 +23242,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23276,6 +23379,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23432,6 +23536,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23845,6 +23950,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23953,6 +24059,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24604,6 +24711,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24645,6 +24753,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25278,6 +25387,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25739,6 +25849,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26085,6 +26196,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26112,6 +26224,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26616,6 +26729,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26805,6 +26919,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26886,6 +27001,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26948,6 +27064,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27017,6 +27134,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27213,6 +27331,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27424,6 +27543,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27451,6 +27571,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27890,6 +28011,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27917,6 +28039,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27992,6 +28115,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28181,6 +28305,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28323,6 +28448,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28689,6 +28815,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28973,6 +29100,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29193,6 +29321,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29342,6 +29471,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29938,6 +30068,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30318,6 +30449,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30561,6 +30693,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31205,6 +31338,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31462,6 +31596,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31517,6 +31652,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31652,6 +31788,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31959,6 +32096,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32054,6 +32192,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32197,6 +32336,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32555,6 +32695,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32771,6 +32912,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33030,6 +33172,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33267,6 +33410,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33348,6 +33492,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33444,6 +33589,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33519,6 +33665,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33594,6 +33741,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33621,6 +33769,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33764,6 +33913,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33791,6 +33941,7 @@
         {
             "id": "0xd8e72a62e214864cbd9381cc04fa1006a8c8fb10",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23b608675a2b2fb1890d3abbd85c5775c51691d5",
@@ -33975,6 +34126,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34002,6 +34154,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34531,6 +34684,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34851,6 +35005,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34878,6 +35033,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34932,6 +35088,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35169,6 +35326,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35196,6 +35354,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35244,6 +35403,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35949,6 +36109,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36508,6 +36669,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36535,6 +36697,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36664,6 +36827,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37118,6 +37282,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37709,6 +37874,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37899,6 +38065,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38191,6 +38358,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38232,6 +38400,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38300,6 +38469,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38470,6 +38640,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38551,6 +38722,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38747,6 +38919,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38957,6 +39130,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39215,6 +39389,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39928,6 +40104,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40070,6 +40247,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x4313a949375dd43297dd73bb754f33a1a9d9680a3650fcc867e202fa5914ef2c.json
+++ b/test/testData/testPools/0x4313a949375dd43297dd73bb754f33a1a9d9680a3650fcc867e202fa5914ef2c.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -827,6 +832,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1392,6 +1399,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1826,6 +1834,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1921,6 +1930,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1955,6 +1965,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2031,6 +2042,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2133,6 +2145,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2406,6 +2419,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2433,6 +2447,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2494,6 +2509,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2636,6 +2652,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3002,6 +3019,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3362,6 +3380,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4047,6 +4066,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4217,6 +4237,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4319,6 +4340,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4400,6 +4422,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4739,6 +4762,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4957,6 +4981,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5026,6 +5051,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5080,6 +5106,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5249,6 +5276,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5358,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5466,6 +5495,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5635,6 +5665,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5886,6 +5917,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6355,6 +6387,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6900,6 +6933,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6981,6 +7015,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7157,6 +7192,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7320,6 +7356,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7455,6 +7492,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7578,6 +7616,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7658,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7788,6 +7828,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8161,6 +8202,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8474,6 +8516,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8624,6 +8667,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +8933,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9174,6 +9219,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9269,6 +9315,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10362,6 +10409,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10491,6 +10539,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10599,6 +10648,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10680,6 +10730,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10953,6 +11004,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10980,6 +11032,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11641,6 +11694,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11979,6 +12033,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12264,6 +12319,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12508,6 +12564,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12719,6 +12776,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12746,6 +12804,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12794,6 +12853,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12862,6 +12922,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13182,6 +13243,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13353,6 +13415,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13421,6 +13484,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13482,6 +13546,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13523,6 +13588,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13619,6 +13685,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13998,6 +14065,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14195,6 +14263,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14222,6 +14291,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14291,6 +14361,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14548,6 +14619,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14698,6 +14770,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14806,6 +14879,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14887,6 +14961,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15083,6 +15158,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15382,6 +15458,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15451,6 +15528,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15850,6 +15928,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16481,6 +16560,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16671,6 +16751,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16908,6 +16989,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16977,6 +17059,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17180,6 +17263,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17465,6 +17549,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17866,6 +17951,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18049,6 +18135,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18103,6 +18190,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18307,6 +18395,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19149,6 +19238,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19230,6 +19320,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19257,6 +19348,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19345,6 +19437,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19595,6 +19688,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20232,6 +20326,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20845,6 +20940,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21343,6 +21439,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21742,6 +21839,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22291,6 +22389,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22318,6 +22417,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22359,6 +22459,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22529,6 +22630,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23140,6 +23242,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23276,6 +23379,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23432,6 +23536,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23845,6 +23950,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23953,6 +24059,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24604,6 +24711,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24645,6 +24753,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25278,6 +25387,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25739,6 +25849,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26085,6 +26196,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26112,6 +26224,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26616,6 +26729,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26805,6 +26919,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26886,6 +27001,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26948,6 +27064,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27017,6 +27134,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27213,6 +27331,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27424,6 +27543,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27451,6 +27571,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27863,6 +27984,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27890,6 +28012,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27965,6 +28088,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28154,6 +28278,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28296,6 +28421,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28662,6 +28788,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28946,6 +29073,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29166,6 +29294,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29315,6 +29444,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29911,6 +30041,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30291,6 +30422,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30534,6 +30666,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31178,6 +31311,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31435,6 +31569,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31490,6 +31625,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31625,6 +31761,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31932,6 +32069,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32027,6 +32165,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32170,6 +32309,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32528,6 +32668,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32744,6 +32885,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33003,6 +33145,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33240,6 +33383,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33321,6 +33465,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33417,6 +33562,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33492,6 +33638,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33567,6 +33714,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33594,6 +33742,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33737,6 +33886,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33764,6 +33914,7 @@
         {
             "id": "0xd8e72a62e214864cbd9381cc04fa1006a8c8fb10",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23b608675a2b2fb1890d3abbd85c5775c51691d5",
@@ -33948,6 +34099,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33975,6 +34127,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34504,6 +34657,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34824,6 +34978,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34851,6 +35006,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34905,6 +35061,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35142,6 +35299,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35169,6 +35327,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35217,6 +35376,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35922,6 +36082,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36481,6 +36642,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36508,6 +36670,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36637,6 +36800,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37091,6 +37255,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37682,6 +37847,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37872,6 +38038,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38164,6 +38331,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38205,6 +38373,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38273,6 +38442,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38443,6 +38613,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38524,6 +38695,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38720,6 +38892,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38930,6 +39103,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39188,6 +39362,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39724,6 +39899,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39901,6 +40077,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40043,6 +40220,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x4538a9ba66778343983d39a744e6c337ee497247be50090e8feb18761d275306.json
+++ b/test/testData/testPools/0x4538a9ba66778343983d39a744e6c337ee497247be50090e8feb18761d275306.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x4538a9ba66778343983d39a744e6c337ee497247be50090e8feb18761d275306.json
+++ b/test/testData/testPools/0x4538a9ba66778343983d39a744e6c337ee497247be50090e8feb18761d275306.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -171,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -198,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -232,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -259,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -286,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -313,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -340,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -367,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -422,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -470,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -511,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -538,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -621,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -648,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -696,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -723,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -750,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -854,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -881,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -908,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -935,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -962,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1003,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1030,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1071,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1098,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1237,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1264,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1291,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1318,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1345,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1400,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1427,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1475,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1502,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1550,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1577,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1604,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1631,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1672,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1699,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1726,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1753,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1780,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1835,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1876,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1987,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2063,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2181,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2229,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2256,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2283,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2338,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2365,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2455,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2510,6 +2568,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2544,6 +2603,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2571,6 +2631,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2598,6 +2659,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2674,6 +2736,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2701,6 +2764,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2735,6 +2799,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2762,6 +2827,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2789,6 +2855,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2816,6 +2883,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2843,6 +2911,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2877,6 +2946,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2904,6 +2974,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2931,6 +3002,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2958,6 +3030,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3062,6 +3135,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3096,6 +3170,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3123,6 +3198,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3150,6 +3226,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3177,6 +3254,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3218,6 +3296,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3245,6 +3324,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3272,6 +3352,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3299,6 +3380,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3326,6 +3408,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3395,6 +3478,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3443,6 +3527,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3470,6 +3555,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3497,6 +3583,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3524,6 +3611,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3551,6 +3639,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3620,6 +3709,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3647,6 +3737,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3674,6 +3765,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3701,6 +3793,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3728,6 +3821,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3755,6 +3849,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3782,6 +3877,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3809,6 +3905,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3843,6 +3940,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3870,6 +3968,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3897,6 +3996,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3924,6 +4024,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3958,6 +4059,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3985,6 +4087,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4012,6 +4115,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4067,6 +4171,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4108,6 +4213,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4135,6 +4241,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4183,6 +4290,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4259,6 +4367,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4286,6 +4395,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4341,6 +4451,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4368,6 +4479,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4451,6 +4563,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4492,6 +4605,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4519,6 +4633,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4546,6 +4661,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4573,6 +4689,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4600,6 +4717,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4627,6 +4745,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4654,6 +4773,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4681,6 +4801,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4708,6 +4829,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4763,6 +4885,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4832,6 +4955,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4859,6 +4983,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4886,6 +5011,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4913,6 +5039,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5052,6 +5179,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5107,6 +5235,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5141,6 +5270,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5168,6 +5298,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5195,6 +5326,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5222,6 +5354,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5277,6 +5410,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5304,6 +5438,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5359,6 +5494,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5386,6 +5522,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5441,6 +5578,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5503,6 +5641,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5530,6 +5669,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5557,6 +5697,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5584,6 +5725,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5611,6 +5753,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5666,6 +5809,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5700,6 +5844,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5727,6 +5872,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5754,6 +5900,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5809,6 +5956,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5836,6 +5984,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5863,6 +6012,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5918,6 +6068,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5945,6 +6096,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5972,6 +6124,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5999,6 +6152,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6026,6 +6180,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6053,6 +6208,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6101,6 +6257,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6128,6 +6285,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6169,6 +6327,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6217,6 +6376,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6244,6 +6404,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6271,6 +6432,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6326,6 +6488,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6402,6 +6565,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6471,6 +6635,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6498,6 +6663,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6532,6 +6698,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6559,6 +6726,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6586,6 +6754,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6613,6 +6782,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6640,6 +6810,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6667,6 +6838,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6694,6 +6866,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6721,6 +6894,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6783,6 +6957,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6852,6 +7027,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6879,6 +7055,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6934,6 +7111,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6961,6 +7139,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7023,6 +7202,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7050,6 +7230,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7077,6 +7258,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7104,6 +7286,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7138,6 +7321,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7193,6 +7377,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7220,6 +7405,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7275,6 +7461,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7302,6 +7489,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7357,6 +7545,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7384,6 +7573,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7411,6 +7601,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7438,6 +7629,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7493,6 +7685,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7520,6 +7713,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7659,6 +7853,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7686,6 +7881,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7713,6 +7909,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7740,6 +7937,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7767,6 +7965,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7829,6 +8028,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7863,6 +8063,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7890,6 +8091,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7917,6 +8119,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7965,6 +8168,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7992,6 +8196,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8019,6 +8224,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8046,6 +8252,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8073,6 +8280,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8100,6 +8308,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8127,6 +8336,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8203,6 +8413,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8230,6 +8441,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8264,6 +8476,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8291,6 +8504,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8318,6 +8532,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8359,6 +8574,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8386,6 +8602,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8420,6 +8637,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8517,6 +8735,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8544,6 +8763,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8571,6 +8791,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8668,6 +8889,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8695,6 +8917,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8722,6 +8945,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8756,6 +8980,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8783,6 +9008,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8831,6 +9057,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8879,6 +9106,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8934,6 +9162,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8961,6 +9190,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8988,6 +9218,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9015,6 +9246,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9042,6 +9274,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9111,6 +9344,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9138,6 +9372,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9165,6 +9400,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9220,6 +9456,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9261,6 +9498,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9358,6 +9596,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9406,6 +9645,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9433,6 +9673,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9502,6 +9743,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9550,6 +9792,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9577,6 +9820,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9604,6 +9848,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9631,6 +9876,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9658,6 +9904,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9685,6 +9932,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9712,6 +9960,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9739,6 +9988,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9766,6 +10016,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9793,6 +10044,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9820,6 +10072,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9847,6 +10100,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9874,6 +10128,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9901,6 +10156,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9928,6 +10184,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9955,6 +10212,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9982,6 +10240,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10009,6 +10268,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10050,6 +10310,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10077,6 +10338,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10104,6 +10366,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10159,6 +10422,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10186,6 +10450,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10213,6 +10478,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10247,6 +10513,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10274,6 +10541,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10301,6 +10569,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10328,6 +10597,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10355,6 +10625,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10410,6 +10681,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10437,6 +10709,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10485,6 +10758,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10540,6 +10814,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10567,6 +10842,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10594,6 +10870,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10649,6 +10926,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10676,6 +10954,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10766,6 +11045,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10793,6 +11073,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10820,6 +11101,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10847,6 +11129,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10916,6 +11199,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10950,6 +11234,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11033,6 +11318,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11060,6 +11346,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11108,6 +11395,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11135,6 +11423,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11183,6 +11472,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11210,6 +11500,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11237,6 +11528,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11299,6 +11591,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11340,6 +11633,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11367,6 +11661,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11394,6 +11689,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11421,6 +11717,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11448,6 +11745,7 @@
         {
             "id": "0x4b3fa856cef9aa85ed9bbfa8992d6138c5f150e6",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -11517,6 +11815,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11586,6 +11885,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11613,6 +11913,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11640,6 +11941,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11702,6 +12004,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11736,6 +12039,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11763,6 +12067,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11790,6 +12095,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11817,6 +12123,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11844,6 +12151,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11871,6 +12179,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11898,6 +12207,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11925,6 +12235,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11952,6 +12263,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11979,6 +12291,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12034,6 +12347,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12061,6 +12375,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12088,6 +12403,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12115,6 +12431,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12177,6 +12494,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12211,6 +12529,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12238,6 +12557,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12265,6 +12585,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12320,6 +12641,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12375,6 +12697,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12402,6 +12725,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12429,6 +12753,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12456,6 +12781,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12483,6 +12809,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12510,6 +12837,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12565,6 +12893,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12634,6 +12963,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12661,6 +12991,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12688,6 +13019,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12722,6 +13054,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12854,6 +13187,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12951,6 +13285,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12985,6 +13320,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -13054,6 +13390,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13081,6 +13418,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13108,6 +13446,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13135,6 +13474,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13162,6 +13502,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13189,6 +13530,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13244,6 +13586,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13271,6 +13614,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13319,6 +13663,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13416,6 +13761,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13485,6 +13831,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13631,6 +13978,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13686,6 +14034,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13713,6 +14062,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13740,6 +14090,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13795,6 +14146,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13822,6 +14174,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13849,6 +14202,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13876,6 +14230,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13903,6 +14258,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13930,6 +14286,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13957,6 +14314,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13984,6 +14342,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -14011,6 +14370,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -14101,6 +14461,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14128,6 +14489,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14155,6 +14517,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14182,6 +14545,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14335,6 +14699,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14362,6 +14727,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14389,6 +14755,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14416,6 +14783,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14457,6 +14825,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14484,6 +14853,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14511,6 +14881,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14538,6 +14909,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14593,6 +14965,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14620,6 +14993,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14647,6 +15021,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14744,6 +15119,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14771,6 +15147,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14798,6 +15175,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14853,6 +15231,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14880,6 +15259,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14942,6 +15322,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14969,6 +15350,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14996,6 +15378,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -15023,6 +15406,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15050,6 +15434,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15077,6 +15462,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15132,6 +15518,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15201,6 +15588,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15228,6 +15616,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15255,6 +15644,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15282,6 +15672,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15309,6 +15700,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15336,6 +15728,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15363,6 +15756,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15502,6 +15896,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15529,6 +15924,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15556,6 +15952,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15583,6 +15980,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15610,6 +16008,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15651,6 +16050,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15678,6 +16078,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15705,6 +16106,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15732,6 +16134,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15759,6 +16162,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15793,6 +16197,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15820,6 +16225,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15847,6 +16253,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15944,6 +16351,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15971,6 +16379,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15998,6 +16407,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -16025,6 +16435,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -16052,6 +16463,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16079,6 +16491,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16106,6 +16519,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16133,6 +16547,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16160,6 +16575,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16187,6 +16603,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16214,6 +16631,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16255,6 +16673,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16282,6 +16701,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16309,6 +16729,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16371,6 +16792,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16398,6 +16820,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16425,6 +16848,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16452,6 +16876,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16479,6 +16904,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16534,6 +16960,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16561,6 +16988,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16588,6 +17016,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16615,6 +17044,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16642,6 +17072,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16732,6 +17163,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16759,6 +17191,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16786,6 +17219,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16813,6 +17247,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16840,6 +17275,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16867,6 +17303,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16894,6 +17331,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -17040,6 +17478,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17067,6 +17506,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17094,6 +17534,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17121,6 +17562,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17148,6 +17590,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17182,6 +17625,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17237,6 +17681,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17306,6 +17751,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17333,6 +17779,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17360,6 +17807,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17387,6 +17835,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17414,6 +17863,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17441,6 +17891,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17468,6 +17919,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17558,6 +18010,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17585,6 +18038,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17612,6 +18066,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17639,6 +18094,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17666,6 +18122,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17714,6 +18171,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17755,6 +18213,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17782,6 +18241,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17809,6 +18269,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17843,6 +18304,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17870,6 +18332,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17939,6 +18402,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17966,6 +18430,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -18000,6 +18465,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -18027,6 +18493,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -18054,6 +18521,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18109,6 +18577,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18164,6 +18633,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18233,6 +18703,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18260,6 +18731,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18287,6 +18759,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18314,6 +18787,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18369,6 +18843,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18438,6 +18913,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18465,6 +18941,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18534,6 +19011,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18561,6 +19039,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18588,6 +19067,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18615,6 +19095,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18642,6 +19123,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18669,6 +19151,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18696,6 +19179,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18730,6 +19214,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18764,6 +19249,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18791,6 +19277,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18818,6 +19305,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18873,6 +19361,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18900,6 +19389,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18927,6 +19417,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18954,6 +19445,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18988,6 +19480,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -19015,6 +19508,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -19042,6 +19536,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19069,6 +19564,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19096,6 +19592,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19130,6 +19627,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19157,6 +19655,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19212,6 +19711,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19239,6 +19739,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19322,6 +19823,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19356,6 +19858,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19411,6 +19914,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19438,6 +19942,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19465,6 +19970,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19492,6 +19998,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19526,6 +20033,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19553,6 +20061,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19580,6 +20089,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19607,6 +20117,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19662,6 +20173,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19689,6 +20201,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19716,6 +20229,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19764,6 +20278,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19791,6 +20306,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19818,6 +20334,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19845,6 +20362,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19872,6 +20390,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19899,6 +20418,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19926,6 +20446,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19953,6 +20474,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19980,6 +20502,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -20049,6 +20572,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20076,6 +20600,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20103,6 +20628,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20130,6 +20656,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20164,6 +20691,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20191,6 +20719,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20218,6 +20747,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20245,6 +20775,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20314,6 +20845,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20341,6 +20873,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20382,6 +20915,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20409,6 +20943,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20478,6 +21013,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20540,6 +21076,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20567,6 +21104,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20636,6 +21174,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20663,6 +21202,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20690,6 +21230,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20717,6 +21258,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20744,6 +21286,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20771,6 +21314,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20798,6 +21342,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20825,6 +21370,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20859,6 +21405,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20949,6 +21496,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20976,6 +21524,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -21003,6 +21552,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -21037,6 +21587,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21071,6 +21622,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21112,6 +21664,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21167,6 +21720,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21194,6 +21748,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21221,6 +21776,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21290,6 +21846,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21317,6 +21874,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21358,6 +21916,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21413,6 +21972,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21440,6 +22000,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21467,6 +22028,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21501,6 +22063,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21528,6 +22091,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21555,6 +22119,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21582,6 +22147,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21609,6 +22175,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21636,6 +22203,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21677,6 +22245,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21704,6 +22273,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21731,6 +22301,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21758,6 +22329,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21834,6 +22406,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21861,6 +22434,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21888,6 +22462,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21915,6 +22490,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21942,6 +22518,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21969,6 +22546,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22017,6 +22595,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22051,6 +22630,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22078,6 +22658,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22105,6 +22686,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22132,6 +22714,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22159,6 +22742,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22186,6 +22770,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22213,6 +22798,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22254,6 +22840,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22281,6 +22868,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22308,6 +22896,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22447,6 +23036,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22488,6 +23078,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22515,6 +23106,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22549,6 +23141,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22604,6 +23197,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22631,6 +23225,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22658,6 +23253,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22706,6 +23302,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22747,6 +23344,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22774,6 +23372,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22801,6 +23400,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22870,6 +23470,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22904,6 +23505,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22931,6 +23533,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22965,6 +23568,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22999,6 +23603,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -23026,6 +23631,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -23053,6 +23659,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23080,6 +23687,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23107,6 +23715,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23134,6 +23743,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23161,6 +23771,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23216,6 +23827,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23243,6 +23855,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23298,6 +23911,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23360,6 +23974,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23387,6 +24002,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23414,6 +24030,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23455,6 +24072,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23510,6 +24128,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23537,6 +24156,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23564,6 +24184,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23591,6 +24212,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23625,6 +24247,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23652,6 +24275,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23686,6 +24310,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23713,6 +24338,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23761,6 +24387,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23788,6 +24415,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23815,6 +24443,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23842,6 +24471,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23869,6 +24499,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23924,6 +24555,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23951,6 +24583,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23978,6 +24611,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -24033,6 +24667,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -24060,6 +24695,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24108,6 +24744,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24156,6 +24793,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24183,6 +24821,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24210,6 +24849,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24237,6 +24877,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24264,6 +24905,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24291,6 +24933,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24318,6 +24961,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24345,6 +24989,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24372,6 +25017,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24399,6 +25045,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24426,6 +25073,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24453,6 +25101,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24480,6 +25129,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24514,6 +25164,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24576,6 +25227,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24603,6 +25255,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24630,6 +25283,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24769,6 +25423,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24838,6 +25493,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24865,6 +25521,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24892,6 +25549,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24961,6 +25619,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24988,6 +25647,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25015,6 +25675,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -25042,6 +25703,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -25076,6 +25738,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25117,6 +25780,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25144,6 +25808,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25171,6 +25836,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25198,6 +25864,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25225,6 +25892,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25252,6 +25920,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25279,6 +25948,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25306,6 +25976,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25375,6 +26046,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25402,6 +26074,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25429,6 +26102,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25463,6 +26137,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25490,6 +26165,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25538,6 +26214,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25572,6 +26249,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25599,6 +26277,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25626,6 +26305,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25653,6 +26333,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25680,6 +26361,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25707,6 +26389,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25734,6 +26417,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25761,6 +26445,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25823,6 +26508,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25850,6 +26536,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25884,6 +26571,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25911,6 +26599,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25938,6 +26627,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25986,6 +26676,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26013,6 +26704,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -26040,6 +26732,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26067,6 +26760,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26101,6 +26795,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26198,6 +26893,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26225,6 +26921,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26287,6 +26984,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26314,6 +27012,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26341,6 +27040,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26368,6 +27068,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26395,6 +27096,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26422,6 +27124,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26449,6 +27152,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26483,6 +27187,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26510,6 +27215,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26579,6 +27285,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26606,6 +27313,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26703,6 +27411,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26730,6 +27439,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26757,6 +27467,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26784,6 +27495,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26811,6 +27523,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26838,6 +27551,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26893,6 +27607,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26920,6 +27635,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27108,6 +27824,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27135,6 +27852,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27162,6 +27880,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27189,6 +27908,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27223,6 +27943,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27250,6 +27971,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27326,6 +28048,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27353,6 +28076,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27394,6 +28118,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27421,6 +28146,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27462,6 +28188,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27552,6 +28279,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27579,6 +28307,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27606,6 +28335,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27633,6 +28363,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27660,6 +28391,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27687,6 +28419,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27714,6 +28447,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27741,6 +28475,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27768,6 +28503,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27795,6 +28531,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27822,6 +28559,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27849,6 +28587,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27876,6 +28615,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27903,6 +28643,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -28007,6 +28748,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -28062,6 +28804,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -28089,6 +28832,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -28116,6 +28860,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28143,6 +28888,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28170,6 +28916,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28197,6 +28944,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28252,6 +29000,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28279,6 +29028,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28306,6 +29056,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28340,6 +29091,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28395,6 +29147,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28422,6 +29175,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28449,6 +29203,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28518,6 +29273,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28545,6 +29301,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28572,6 +29329,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28599,6 +29357,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28626,6 +29385,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28653,6 +29413,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28680,6 +29441,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28707,6 +29469,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28762,6 +29525,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28789,6 +29553,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28816,6 +29581,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28850,6 +29616,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28877,6 +29644,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28911,6 +29679,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28938,6 +29707,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28965,6 +29735,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28992,6 +29763,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -29075,6 +29847,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29102,6 +29875,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29171,6 +29945,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29268,6 +30043,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29295,6 +30071,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29322,6 +30099,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29349,6 +30127,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29418,6 +30197,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29445,6 +30225,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29500,6 +30281,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29527,6 +30309,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29554,6 +30337,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29581,6 +30365,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29622,6 +30407,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29649,6 +30435,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29683,6 +30470,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29710,6 +30498,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29737,6 +30526,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29764,6 +30554,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29791,6 +30582,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29825,6 +30617,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29852,6 +30645,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29879,6 +30673,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29906,6 +30701,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29933,6 +30729,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29960,6 +30757,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -30057,6 +30855,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -30084,6 +30883,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -30111,6 +30911,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30138,6 +30939,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30165,6 +30967,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30192,6 +30995,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30219,6 +31023,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30246,6 +31051,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30287,6 +31093,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30314,6 +31121,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30341,6 +31149,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30396,6 +31205,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30423,6 +31233,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30450,6 +31261,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30477,6 +31289,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30504,6 +31317,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30531,6 +31345,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30558,6 +31373,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30613,6 +31429,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30640,6 +31457,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30674,6 +31492,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30736,6 +31555,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30763,6 +31583,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30790,6 +31611,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30817,6 +31639,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30844,6 +31667,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30871,6 +31695,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30898,6 +31723,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30925,6 +31751,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30952,6 +31779,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31007,6 +31835,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -31034,6 +31863,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -31061,6 +31891,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31088,6 +31919,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -31115,6 +31947,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31142,6 +31975,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31176,6 +32010,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31203,6 +32038,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31258,6 +32094,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31285,6 +32122,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31312,6 +32150,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31339,6 +32178,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31366,6 +32206,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31393,6 +32234,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31420,6 +32262,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31447,6 +32290,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31572,6 +32416,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31599,6 +32444,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31626,6 +32472,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31653,6 +32500,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31708,6 +32556,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31735,6 +32584,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31790,6 +32640,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31817,6 +32668,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31844,6 +32696,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31899,6 +32752,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31933,6 +32787,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32023,6 +32878,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32050,6 +32906,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -32133,6 +32990,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32174,6 +33032,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32201,6 +33060,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32256,6 +33116,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32283,6 +33144,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32310,6 +33172,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32344,6 +33207,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32371,6 +33235,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32398,6 +33263,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32425,6 +33291,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32452,6 +33319,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32479,6 +33347,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32506,6 +33375,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32533,6 +33403,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32560,6 +33431,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32615,6 +33487,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32642,6 +33515,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32669,6 +33543,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32696,6 +33571,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32723,6 +33599,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32750,6 +33627,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32777,6 +33655,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32832,6 +33711,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32880,6 +33760,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32921,6 +33802,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32948,6 +33830,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32975,6 +33858,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -33002,6 +33886,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33092,6 +33977,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33119,6 +34005,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33146,6 +34033,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33180,6 +34068,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33207,6 +34096,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33234,6 +34124,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33275,6 +34166,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33330,6 +34222,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33357,6 +34250,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33454,6 +34348,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33530,6 +34425,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33606,6 +34502,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33696,6 +34593,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33737,6 +34635,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33778,6 +34677,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33833,6 +34733,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33860,6 +34761,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33894,6 +34796,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33921,6 +34824,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -34004,6 +34908,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -34031,6 +34936,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -34058,6 +34964,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34085,6 +34992,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34112,6 +35020,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -34139,6 +35048,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34180,6 +35090,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34207,6 +35118,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34276,6 +35188,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34303,6 +35216,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34330,6 +35244,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34357,6 +35272,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34384,6 +35300,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34411,6 +35328,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34445,6 +35363,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34479,6 +35398,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34576,6 +35496,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34603,6 +35524,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34630,6 +35552,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34657,6 +35580,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34684,6 +35608,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34711,6 +35636,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34766,6 +35692,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34793,6 +35720,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34883,6 +35811,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34938,6 +35867,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34965,6 +35895,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34992,6 +35923,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35019,6 +35951,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -35067,6 +36000,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35094,6 +36028,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35121,6 +36056,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35253,6 +36189,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35280,6 +36217,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35307,6 +36245,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35334,6 +36273,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35361,6 +36301,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35388,6 +36329,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35415,6 +36357,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35442,6 +36385,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35469,6 +36413,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35496,6 +36441,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35558,6 +36504,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35606,6 +36553,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35633,6 +36581,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35660,6 +36609,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35687,6 +36637,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35714,6 +36665,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35748,6 +36700,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35775,6 +36728,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35802,6 +36756,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35829,6 +36784,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35856,6 +36812,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35904,6 +36861,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35959,6 +36917,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35986,6 +36945,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -36013,6 +36973,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36047,6 +37008,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -36074,6 +37036,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36143,6 +37106,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36191,6 +37155,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36246,6 +37211,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36287,6 +37253,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36314,6 +37281,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36383,6 +37351,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36410,6 +37379,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36437,6 +37407,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36464,6 +37435,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36568,6 +37540,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36595,6 +37568,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36622,6 +37596,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36719,6 +37694,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36746,6 +37722,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36773,6 +37750,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36800,6 +37778,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36827,6 +37806,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36854,6 +37834,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36881,6 +37862,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36908,6 +37890,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36935,6 +37918,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36962,6 +37946,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36989,6 +37974,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -37023,6 +38009,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -37050,6 +38037,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -37077,6 +38065,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37132,6 +38121,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37159,6 +38149,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37186,6 +38177,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37241,6 +38233,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37268,6 +38261,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37323,6 +38317,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37350,6 +38345,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37377,6 +38373,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37425,6 +38422,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37452,6 +38450,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37479,6 +38478,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37506,6 +38506,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37547,6 +38548,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37574,6 +38576,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37608,6 +38611,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37635,6 +38639,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37669,6 +38674,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37724,6 +38730,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37751,6 +38758,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37778,6 +38786,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37826,6 +38835,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37860,6 +38870,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37922,6 +38933,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37949,6 +38961,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37976,6 +38989,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38024,6 +39038,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -38051,6 +39066,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38078,6 +39094,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -38126,6 +39143,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38153,6 +39171,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38264,6 +39283,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38319,6 +39339,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38346,6 +39367,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38394,6 +39416,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38421,6 +39444,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38490,6 +39514,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38517,6 +39542,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38572,6 +39598,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38599,6 +39626,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38626,6 +39654,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38653,6 +39682,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38680,6 +39710,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38707,6 +39738,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38769,6 +39801,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38796,6 +39829,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38844,6 +39878,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38871,6 +39906,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38898,6 +39934,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38925,6 +39962,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38980,6 +40018,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39007,6 +40046,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -39034,6 +40074,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -39061,6 +40102,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -39130,6 +40172,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39157,6 +40200,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39184,6 +40228,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39260,6 +40305,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39287,6 +40333,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39321,6 +40368,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39355,6 +40403,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39389,6 +40438,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39416,6 +40466,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39443,6 +40494,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39470,6 +40522,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39504,6 +40557,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39531,6 +40585,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39558,6 +40613,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39585,6 +40641,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39619,6 +40676,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39653,6 +40711,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39680,6 +40739,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39707,6 +40767,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39818,6 +40879,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39845,6 +40907,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39872,6 +40935,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39899,6 +40963,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39954,6 +41019,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39981,6 +41047,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40015,6 +41082,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40042,6 +41110,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -40139,6 +41208,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40166,6 +41236,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40193,6 +41264,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40220,6 +41292,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40289,6 +41362,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x460539952504c660268f525812e0eef7f6d80c5cd24a1d3743df23059f51d243.json
+++ b/test/testData/testPools/0x460539952504c660268f525812e0eef7f6d80c5cd24a1d3743df23059f51d243.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x462bd3a36b8a1fdf64e0d9dcf88d18c1d246b4dfca1704f26f883face2612c18.json
+++ b/test/testData/testPools/0x462bd3a36b8a1fdf64e0d9dcf88d18c1d246b4dfca1704f26f883face2612c18.json
@@ -100,6 +100,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -129,6 +130,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -422,6 +424,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -607,6 +610,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -636,6 +640,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -866,6 +871,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1260,6 +1266,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1482,6 +1489,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1952,6 +1960,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2055,6 +2064,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2092,6 +2102,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2175,6 +2186,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2288,6 +2300,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2587,6 +2600,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2616,6 +2630,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2682,6 +2697,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2835,6 +2851,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3231,6 +3248,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3622,6 +3640,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4364,6 +4383,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4549,6 +4569,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4660,6 +4681,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4747,6 +4769,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5114,6 +5137,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5352,6 +5376,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5429,6 +5454,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5487,6 +5513,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5669,6 +5696,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5756,6 +5784,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5904,6 +5933,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6086,6 +6116,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6358,6 +6389,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6868,6 +6900,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7463,6 +7496,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7550,6 +7584,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7740,6 +7775,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7917,6 +7953,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8062,6 +8099,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8197,6 +8235,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8242,6 +8281,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8424,6 +8464,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8828,6 +8869,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9169,6 +9211,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9333,6 +9376,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9621,6 +9665,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9930,6 +9975,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10033,6 +10079,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11219,6 +11266,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11359,6 +11407,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11475,6 +11524,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11562,6 +11612,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11861,6 +11912,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11890,6 +11942,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12535,6 +12588,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12899,6 +12953,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13208,6 +13263,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13472,6 +13528,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13702,6 +13759,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13731,6 +13789,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13784,6 +13843,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13858,6 +13918,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14207,6 +14268,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14395,6 +14457,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14469,6 +14532,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14535,6 +14599,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14580,6 +14645,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14686,6 +14752,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -15095,6 +15162,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15280,6 +15348,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15309,6 +15378,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15386,6 +15456,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15663,6 +15734,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15827,6 +15899,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15943,6 +16016,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -16030,6 +16104,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16241,6 +16316,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16566,6 +16642,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16643,6 +16720,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -17073,6 +17151,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17757,6 +17836,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17963,6 +18043,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -18219,6 +18300,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -18296,6 +18378,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18515,6 +18598,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18824,6 +18908,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -19260,6 +19345,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19458,6 +19544,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -19516,6 +19603,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19738,6 +19826,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -20652,6 +20741,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20739,6 +20829,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20768,6 +20859,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20863,6 +20955,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -21169,6 +21262,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21858,6 +21952,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -22527,6 +22622,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23072,6 +23168,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23502,6 +23599,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24096,6 +24194,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -24125,6 +24224,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -24170,6 +24270,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -24355,6 +24456,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -25018,6 +25120,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25166,6 +25269,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -25335,6 +25439,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25781,6 +25886,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -25897,6 +26003,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -26602,6 +26709,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26647,6 +26755,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -27337,6 +27446,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -27836,6 +27946,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -28211,6 +28322,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -28240,6 +28352,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28790,6 +28903,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -28993,6 +29107,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29080,6 +29195,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29149,6 +29265,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -29226,6 +29343,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -29437,6 +29555,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -29667,6 +29786,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -29696,6 +29816,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -30139,6 +30260,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30168,6 +30290,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30250,6 +30373,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30453,6 +30577,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -30606,6 +30731,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31002,6 +31128,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31308,6 +31435,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31552,6 +31680,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31713,6 +31842,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -32386,6 +32516,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32798,6 +32929,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -33030,6 +33162,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -33727,6 +33860,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -34004,6 +34138,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -34065,6 +34200,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34210,6 +34346,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -34546,6 +34683,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34649,6 +34787,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34805,6 +34944,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -35190,6 +35330,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -35422,6 +35563,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35705,6 +35847,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -35961,6 +36104,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36048,6 +36192,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36154,6 +36299,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -36236,6 +36382,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36318,6 +36465,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -36347,6 +36495,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -36503,6 +36652,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36656,6 +36806,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -36685,6 +36836,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -37258,6 +37410,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37607,6 +37760,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -37636,6 +37790,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -37694,6 +37849,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -37987,6 +38143,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38016,6 +38173,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38069,6 +38227,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -38832,6 +38991,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -39443,6 +39603,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39472,6 +39633,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39612,6 +39774,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40103,6 +40266,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -40745,6 +40909,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40951,6 +41116,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -41268,6 +41434,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -41313,6 +41480,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -41387,6 +41555,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -41572,6 +41741,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -41659,6 +41829,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -41870,6 +42041,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -42097,6 +42269,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -42377,6 +42550,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -42958,6 +43132,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -43151,6 +43326,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -43304,6 +43480,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x465ef97f569b568bb486a600a5d7c11389f9a925fce5d5f07d6caf5893c7b6e2.json
+++ b/test/testData/testPools/0x465ef97f569b568bb486a600a5d7c11389f9a925fce5d5f07d6caf5893c7b6e2.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x4794ccc4f633a3caec767a811b569234798bc49b9b454de6e85a9c5e544a86e4.json
+++ b/test/testData/testPools/0x4794ccc4f633a3caec767a811b569234798bc49b9b454de6e85a9c5e544a86e4.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x4b0b1c2598cac7a08d716683ac35f88f234df76508b14982cdd7a88b170c20a5.json
+++ b/test/testData/testPools/0x4b0b1c2598cac7a08d716683ac35f88f234df76508b14982cdd7a88b170c20a5.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x4c01eda6ce118df14db981777a0afa36276291d2170632ac01dbb8728d02acf2.json
+++ b/test/testData/testPools/0x4c01eda6ce118df14db981777a0afa36276291d2170632ac01dbb8728d02acf2.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x4cc50daad4c6e2db5dd9ed3668019db96e88b7ad4ca58027e7486835a0e977eb.json
+++ b/test/testData/testPools/0x4cc50daad4c6e2db5dd9ed3668019db96e88b7ad4ca58027e7486835a0e977eb.json
@@ -990,6 +990,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1017,6 +1018,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1288,6 +1290,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -1458,6 +1461,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -1485,6 +1489,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -1696,6 +1701,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2057,6 +2063,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2261,6 +2268,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2695,6 +2703,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2790,6 +2799,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2824,6 +2834,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2900,6 +2911,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3002,6 +3014,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3275,6 +3288,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -3302,6 +3316,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3363,6 +3378,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3505,6 +3521,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3871,6 +3888,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -4231,6 +4249,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4916,6 +4935,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -5086,6 +5106,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5188,6 +5209,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5269,6 +5291,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5608,6 +5631,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5826,6 +5850,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5895,6 +5920,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5949,6 +5975,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6118,6 +6145,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6199,6 +6227,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6335,6 +6364,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6504,6 +6534,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6755,6 +6786,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -7224,6 +7256,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7769,6 +7802,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7850,6 +7884,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8026,6 +8061,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8189,6 +8225,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8324,6 +8361,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8447,6 +8485,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8488,6 +8527,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8657,6 +8697,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -9030,6 +9071,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9343,6 +9385,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9493,6 +9536,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9758,6 +9802,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10043,6 +10088,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10138,6 +10184,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11231,6 +11278,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11360,6 +11408,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11468,6 +11517,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11549,6 +11599,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11822,6 +11873,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11849,6 +11901,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12510,6 +12563,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12848,6 +12902,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13133,6 +13188,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13377,6 +13433,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13588,6 +13645,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13615,6 +13673,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13663,6 +13722,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13731,6 +13791,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14051,6 +14112,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14222,6 +14284,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14290,6 +14353,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14351,6 +14415,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14392,6 +14457,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14488,6 +14554,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14867,6 +14934,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15037,6 +15105,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15064,6 +15133,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15133,6 +15203,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15390,6 +15461,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15540,6 +15612,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15648,6 +15721,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15729,6 +15803,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15925,6 +16000,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16224,6 +16300,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16293,6 +16370,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16692,6 +16770,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17323,6 +17402,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17513,6 +17593,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17750,6 +17831,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17819,6 +17901,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18022,6 +18105,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18307,6 +18391,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18708,6 +18793,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18891,6 +18977,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18945,6 +19032,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19149,6 +19237,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19991,6 +20080,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20072,6 +20162,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20099,6 +20190,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20187,6 +20279,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20437,6 +20530,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21074,6 +21168,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21687,6 +21782,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22185,6 +22281,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22584,6 +22681,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23133,6 +23231,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -23160,6 +23259,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -23201,6 +23301,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -23371,6 +23472,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23982,6 +24084,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24118,6 +24221,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -24274,6 +24378,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24687,6 +24792,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24795,6 +24901,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25446,6 +25553,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25487,6 +25595,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26120,6 +26229,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26581,6 +26691,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26927,6 +27038,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26954,6 +27066,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +27571,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27647,6 +27761,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27728,6 +27843,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27790,6 +27906,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27859,6 +27976,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -28055,6 +28173,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28266,6 +28385,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -28293,6 +28413,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28705,6 +28826,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28732,6 +28854,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28807,6 +28930,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28996,6 +29120,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -29138,6 +29263,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29504,6 +29630,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29788,6 +29915,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30008,6 +30136,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30157,6 +30286,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30753,6 +30883,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31133,6 +31264,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31349,6 +31481,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31993,6 +32126,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32250,6 +32384,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32305,6 +32440,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32440,6 +32576,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32747,6 +32884,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32842,6 +32980,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32985,6 +33124,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33343,6 +33483,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33559,6 +33700,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33818,6 +33960,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -34055,6 +34198,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34136,6 +34280,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34232,6 +34377,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34307,6 +34453,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34382,6 +34529,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34409,6 +34557,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34552,6 +34701,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34694,6 +34844,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34721,6 +34872,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35250,6 +35402,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35570,6 +35723,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35597,6 +35751,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35651,6 +35806,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35888,6 +36044,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35915,6 +36072,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35963,6 +36121,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36668,6 +36827,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37227,6 +37387,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37254,6 +37415,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37383,6 +37545,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37837,6 +38000,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38428,6 +38592,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38618,6 +38783,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38910,6 +39076,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38951,6 +39118,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39019,6 +39187,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39189,6 +39358,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39270,6 +39440,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39466,6 +39637,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39676,6 +39848,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39934,6 +40107,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40470,6 +40644,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40647,6 +40822,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40789,6 +40965,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x4cdd6c43d7eea494b7006b2c1dd76c7154fe72c18c35fc4fb0ae525e99082247.json
+++ b/test/testData/testPools/0x4cdd6c43d7eea494b7006b2c1dd76c7154fe72c18c35fc4fb0ae525e99082247.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x5523ac56f308a7a2b3d26197cc8498a29d2d7ed8bfda52dbed83698166971a27.json
+++ b/test/testData/testPools/0x5523ac56f308a7a2b3d26197cc8498a29d2d7ed8bfda52dbed83698166971a27.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x5692950aa787b0502fac586425f7c0ab503c43e667236300a032f18a8de6d796.json
+++ b/test/testData/testPools/0x5692950aa787b0502fac586425f7c0ab503c43e667236300a032f18a8de6d796.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x5ab001723607608fcc0a2bc085aac73145b7b55163359a0910fc71d5e327aaf1.json
+++ b/test/testData/testPools/0x5ab001723607608fcc0a2bc085aac73145b7b55163359a0910fc71d5e327aaf1.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x5d8ac083d65d9b16c701964a3a3b34585b883180473a187e9f9ed25531a5d0e3.json
+++ b/test/testData/testPools/0x5d8ac083d65d9b16c701964a3a3b34585b883180473a187e9f9ed25531a5d0e3.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x5fccb4ca1117b8a274bc6e939c63493203e5744cdf04d0045cf2bc08b01f4c18.json
+++ b/test/testData/testPools/0x5fccb4ca1117b8a274bc6e939c63493203e5744cdf04d0045cf2bc08b01f4c18.json
@@ -2541,7 +2541,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6042,7 +6041,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8387,7 +8385,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0x5fccb4ca1117b8a274bc6e939c63493203e5744cdf04d0045cf2bc08b01f4c18.json
+++ b/test/testData/testPools/0x5fccb4ca1117b8a274bc6e939c63493203e5744cdf04d0045cf2bc08b01f4c18.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -94,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -169,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -196,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -230,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -257,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -284,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -311,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -338,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -365,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -392,6 +405,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -419,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -467,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -508,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -535,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -562,6 +580,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +608,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -616,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -643,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -691,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -718,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -745,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -800,6 +825,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -848,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -875,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -902,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -929,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -956,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -997,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1024,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1065,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1092,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1161,6 +1196,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1230,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1257,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1284,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1311,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1338,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1365,6 +1406,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1392,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1419,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1467,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1494,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1542,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1569,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1596,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1623,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1664,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1691,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1718,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1745,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1772,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1799,6 +1854,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1826,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1867,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1894,6 +1952,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1987,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -1976,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2004,6 +2065,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2051,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2169,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2168,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2216,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2243,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2270,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2325,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2352,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2379,6 +2449,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2477,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2440,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2467,6 +2540,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2494,6 +2569,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2528,6 +2604,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2555,6 +2632,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2582,6 +2660,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2609,6 +2688,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2657,6 +2737,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2684,6 +2765,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2718,6 +2800,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2745,6 +2828,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2772,6 +2856,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2799,6 +2884,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2826,6 +2912,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2860,6 +2947,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2887,6 +2975,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2914,6 +3003,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2941,6 +3031,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -2975,6 +3066,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3044,6 +3136,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3078,6 +3171,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3105,6 +3199,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3132,6 +3227,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3159,6 +3255,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3200,6 +3297,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3227,6 +3325,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3254,6 +3353,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3281,6 +3381,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3308,6 +3409,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3335,6 +3437,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3376,6 +3479,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3424,6 +3528,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3451,6 +3556,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3478,6 +3584,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3505,6 +3612,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3532,6 +3640,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3601,6 +3710,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3628,6 +3738,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3655,6 +3766,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3682,6 +3794,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3709,6 +3822,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3736,6 +3850,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3763,6 +3878,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3790,6 +3906,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3824,6 +3941,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3851,6 +3969,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3878,6 +3997,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3905,6 +4025,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3939,6 +4060,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3966,6 +4088,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -3993,6 +4116,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4020,6 +4144,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4047,6 +4172,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4088,6 +4214,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4115,6 +4242,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4163,6 +4291,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4190,6 +4319,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4238,6 +4368,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4265,6 +4396,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4292,6 +4424,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4319,6 +4452,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4346,6 +4480,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4373,6 +4508,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4428,6 +4564,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4469,6 +4606,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4496,6 +4634,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4523,6 +4662,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4550,6 +4690,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4577,6 +4718,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4604,6 +4746,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4774,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4658,6 +4802,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4685,6 +4830,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4712,6 +4858,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4739,6 +4886,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4808,6 +4956,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4835,6 +4984,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4862,6 +5012,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4889,6 +5040,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -4930,6 +5082,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5152,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5026,6 +5180,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5053,6 +5208,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5080,6 +5236,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5114,6 +5271,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5141,6 +5299,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5168,6 +5327,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5195,6 +5355,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5222,6 +5383,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5249,6 +5411,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5276,6 +5439,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5303,6 +5467,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5495,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5357,6 +5523,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5412,6 +5579,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5439,6 +5607,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5473,6 +5642,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5500,6 +5670,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5527,6 +5698,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5554,6 +5726,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5581,6 +5754,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5608,6 +5782,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5635,6 +5810,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5669,6 +5845,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5696,6 +5873,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5723,6 +5901,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5778,6 +5957,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5805,6 +5985,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5832,6 +6013,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5859,6 +6041,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -5886,6 +6070,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5913,6 +6098,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5940,6 +6126,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5967,6 +6154,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5994,6 +6182,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6021,6 +6210,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6069,6 +6259,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6096,6 +6287,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6137,6 +6329,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6185,6 +6378,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6212,6 +6406,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6239,6 +6434,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6294,6 +6490,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6328,6 +6525,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6369,6 +6567,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6438,6 +6637,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6465,6 +6665,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6499,6 +6700,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6526,6 +6728,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6553,6 +6756,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6580,6 +6784,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6607,6 +6812,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6634,6 +6840,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6661,6 +6868,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6688,6 +6896,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6750,6 +6959,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6819,6 +7029,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6846,6 +7057,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6873,6 +7085,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6900,6 +7113,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6927,6 +7141,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6954,6 +7169,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -6988,6 +7204,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7015,6 +7232,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7042,6 +7260,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7069,6 +7288,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7103,6 +7323,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7130,6 +7351,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7157,6 +7379,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7184,6 +7407,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7239,6 +7463,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7266,6 +7491,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7293,6 +7519,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7320,6 +7547,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7347,6 +7575,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7374,6 +7603,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7401,6 +7631,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7428,6 +7659,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7455,6 +7687,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7482,6 +7715,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7551,6 +7785,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7827,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7855,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7646,6 +7883,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7673,6 +7911,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7700,6 +7939,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7727,6 +7967,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7761,6 +8002,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7788,6 +8030,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7822,6 +8065,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7849,6 +8093,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7876,6 +8121,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7924,6 +8170,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7951,6 +8198,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -7978,6 +8226,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8005,6 +8254,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8032,6 +8282,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8059,6 +8310,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8086,6 +8338,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8134,6 +8387,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8161,6 +8416,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8188,6 +8444,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8222,6 +8479,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8249,6 +8507,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8276,6 +8535,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8317,6 +8577,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8344,6 +8605,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8378,6 +8640,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8447,6 +8710,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8474,6 +8738,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8501,6 +8766,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8528,6 +8794,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8597,6 +8864,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8624,6 +8892,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8651,6 +8920,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8678,6 +8948,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8712,6 +8983,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8739,6 +9011,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8787,6 +9060,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8835,6 +9109,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8862,6 +9137,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +9165,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8916,6 +9193,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8943,6 +9221,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -8970,6 +9249,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8997,6 +9277,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9066,6 +9347,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9093,6 +9375,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9120,6 +9403,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9147,6 +9431,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9174,6 +9459,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9215,6 +9501,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9242,6 +9529,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -9311,6 +9599,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9359,6 +9648,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9386,6 +9676,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9455,6 +9746,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9503,6 +9795,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9530,6 +9823,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9557,6 +9851,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9584,6 +9879,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9611,6 +9907,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9638,6 +9935,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9665,6 +9963,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9692,6 +9991,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9719,6 +10019,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9746,6 +10047,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9773,6 +10075,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9800,6 +10103,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9827,6 +10131,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9854,6 +10159,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9881,6 +10187,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9908,6 +10215,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9935,6 +10243,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -9962,6 +10271,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10003,6 +10313,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10030,6 +10341,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10057,6 +10369,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10112,6 +10425,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10139,6 +10453,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10166,6 +10481,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10200,6 +10516,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10227,6 +10544,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10254,6 +10572,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10281,6 +10600,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10308,6 +10628,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10335,6 +10656,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10362,6 +10684,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10389,6 +10712,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10437,6 +10761,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10464,6 +10789,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10491,6 +10817,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10518,6 +10845,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10545,6 +10873,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10572,6 +10901,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10599,6 +10929,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10626,6 +10957,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10653,6 +10985,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10715,6 +11048,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10742,6 +11076,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10769,6 +11104,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10796,6 +11132,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10865,6 +11202,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10899,6 +11237,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -10926,6 +11265,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11293,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -10980,6 +11321,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11007,6 +11349,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11055,6 +11398,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11082,6 +11426,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11130,6 +11475,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11157,6 +11503,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11184,6 +11531,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11246,6 +11594,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11287,6 +11636,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11314,6 +11664,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11341,6 +11692,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11368,6 +11720,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11395,6 +11748,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11464,6 +11818,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11491,6 +11846,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11518,6 +11874,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11545,6 +11902,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11579,6 +11937,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11613,6 +11972,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11640,6 +12000,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11667,6 +12028,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11694,6 +12056,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11721,6 +12084,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11748,6 +12112,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11775,6 +12140,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11802,6 +12168,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11829,6 +12196,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11856,6 +12224,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11883,6 +12252,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -11910,6 +12280,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -11937,6 +12308,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -11964,6 +12336,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -11991,6 +12364,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12053,6 +12427,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12087,6 +12462,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12114,6 +12490,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12141,6 +12518,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12168,6 +12546,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12195,6 +12574,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12250,6 +12630,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12277,6 +12658,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12304,6 +12686,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12331,6 +12714,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12358,6 +12742,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12385,6 +12770,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12412,6 +12798,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12439,6 +12826,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12508,6 +12896,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12535,6 +12924,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12562,6 +12952,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12596,6 +12987,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12623,6 +13015,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +13043,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +13092,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12725,6 +13120,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +13162,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12821,6 +13218,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12855,6 +13253,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12924,6 +13323,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -12951,6 +13351,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -12978,6 +13379,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13005,6 +13407,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13032,6 +13435,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13059,6 +13463,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13086,6 +13491,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13113,6 +13519,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13140,6 +13547,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13188,6 +13596,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13257,6 +13666,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13284,6 +13694,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13325,6 +13736,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13352,6 +13764,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13386,6 +13799,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13841,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13496,6 +13911,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13523,6 +13939,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13550,6 +13967,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13577,6 +13995,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13604,6 +14023,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13659,6 +14079,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13686,6 +14107,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13713,6 +14135,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13740,6 +14163,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13767,6 +14191,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13794,6 +14219,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13821,6 +14247,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13848,6 +14275,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13875,6 +14303,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -13902,6 +14331,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13964,6 +14394,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -13991,6 +14422,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14018,6 +14450,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14045,6 +14478,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14072,6 +14506,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14534,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14604,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14195,6 +14632,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14222,6 +14660,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14249,6 +14688,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14276,6 +14716,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14317,6 +14758,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14344,6 +14786,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14371,6 +14814,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14398,6 +14842,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14425,6 +14870,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14452,6 +14898,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14479,6 +14926,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14506,6 +14954,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14575,6 +15024,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14602,6 +15052,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14629,6 +15080,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14656,6 +15108,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14683,6 +15136,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14710,6 +15164,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14737,6 +15192,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14764,6 +15220,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14798,6 +15255,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14825,6 +15283,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14852,6 +15311,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14879,6 +15339,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14906,6 +15367,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -14933,6 +15395,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -14960,6 +15423,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -14987,6 +15451,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15056,6 +15521,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15083,6 +15549,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15110,6 +15577,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15137,6 +15605,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15164,6 +15633,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15191,6 +15661,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15218,6 +15689,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15259,6 +15731,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15801,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15355,6 +15829,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15382,6 +15857,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15409,6 +15885,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15436,6 +15913,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15463,6 +15941,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15504,6 +15983,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15531,6 +16011,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15558,6 +16039,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15585,6 +16067,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15612,6 +16095,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15646,6 +16130,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15673,6 +16158,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15700,6 +16186,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15727,6 +16214,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -15796,6 +16284,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15823,6 +16312,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15850,6 +16340,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15877,6 +16368,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15904,6 +16396,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -15931,6 +16424,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15958,6 +16452,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -15985,6 +16480,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16012,6 +16508,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16039,6 +16536,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16066,6 +16564,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16107,6 +16606,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16134,6 +16634,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16161,6 +16662,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16223,6 +16725,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16250,6 +16753,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16277,6 +16781,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16304,6 +16809,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16331,6 +16837,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16358,6 +16865,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16385,6 +16893,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16412,6 +16921,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16439,6 +16949,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16466,6 +16977,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16493,6 +17005,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16548,6 +17061,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16582,6 +17096,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16609,6 +17124,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16636,6 +17152,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16663,6 +17180,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16690,6 +17208,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16717,6 +17236,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16744,6 +17264,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16785,6 +17306,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +17376,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -16888,6 +17411,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16915,6 +17439,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -16942,6 +17467,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16969,6 +17495,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -16996,6 +17523,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17030,6 +17558,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17057,6 +17586,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17084,6 +17614,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17153,6 +17684,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17180,6 +17712,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17207,6 +17740,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17234,6 +17768,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17261,6 +17796,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17288,6 +17824,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17315,6 +17852,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17342,6 +17880,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17404,6 +17943,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17431,6 +17971,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17458,6 +17999,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17485,6 +18027,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17512,6 +18055,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17560,6 +18104,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17601,6 +18146,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17628,6 +18174,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17655,6 +18202,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17689,6 +18237,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17716,6 +18265,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17743,6 +18293,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17784,6 +18335,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17811,6 +18363,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17845,6 +18398,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17872,6 +18426,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17899,6 +18454,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17926,6 +18482,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17953,6 +18510,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -17980,6 +18538,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18007,6 +18566,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18076,6 +18636,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18103,6 +18664,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18130,6 +18692,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18157,6 +18720,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18184,6 +18748,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -18211,6 +18776,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18280,6 +18846,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18307,6 +18874,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18376,6 +18944,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18403,6 +18972,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18430,6 +19000,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18457,6 +19028,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18484,6 +19056,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18511,6 +19084,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18538,6 +19112,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18572,6 +19147,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18606,6 +19182,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18633,6 +19210,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18660,6 +19238,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18715,6 +19294,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18742,6 +19322,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18769,6 +19350,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18796,6 +19378,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18830,6 +19413,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18857,6 +19441,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18884,6 +19469,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18911,6 +19497,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18938,6 +19525,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -18972,6 +19560,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18999,6 +19588,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19026,6 +19616,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19053,6 +19644,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19080,6 +19672,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19107,6 +19700,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19728,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19161,6 +19756,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19195,6 +19791,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19222,6 +19819,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19249,6 +19847,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19276,6 +19875,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19303,6 +19903,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19330,6 +19931,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19364,6 +19966,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19398,6 +20001,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19425,6 +20029,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19452,6 +20057,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19479,6 +20085,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19506,6 +20113,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -19533,6 +20141,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19560,6 +20169,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19587,6 +20197,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19635,6 +20246,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19662,6 +20274,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19689,6 +20302,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19716,6 +20330,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19743,6 +20358,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19770,6 +20386,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19797,6 +20414,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19824,6 +20442,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19851,6 +20470,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -19920,6 +20540,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19947,6 +20568,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19974,6 +20596,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20001,6 +20624,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20035,6 +20659,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20062,6 +20687,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20089,6 +20715,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20116,6 +20743,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20143,6 +20771,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20184,6 +20813,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20211,6 +20841,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20252,6 +20883,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20279,6 +20911,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20348,6 +20981,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20410,6 +21044,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20437,6 +21072,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20506,6 +21142,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20533,6 +21170,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20560,6 +21198,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20587,6 +21226,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20614,6 +21254,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20641,6 +21282,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20668,6 +21310,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20695,6 +21338,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20729,6 +21373,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20756,6 +21401,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -20818,6 +21464,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20845,6 +21492,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20872,6 +21520,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -20906,6 +21555,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20940,6 +21590,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -20981,6 +21632,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21036,6 +21688,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21063,6 +21716,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21090,6 +21744,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21159,6 +21814,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21186,6 +21842,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21227,6 +21884,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21254,6 +21912,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21281,6 +21940,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21308,6 +21968,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21335,6 +21996,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21369,6 +22031,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21396,6 +22059,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21423,6 +22087,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21450,6 +22115,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21477,6 +22143,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21504,6 +22171,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21545,6 +22213,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21572,6 +22241,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21599,6 +22269,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21626,6 +22297,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21653,6 +22325,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -21701,6 +22374,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21728,6 +22402,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21755,6 +22430,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21782,6 +22458,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21809,6 +22486,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21836,6 +22514,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21884,6 +22563,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -21918,6 +22598,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21945,6 +22626,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -21972,6 +22654,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21999,6 +22682,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22026,6 +22710,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22053,6 +22738,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22080,6 +22766,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22121,6 +22808,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22148,6 +22836,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22175,6 +22864,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22202,6 +22892,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22920,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22962,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22311,6 +23004,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22352,6 +23046,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22379,6 +23074,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22413,6 +23109,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22440,6 +23137,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -22467,6 +23165,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22494,6 +23193,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22521,6 +23221,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22569,6 +23270,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22610,6 +23312,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22637,6 +23340,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22664,6 +23368,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22733,6 +23438,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22767,6 +23473,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22794,6 +23501,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22828,6 +23536,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22862,6 +23571,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22889,6 +23599,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22916,6 +23627,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -22943,6 +23655,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22970,6 +23683,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22997,6 +23711,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23024,6 +23739,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23051,6 +23767,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23078,6 +23795,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23105,6 +23823,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23160,6 +23879,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23187,6 +23907,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23221,6 +23942,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23248,6 +23970,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23275,6 +23998,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23316,6 +24040,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23343,6 +24068,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23370,6 +24096,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23397,6 +24124,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23424,6 +24152,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23451,6 +24180,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23485,6 +24215,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23512,6 +24243,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23546,6 +24278,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23573,6 +24306,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23621,6 +24355,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23648,6 +24383,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23675,6 +24411,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23702,6 +24439,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23729,6 +24467,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23756,6 +24495,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23783,6 +24523,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23810,6 +24551,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23837,6 +24579,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23864,6 +24607,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -23891,6 +24635,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -23918,6 +24663,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -23966,6 +24712,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24014,6 +24761,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24041,6 +24789,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24068,6 +24817,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24095,6 +24845,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24122,6 +24873,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24149,6 +24901,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24176,6 +24929,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24203,6 +24957,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24230,6 +24985,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24257,6 +25013,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24284,6 +25041,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24311,6 +25069,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24338,6 +25097,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24372,6 +25132,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24434,6 +25195,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24461,6 +25223,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24488,6 +25251,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24515,6 +25279,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +25321,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -24625,6 +25391,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24694,6 +25461,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24721,6 +25489,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24748,6 +25517,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24817,6 +25587,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24844,6 +25615,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24871,6 +25643,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24898,6 +25671,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -24932,6 +25706,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24973,6 +25748,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25000,6 +25776,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25027,6 +25804,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25054,6 +25832,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25081,6 +25860,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25108,6 +25888,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25135,6 +25916,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25162,6 +25944,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25189,6 +25972,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25230,6 +26014,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25257,6 +26042,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25284,6 +26070,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25318,6 +26105,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25345,6 +26133,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25393,6 +26182,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25427,6 +26217,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25454,6 +26245,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25481,6 +26273,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25508,6 +26301,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25535,6 +26329,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25562,6 +26357,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25589,6 +26385,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25616,6 +26413,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25650,6 +26448,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25677,6 +26476,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25704,6 +26504,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25738,6 +26539,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25765,6 +26567,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25792,6 +26595,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25840,6 +26644,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25867,6 +26672,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -25894,6 +26700,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25921,6 +26728,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25955,6 +26763,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25996,6 +26805,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26833,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26050,6 +26861,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26077,6 +26889,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26139,6 +26952,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26166,6 +26980,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26193,6 +27008,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26220,6 +27036,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26247,6 +27064,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26274,6 +27092,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26301,6 +27120,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26335,6 +27155,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26362,6 +27183,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26431,6 +27253,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26458,6 +27281,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26527,6 +27351,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26554,6 +27379,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26581,6 +27407,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26608,6 +27435,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26635,6 +27463,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26662,6 +27491,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26689,6 +27519,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26716,6 +27547,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26743,6 +27575,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26770,6 +27603,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26797,6 +27631,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +27694,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27764,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -26955,6 +27792,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -26982,6 +27820,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27009,6 +27848,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27036,6 +27876,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27070,6 +27911,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27097,6 +27939,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27124,6 +27967,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27172,6 +28016,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27199,6 +28044,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27240,6 +28086,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27267,6 +28114,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27308,6 +28156,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27335,6 +28184,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +28212,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27396,6 +28247,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27423,6 +28275,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27450,6 +28303,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27477,6 +28331,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27504,6 +28359,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27531,6 +28387,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27558,6 +28415,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27585,6 +28443,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27612,6 +28471,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27639,6 +28499,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27666,6 +28527,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27693,6 +28555,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27720,6 +28583,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27747,6 +28611,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27774,6 +28639,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +28667,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27849,6 +28716,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -27876,6 +28744,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27903,6 +28772,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -27930,6 +28800,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -27957,6 +28828,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27984,6 +28856,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28011,6 +28884,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28038,6 +28912,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28065,6 +28940,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28092,6 +28968,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28119,6 +28996,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28146,6 +29024,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28180,6 +29059,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28207,6 +29087,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28234,6 +29115,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28261,6 +29143,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28288,6 +29171,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28357,6 +29241,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28384,6 +29269,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28411,6 +29297,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28438,6 +29325,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28465,6 +29353,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28492,6 +29381,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28519,6 +29409,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28546,6 +29437,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28573,6 +29465,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28600,6 +29493,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28627,6 +29521,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28654,6 +29549,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28688,6 +29584,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28715,6 +29612,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28749,6 +29647,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28776,6 +29675,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28803,6 +29703,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28830,6 +29731,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -28857,6 +29759,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28912,6 +29815,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28939,6 +29843,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29008,6 +29913,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29077,6 +29983,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29104,6 +30011,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29131,6 +30039,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29158,6 +30067,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29185,6 +30095,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29226,6 +30137,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29253,6 +30165,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29280,6 +30193,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29335,6 +30249,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29362,6 +30277,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29389,6 +30305,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29416,6 +30333,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29457,6 +30375,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29484,6 +30403,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29518,6 +30438,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29545,6 +30466,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29572,6 +30494,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29599,6 +30522,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29626,6 +30550,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29660,6 +30585,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29687,6 +30613,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29714,6 +30641,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29741,6 +30669,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29768,6 +30697,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29795,6 +30725,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29822,6 +30753,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -29849,6 +30781,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29918,6 +30851,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -29945,6 +30879,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -29972,6 +30907,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -29999,6 +30935,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30026,6 +30963,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30053,6 +30991,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30080,6 +31019,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30107,6 +31047,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30148,6 +31089,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30175,6 +31117,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30202,6 +31145,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30229,6 +31173,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30256,6 +31201,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30283,6 +31229,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30310,6 +31257,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30337,6 +31285,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30364,6 +31313,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30391,6 +31341,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30418,6 +31369,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30445,6 +31397,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -30472,6 +31425,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30499,6 +31453,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30533,6 +31488,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30595,6 +31551,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30622,6 +31579,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30649,6 +31607,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30676,6 +31635,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30703,6 +31663,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30730,6 +31691,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30757,6 +31719,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30784,6 +31747,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30811,6 +31775,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30866,6 +31831,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -30893,6 +31859,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30920,6 +31887,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30947,6 +31915,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -30974,6 +31943,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31001,6 +31971,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31035,6 +32006,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31062,6 +32034,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31089,6 +32062,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31116,6 +32090,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31143,6 +32118,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31170,6 +32146,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31197,6 +32174,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31224,6 +32202,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31251,6 +32230,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31278,6 +32258,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31305,6 +32286,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31346,6 +32328,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +32384,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31428,6 +32412,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31455,6 +32440,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31482,6 +32468,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31509,6 +32496,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31536,6 +32524,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31563,6 +32552,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31590,6 +32580,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31645,6 +32636,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31672,6 +32664,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31699,6 +32692,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31754,6 +32748,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31788,6 +32783,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31843,6 +32839,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31877,6 +32874,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31904,6 +32902,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -31938,6 +32937,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31986,6 +32986,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32027,6 +33028,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32054,6 +33056,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32081,6 +33084,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32108,6 +33112,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32135,6 +33140,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32162,6 +33168,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32196,6 +33203,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32223,6 +33231,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32250,6 +33259,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32277,6 +33287,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32304,6 +33315,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32331,6 +33343,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32358,6 +33371,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32439,6 +33453,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +33670,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33930,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +34168,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +34250,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +34347,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +34423,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +34499,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +34527,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +34671,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +34814,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +34842,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +35372,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +35693,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +35721,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +35776,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +36048,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +36076,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +36125,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +36831,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +37391,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +37419,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +37549,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +38004,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +38596,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +38787,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +39080,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +39122,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +39191,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +39362,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +39444,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +39641,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +39852,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +40111,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +40648,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +40826,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40969,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x5fd850f563e180d962bc8e243fbfa27a410e9610faff5f1ecbd2ccdf6599f907.json
+++ b/test/testData/testPools/0x5fd850f563e180d962bc8e243fbfa27a410e9610faff5f1ecbd2ccdf6599f907.json
@@ -2756,7 +2756,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6541,7 +6540,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -9081,7 +9079,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -37366,7 +37363,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0x5fd850f563e180d962bc8e243fbfa27a410e9610faff5f1ecbd2ccdf6599f907.json
+++ b/test/testData/testPools/0x5fd850f563e180d962bc8e243fbfa27a410e9610faff5f1ecbd2ccdf6599f907.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -42,6 +43,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -71,6 +73,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -100,6 +103,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -129,6 +133,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -182,6 +187,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -211,6 +217,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -248,6 +255,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -277,6 +285,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -306,6 +315,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -335,6 +345,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -364,6 +375,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -393,6 +405,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -422,6 +435,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -451,6 +465,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -504,6 +519,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -549,6 +565,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -578,6 +595,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -607,6 +625,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -636,6 +655,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -665,6 +685,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -694,6 +715,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -747,6 +769,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -776,6 +799,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -805,6 +829,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -866,6 +891,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -919,6 +945,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -948,6 +975,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -977,6 +1005,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -1006,6 +1035,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -1035,6 +1065,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1080,6 +1111,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1109,6 +1141,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1154,6 +1187,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1183,6 +1217,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1260,6 +1295,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1337,6 +1373,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1366,6 +1403,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1395,6 +1433,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1424,6 +1463,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1453,6 +1493,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1482,6 +1523,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1511,6 +1553,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1540,6 +1583,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1593,6 +1637,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1622,6 +1667,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1675,6 +1721,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1704,6 +1751,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1733,6 +1781,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1762,6 +1811,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1807,6 +1857,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1836,6 +1887,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1865,6 +1917,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1894,6 +1947,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1923,6 +1977,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1952,6 +2007,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1981,6 +2037,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -2026,6 +2083,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -2055,6 +2113,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2092,6 +2151,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2145,6 +2205,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2175,6 +2236,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2227,6 +2289,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2288,6 +2351,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2357,6 +2421,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2410,6 +2475,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2439,6 +2505,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2468,6 +2535,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2529,6 +2597,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2558,6 +2627,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2587,6 +2657,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2616,6 +2687,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2653,6 +2725,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2682,6 +2755,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2711,6 +2786,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2748,6 +2824,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2777,6 +2854,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2806,6 +2884,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2835,6 +2914,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2888,6 +2968,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2917,6 +2998,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2954,6 +3036,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2983,6 +3066,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -3012,6 +3096,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3041,6 +3126,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -3070,6 +3156,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3107,6 +3194,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -3136,6 +3224,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -3165,6 +3254,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -3194,6 +3284,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3231,6 +3322,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3308,6 +3400,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3345,6 +3438,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3374,6 +3468,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3403,6 +3498,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3432,6 +3528,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3477,6 +3574,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3506,6 +3604,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3535,6 +3634,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3564,6 +3664,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3593,6 +3694,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3622,6 +3724,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3667,6 +3770,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3720,6 +3824,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3749,6 +3854,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3778,6 +3884,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3807,6 +3914,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3836,6 +3944,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3913,6 +4022,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3942,6 +4052,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3971,6 +4082,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4000,6 +4112,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -4029,6 +4142,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -4058,6 +4172,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -4087,6 +4202,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -4116,6 +4232,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -4153,6 +4270,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -4182,6 +4300,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4211,6 +4330,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -4240,6 +4360,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4277,6 +4398,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4306,6 +4428,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4335,6 +4458,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4364,6 +4488,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4393,6 +4518,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4438,6 +4564,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4467,6 +4594,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4520,6 +4648,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4549,6 +4678,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4602,6 +4732,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4762,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4660,6 +4792,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4689,6 +4822,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4718,6 +4852,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4747,6 +4882,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4808,6 +4944,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4853,6 +4990,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4882,6 +5020,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4911,6 +5050,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4940,6 +5080,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4969,6 +5110,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4998,6 +5140,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5027,6 +5170,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5056,6 +5200,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -5085,6 +5230,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5114,6 +5260,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5143,6 +5290,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -5220,6 +5368,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -5249,6 +5398,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5278,6 +5428,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5307,6 +5458,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5352,6 +5504,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5429,6 +5582,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5458,6 +5612,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5487,6 +5642,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5516,6 +5672,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5553,6 +5710,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5582,6 +5740,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5611,6 +5770,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5640,6 +5800,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5669,6 +5830,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5698,6 +5860,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5727,6 +5890,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5756,6 +5920,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5785,6 +5950,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5814,6 +5980,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5875,6 +6042,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5904,6 +6072,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5941,6 +6110,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5970,6 +6140,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5999,6 +6170,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -6028,6 +6200,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -6057,6 +6230,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -6086,6 +6260,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6115,6 +6290,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -6152,6 +6328,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6181,6 +6358,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -6210,6 +6388,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -6271,6 +6450,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -6300,6 +6480,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -6329,6 +6510,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -6358,6 +6540,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6387,6 +6571,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -6416,6 +6601,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6445,6 +6631,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6474,6 +6661,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6503,6 +6691,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6532,6 +6721,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6585,6 +6775,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6614,6 +6805,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6659,6 +6851,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6712,6 +6905,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6741,6 +6935,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6770,6 +6965,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6831,6 +7027,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6868,6 +7065,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6913,6 +7111,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6990,6 +7189,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7019,6 +7219,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -7056,6 +7257,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -7085,6 +7287,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -7114,6 +7317,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7143,6 +7347,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7172,6 +7377,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -7201,6 +7407,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -7230,6 +7437,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7259,6 +7467,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -7328,6 +7537,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -7405,6 +7615,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -7434,6 +7645,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7463,6 +7675,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7492,6 +7705,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7521,6 +7735,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7550,6 +7765,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7587,6 +7803,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7616,6 +7833,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7645,6 +7863,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7674,6 +7893,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7711,6 +7931,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7740,6 +7961,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7769,6 +7991,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7798,6 +8021,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7859,6 +8083,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7888,6 +8113,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7917,6 +8143,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7946,6 +8173,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7975,6 +8203,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -8004,6 +8233,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -8033,6 +8263,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -8062,6 +8293,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8091,6 +8323,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -8120,6 +8353,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -8197,6 +8431,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8242,6 +8477,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8271,6 +8507,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -8300,6 +8537,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -8329,6 +8567,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -8358,6 +8597,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8387,6 +8627,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -8424,6 +8665,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8453,6 +8695,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -8490,6 +8733,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8519,6 +8763,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -8548,6 +8793,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -8601,6 +8847,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -8630,6 +8877,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8659,6 +8907,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8688,6 +8937,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8717,6 +8967,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8746,6 +8997,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8775,6 +9027,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8828,6 +9081,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8857,6 +9112,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8886,6 +9142,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8923,6 +9180,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8952,6 +9210,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8981,6 +9240,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9026,6 +9286,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9055,6 +9316,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9092,6 +9354,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -9169,6 +9432,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9198,6 +9462,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9227,6 +9492,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9256,6 +9522,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -9333,6 +9600,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9362,6 +9630,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -9391,6 +9660,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -9420,6 +9690,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -9457,6 +9728,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9486,6 +9758,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -9539,6 +9812,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -9592,6 +9866,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9621,6 +9896,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9650,6 +9926,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9679,6 +9956,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -9708,6 +9986,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9737,6 +10016,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9766,6 +10046,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9843,6 +10124,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9872,6 +10154,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9901,6 +10184,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9930,6 +10214,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9959,6 +10244,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -10004,6 +10290,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -10033,6 +10320,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10110,6 +10398,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -10163,6 +10452,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -10192,6 +10482,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -10269,6 +10560,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -10322,6 +10614,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -10351,6 +10644,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -10380,6 +10674,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -10409,6 +10704,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -10438,6 +10734,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -10467,6 +10764,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10496,6 +10794,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -10525,6 +10824,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -10554,6 +10854,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -10583,6 +10884,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10612,6 +10914,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -10641,6 +10944,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10670,6 +10974,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -10699,6 +11004,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +11034,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -10757,6 +11064,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -10786,6 +11094,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10815,6 +11124,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10860,6 +11170,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10889,6 +11200,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10918,6 +11230,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10979,6 +11292,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -11008,6 +11322,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -11037,6 +11352,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -11074,6 +11390,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -11103,6 +11420,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11132,6 +11450,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11161,6 +11480,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -11190,6 +11510,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -11219,6 +11540,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11248,6 +11570,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11277,6 +11600,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11330,6 +11654,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11359,6 +11684,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11388,6 +11714,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11417,6 +11744,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -11446,6 +11774,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -11475,6 +11804,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11504,6 +11834,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -11533,6 +11864,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -11562,6 +11894,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11631,6 +11964,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -11660,6 +11994,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -11689,6 +12024,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -11718,6 +12054,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -11795,6 +12132,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -11832,6 +12170,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11861,6 +12200,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11890,6 +12230,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11919,6 +12260,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11948,6 +12290,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -12001,6 +12344,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -12030,6 +12374,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12083,6 +12428,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12112,6 +12458,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12141,6 +12488,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12210,6 +12558,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -12255,6 +12604,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -12284,6 +12634,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -12313,6 +12664,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -12342,6 +12694,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12371,6 +12724,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12448,6 +12802,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12477,6 +12832,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12506,6 +12862,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -12535,6 +12892,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12572,6 +12930,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -12609,6 +12968,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -12638,6 +12998,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12667,6 +13028,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12696,6 +13058,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -12725,6 +13088,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -12754,6 +13118,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -12783,6 +13148,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12812,6 +13178,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -12841,6 +13208,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12870,6 +13238,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12899,6 +13268,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12928,6 +13298,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12957,6 +13328,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12986,6 +13358,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -13015,6 +13388,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13084,6 +13458,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13121,6 +13496,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -13150,6 +13526,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13179,6 +13556,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13208,6 +13586,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13237,6 +13616,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13298,6 +13678,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13327,6 +13708,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -13356,6 +13738,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13385,6 +13768,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13414,6 +13798,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13443,6 +13828,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13472,6 +13858,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13501,6 +13888,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13578,6 +13966,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -13607,6 +13996,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -13636,6 +14026,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -13673,6 +14064,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -13702,6 +14094,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13731,6 +14124,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13784,6 +14178,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13813,6 +14208,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13858,6 +14254,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13919,6 +14316,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -13956,6 +14354,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -14033,6 +14432,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -14062,6 +14462,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -14091,6 +14492,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14120,6 +14522,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -14149,6 +14552,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14178,6 +14582,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14207,6 +14612,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14236,6 +14642,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -14265,6 +14672,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -14318,6 +14726,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14395,6 +14804,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14424,6 +14834,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14469,6 +14880,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14498,6 +14910,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -14535,6 +14948,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14580,6 +14994,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14657,6 +15072,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -14686,6 +15102,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14715,6 +15132,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14744,6 +15162,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -14773,6 +15192,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -14834,6 +15254,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14863,6 +15284,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -14892,6 +15314,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -14921,6 +15344,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14950,6 +15374,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -14979,6 +15404,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -15008,6 +15434,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15037,6 +15464,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -15066,6 +15494,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -15095,6 +15524,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15164,6 +15594,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -15193,6 +15624,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -15222,6 +15654,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15251,6 +15684,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -15280,6 +15714,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15309,6 +15744,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15386,6 +15822,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15415,6 +15852,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -15444,6 +15882,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -15473,6 +15912,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -15502,6 +15942,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15547,6 +15988,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -15576,6 +16018,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -15605,6 +16048,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -15634,6 +16078,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -15663,6 +16108,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15692,6 +16138,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15721,6 +16168,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15750,6 +16198,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -15827,6 +16276,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15856,6 +16306,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15885,6 +16336,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15914,6 +16366,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15943,6 +16396,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15972,6 +16426,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -16001,6 +16456,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16030,6 +16486,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16067,6 +16524,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -16096,6 +16554,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -16125,6 +16584,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -16154,6 +16614,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16183,6 +16644,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -16212,6 +16674,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -16241,6 +16704,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16270,6 +16734,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -16347,6 +16812,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -16376,6 +16842,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -16405,6 +16872,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16434,6 +16902,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -16463,6 +16932,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -16492,6 +16962,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16521,6 +16992,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -16566,6 +17038,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16643,6 +17116,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16672,6 +17146,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -16701,6 +17176,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16730,6 +17206,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -16759,6 +17236,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16788,6 +17266,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -16833,6 +17312,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16862,6 +17342,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -16891,6 +17372,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -16920,6 +17402,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -16949,6 +17432,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16986,6 +17470,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -17015,6 +17500,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17044,6 +17530,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -17073,6 +17560,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17150,6 +17638,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17179,6 +17668,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -17208,6 +17698,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -17237,6 +17728,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -17266,6 +17758,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -17295,6 +17788,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17324,6 +17818,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -17353,6 +17848,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17382,6 +17878,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -17411,6 +17908,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -17440,6 +17938,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17485,6 +17984,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17514,6 +18014,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17543,6 +18044,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -17612,6 +18114,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17641,6 +18144,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17670,6 +18174,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17699,6 +18204,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -17728,6 +18234,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -17757,6 +18264,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17786,6 +18294,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -17815,6 +18324,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17844,6 +18354,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -17873,6 +18384,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -17902,6 +18414,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17963,6 +18476,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -18000,6 +18514,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -18029,6 +18544,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18058,6 +18574,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18087,6 +18604,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18116,6 +18634,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -18145,6 +18664,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -18174,6 +18694,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -18219,6 +18740,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -18296,6 +18818,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18333,6 +18856,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -18362,6 +18886,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -18391,6 +18916,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -18420,6 +18946,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -18449,6 +18976,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -18486,6 +19014,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18515,6 +19044,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18544,6 +19074,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18621,6 +19152,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -18650,6 +19182,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -18679,6 +19212,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18708,6 +19242,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18737,6 +19272,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -18766,6 +19302,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18795,6 +19332,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18824,6 +19362,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18893,6 +19432,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -18922,6 +19462,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -18951,6 +19492,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -18980,6 +19522,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -19009,6 +19552,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -19062,6 +19606,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19107,6 +19652,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -19136,6 +19682,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19165,6 +19712,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -19202,6 +19750,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -19231,6 +19780,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19260,6 +19810,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19305,6 +19856,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -19334,6 +19886,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -19371,6 +19924,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -19400,6 +19954,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -19429,6 +19984,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19458,6 +20014,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -19487,6 +20044,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -19516,6 +20074,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19545,6 +20104,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -19622,6 +20182,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19651,6 +20212,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -19680,6 +20242,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19709,6 +20272,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19738,6 +20302,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19767,6 +20332,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -19844,6 +20410,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -19873,6 +20440,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -19950,6 +20518,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -19979,6 +20548,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -20008,6 +20578,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20037,6 +20608,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -20066,6 +20638,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20095,6 +20668,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -20124,6 +20698,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -20161,6 +20736,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -20198,6 +20774,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20227,6 +20804,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -20256,6 +20834,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20317,6 +20896,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20346,6 +20926,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20375,6 +20956,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -20404,6 +20986,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -20441,6 +21024,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -20470,6 +21054,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -20499,6 +21084,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20528,6 +21114,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -20557,6 +21144,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -20594,6 +21182,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20623,6 +21212,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -20652,6 +21242,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20681,6 +21272,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -20710,6 +21302,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -20739,6 +21332,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20768,6 +21362,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20797,6 +21392,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20834,6 +21430,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20863,6 +21460,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20892,6 +21490,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -20921,6 +21520,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20950,6 +21550,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -20979,6 +21580,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -21016,6 +21618,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21053,6 +21656,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -21082,6 +21686,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -21111,6 +21716,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -21140,6 +21746,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21169,6 +21776,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21198,6 +21806,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21227,6 +21836,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -21256,6 +21866,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21309,6 +21920,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21338,6 +21950,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -21367,6 +21980,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -21396,6 +22010,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -21425,6 +22040,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -21454,6 +22070,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -21483,6 +22100,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -21512,6 +22130,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -21541,6 +22160,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -21618,6 +22238,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21647,6 +22268,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21676,6 +22298,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21705,6 +22328,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -21742,6 +22366,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21771,6 +22396,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -21800,6 +22426,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -21829,6 +22456,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21858,6 +22486,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21903,6 +22532,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21932,6 +22562,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21977,6 +22608,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22006,6 +22638,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -22083,6 +22716,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -22152,6 +22786,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -22181,6 +22816,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22258,6 +22894,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22287,6 +22924,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22316,6 +22954,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -22345,6 +22984,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -22374,6 +23014,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22403,6 +23044,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -22432,6 +23074,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -22461,6 +23104,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -22498,6 +23142,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22527,6 +23172,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22596,6 +23242,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22625,6 +23272,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -22654,6 +23302,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -22691,6 +23340,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22728,6 +23378,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -22773,6 +23424,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -22834,6 +23486,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -22863,6 +23516,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -22892,6 +23546,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -22969,6 +23624,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -22998,6 +23654,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -23043,6 +23700,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23072,6 +23730,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23101,6 +23760,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23130,6 +23790,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23159,6 +23820,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -23196,6 +23858,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23225,6 +23888,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23254,6 +23918,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -23283,6 +23948,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -23312,6 +23978,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -23341,6 +24008,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -23386,6 +24054,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -23415,6 +24084,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23444,6 +24114,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -23473,6 +24144,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -23502,6 +24174,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23555,6 +24228,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23584,6 +24258,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23613,6 +24288,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -23642,6 +24318,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23671,6 +24348,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -23700,6 +24378,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -23753,6 +24432,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23790,6 +24470,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23819,6 +24500,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23848,6 +24530,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23877,6 +24560,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23906,6 +24590,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -23935,6 +24620,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23964,6 +24650,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -24009,6 +24696,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -24038,6 +24726,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -24067,6 +24756,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -24096,6 +24786,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -24125,6 +24816,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -24170,6 +24862,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -24215,6 +24908,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -24260,6 +24954,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24289,6 +24984,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -24326,6 +25022,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -24355,6 +25052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -24384,6 +25082,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24413,6 +25112,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -24442,6 +25142,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -24495,6 +25196,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -24540,6 +25242,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24569,6 +25272,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24598,6 +25302,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24675,6 +25380,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -24712,6 +25418,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -24741,6 +25448,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24778,6 +25486,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -24815,6 +25524,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -24844,6 +25554,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -24873,6 +25584,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -24902,6 +25614,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24931,6 +25644,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -24960,6 +25674,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -24989,6 +25704,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25018,6 +25734,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25047,6 +25764,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -25076,6 +25794,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -25137,6 +25856,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -25166,6 +25886,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -25203,6 +25924,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25232,6 +25954,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25261,6 +25984,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -25306,6 +26030,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -25335,6 +26060,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25364,6 +26090,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25393,6 +26120,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25422,6 +26150,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -25451,6 +26180,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -25488,6 +26218,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25517,6 +26248,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -25554,6 +26286,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25583,6 +26316,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25636,6 +26370,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -25665,6 +26400,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -25694,6 +26430,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -25723,6 +26460,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -25752,6 +26490,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -25781,6 +26520,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -25810,6 +26550,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -25839,6 +26580,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -25868,6 +26610,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -25897,6 +26640,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25926,6 +26670,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -25955,6 +26700,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -26008,6 +26754,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -26061,6 +26808,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -26090,6 +26838,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -26119,6 +26868,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -26148,6 +26898,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26177,6 +26928,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -26206,6 +26958,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26235,6 +26988,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -26264,6 +27018,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -26293,6 +27048,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -26322,6 +27078,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -26351,6 +27108,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -26380,6 +27138,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -26409,6 +27168,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26446,6 +27206,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -26515,6 +27276,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26544,6 +27306,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -26573,6 +27336,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26602,6 +27366,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26647,6 +27412,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26724,6 +27490,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -26801,6 +27568,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -26830,6 +27598,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -26859,6 +27628,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26936,6 +27706,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26965,6 +27736,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -26994,6 +27766,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -27023,6 +27796,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27060,6 +27834,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27105,6 +27880,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27134,6 +27910,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -27163,6 +27940,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -27192,6 +27970,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -27221,6 +28000,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27250,6 +28030,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -27279,6 +28060,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27308,6 +28090,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27337,6 +28120,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -27382,6 +28166,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -27411,6 +28196,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -27440,6 +28226,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -27477,6 +28264,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27506,6 +28294,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -27559,6 +28348,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27596,6 +28386,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -27625,6 +28416,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27654,6 +28446,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -27683,6 +28476,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -27712,6 +28506,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -27741,6 +28536,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -27770,6 +28566,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -27799,6 +28596,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -27836,6 +28634,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -27865,6 +28664,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27894,6 +28694,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -27931,6 +28732,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27960,6 +28762,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -27989,6 +28792,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28042,6 +28846,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28071,6 +28876,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -28100,6 +28906,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28129,6 +28936,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28166,6 +28974,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28211,6 +29020,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -28240,6 +29050,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28269,6 +29080,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28298,6 +29110,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -28367,6 +29180,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -28396,6 +29210,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -28425,6 +29240,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28454,6 +29270,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -28483,6 +29300,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28512,6 +29330,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -28541,6 +29360,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -28578,6 +29398,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -28607,6 +29428,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -28684,6 +29506,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -28713,6 +29536,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -28790,6 +29614,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -28819,6 +29644,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28848,6 +29674,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -28877,6 +29704,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -28906,6 +29734,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28935,6 +29764,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -28964,6 +29794,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -28993,6 +29824,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29022,6 +29854,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -29051,6 +29884,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -29080,6 +29914,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29149,6 +29984,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -29226,6 +30062,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -29255,6 +30092,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -29284,6 +30122,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -29313,6 +30152,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -29342,6 +30182,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29379,6 +30220,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -29408,6 +30250,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -29437,6 +30280,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -29490,6 +30334,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29519,6 +30364,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -29564,6 +30410,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -29593,6 +30440,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -29638,6 +30486,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -29667,6 +30516,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -29696,6 +30546,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -29733,6 +30584,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29762,6 +30614,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29791,6 +30644,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29820,6 +30674,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -29849,6 +30704,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -29878,6 +30734,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -29907,6 +30764,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -29936,6 +30794,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29965,6 +30824,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -29994,6 +30854,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -30023,6 +30884,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -30052,6 +30914,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30081,6 +30944,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30110,6 +30974,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -30139,6 +31004,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30168,6 +31034,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30221,6 +31088,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -30250,6 +31118,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30279,6 +31148,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -30308,6 +31178,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -30337,6 +31208,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30366,6 +31238,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -30395,6 +31268,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -30424,6 +31298,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -30453,6 +31328,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -30482,6 +31358,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -30511,6 +31388,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -30540,6 +31418,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -30577,6 +31456,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -30606,6 +31486,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30635,6 +31516,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -30664,6 +31546,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -30693,6 +31576,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -30770,6 +31654,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30799,6 +31684,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -30828,6 +31714,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30857,6 +31744,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30886,6 +31774,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30915,6 +31804,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -30944,6 +31834,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30973,6 +31864,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -31002,6 +31894,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31031,6 +31924,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31060,6 +31954,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31089,6 +31984,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -31126,6 +32022,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -31155,6 +32052,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31192,6 +32090,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -31221,6 +32120,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -31250,6 +32150,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -31279,6 +32180,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -31308,6 +32210,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31369,6 +32272,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31398,6 +32302,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31475,6 +32380,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -31552,6 +32458,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31581,6 +32488,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31610,6 +32518,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31639,6 +32548,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31668,6 +32578,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -31713,6 +32624,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -31742,6 +32654,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -31771,6 +32684,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -31832,6 +32746,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -31861,6 +32776,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -31890,6 +32806,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31919,6 +32836,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31964,6 +32882,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -31993,6 +32912,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -32030,6 +32950,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -32059,6 +32980,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -32088,6 +33010,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -32117,6 +33040,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -32146,6 +33070,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -32183,6 +33108,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32212,6 +33138,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -32241,6 +33168,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -32270,6 +33198,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -32299,6 +33228,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -32328,6 +33258,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -32357,6 +33288,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -32386,6 +33318,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32463,6 +33396,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -32492,6 +33426,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -32521,6 +33456,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -32550,6 +33486,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -32579,6 +33516,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32608,6 +33546,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -32637,6 +33576,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -32666,6 +33606,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32711,6 +33652,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -32740,6 +33682,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -32769,6 +33712,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -32798,6 +33742,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -32827,6 +33772,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -32856,6 +33802,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -32885,6 +33832,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -32914,6 +33862,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -32943,6 +33892,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -32972,6 +33922,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -33001,6 +33952,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -33030,6 +33982,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -33059,6 +34012,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -33088,6 +34042,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33125,6 +34080,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -33194,6 +34150,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -33223,6 +34180,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -33252,6 +34210,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -33281,6 +34240,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -33310,6 +34270,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -33339,6 +34300,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -33368,6 +34330,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -33397,6 +34360,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -33426,6 +34390,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -33487,6 +34452,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -33516,6 +34482,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -33545,6 +34512,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -33574,6 +34542,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -33603,6 +34572,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33632,6 +34602,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33669,6 +34640,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -33698,6 +34670,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -33727,6 +34700,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -33756,6 +34730,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -33785,6 +34760,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -33814,6 +34790,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -33843,6 +34820,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33872,6 +34850,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -33901,6 +34880,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -33930,6 +34910,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -33959,6 +34940,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -34004,6 +34986,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -34065,6 +35048,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34094,6 +35078,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34123,6 +35108,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34152,6 +35138,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34181,6 +35168,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -34210,6 +35198,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -34239,6 +35228,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -34268,6 +35258,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -34329,6 +35320,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -34358,6 +35350,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34387,6 +35380,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34448,6 +35442,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -34485,6 +35480,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34546,6 +35542,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34583,6 +35580,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34612,6 +35610,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -34649,6 +35648,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34702,6 +35702,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -34747,6 +35748,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -34776,6 +35778,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -34805,6 +35808,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -34834,6 +35838,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -34863,6 +35868,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -34892,6 +35898,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -34929,6 +35936,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -34958,6 +35966,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -34987,6 +35996,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -35016,6 +36026,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -35045,6 +36056,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35074,6 +36086,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35103,6 +36116,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35132,6 +36146,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -35161,6 +36176,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -35190,6 +36206,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -35219,6 +36236,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35248,6 +36266,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -35277,6 +36296,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35306,6 +36326,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -35335,6 +36356,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -35364,6 +36386,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35393,6 +36416,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -35422,6 +36446,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35451,6 +36476,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -35504,6 +36530,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35549,6 +36576,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35578,6 +36606,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -35607,6 +36636,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -35636,6 +36666,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35705,6 +36736,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -35734,6 +36766,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -35763,6 +36796,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35792,6 +36826,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -35829,6 +36864,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -35858,6 +36894,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -35887,6 +36924,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35932,6 +36970,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -35961,6 +37000,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35990,6 +37030,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -36019,6 +37060,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -36048,6 +37090,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36125,6 +37168,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -36154,6 +37198,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -36207,6 +37252,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -36236,6 +37282,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36289,6 +37336,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36318,6 +37366,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -36347,6 +37397,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -36384,6 +37435,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -36429,6 +37481,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36474,6 +37527,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -36503,6 +37557,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36532,6 +37587,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -36561,6 +37617,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -36598,6 +37655,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -36627,6 +37685,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -36654,6 +37713,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -36681,6 +37741,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -36708,6 +37769,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -36735,6 +37797,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -36762,6 +37825,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36789,6 +37853,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36816,6 +37881,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -36843,6 +37909,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -36884,6 +37951,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36911,6 +37979,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36980,6 +38049,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -37007,6 +38077,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37034,6 +38105,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37061,6 +38133,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37088,6 +38161,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -37115,6 +38189,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -37149,6 +38224,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37183,6 +38259,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -37210,6 +38287,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37279,6 +38357,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37306,6 +38385,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -37333,6 +38413,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -37360,6 +38441,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37387,6 +38469,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37414,6 +38497,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -37469,6 +38553,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -37496,6 +38581,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -37530,6 +38616,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -37557,6 +38644,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -37584,6 +38672,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -37611,6 +38700,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -37638,6 +38728,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -37665,6 +38756,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37692,6 +38784,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37719,6 +38812,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -37767,6 +38861,7 @@
         {
             "id": "0xe02e8ddecbe302ba1a40107c726e3ee889b0ff10",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
@@ -37801,6 +38896,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -37828,6 +38924,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -37855,6 +38952,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37882,6 +38980,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37909,6 +39008,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37957,6 +39057,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -37984,6 +39085,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -38011,6 +39113,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -38038,6 +39141,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38065,6 +39169,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38092,6 +39197,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38119,6 +39225,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -38146,6 +39253,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38173,6 +39281,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38200,6 +39309,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38227,6 +39337,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38289,6 +39400,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38337,6 +39449,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38364,6 +39477,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38391,6 +39505,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38418,6 +39533,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -38445,6 +39561,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -38479,6 +39596,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -38506,6 +39624,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38533,6 +39652,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38560,6 +39680,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -38587,6 +39708,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38635,6 +39757,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -38662,6 +39785,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -38689,6 +39813,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -38716,6 +39841,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -38743,6 +39869,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38777,6 +39904,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -38804,6 +39932,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -38873,6 +40002,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38921,6 +40051,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38976,6 +40107,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39017,6 +40149,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39044,6 +40177,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -39113,6 +40247,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -39140,6 +40275,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39167,6 +40303,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -39194,6 +40331,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -39221,6 +40359,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39248,6 +40387,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39296,6 +40436,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -39323,6 +40464,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -39350,6 +40492,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39377,6 +40520,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39446,6 +40590,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -39473,6 +40618,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -39500,6 +40646,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -39527,6 +40674,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39554,6 +40702,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39581,6 +40730,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -39608,6 +40758,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39635,6 +40786,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -39662,6 +40814,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -39689,6 +40842,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -39716,6 +40870,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -39750,6 +40905,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -39777,6 +40933,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -39804,6 +40961,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39831,6 +40989,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -39858,6 +41017,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -39885,6 +41045,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -39912,6 +41073,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -39967,6 +41129,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39994,6 +41157,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -40049,6 +41213,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -40076,6 +41241,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -40103,6 +41269,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40151,6 +41318,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -40178,6 +41346,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -40205,6 +41374,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40232,6 +41402,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -40273,6 +41444,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40300,6 +41472,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40334,6 +41507,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -40361,6 +41535,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -40395,6 +41570,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40422,6 +41598,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40449,6 +41626,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40476,6 +41654,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -40503,6 +41682,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -40551,6 +41731,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -40585,6 +41766,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -40612,6 +41794,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -40646,6 +41829,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -40673,6 +41857,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -40700,6 +41885,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -40748,6 +41934,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -40775,6 +41962,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -40802,6 +41990,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -40850,6 +42039,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -40877,6 +42067,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40904,6 +42095,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40945,6 +42137,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40986,6 +42179,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -41013,6 +42207,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -41040,6 +42235,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -41067,6 +42263,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41115,6 +42312,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -41142,6 +42340,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -41183,6 +42382,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -41210,6 +42410,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -41237,6 +42438,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41264,6 +42466,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -41291,6 +42494,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -41318,6 +42522,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -41345,6 +42550,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -41372,6 +42578,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41399,6 +42606,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -41426,6 +42634,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -41460,6 +42669,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -41487,6 +42697,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -41514,6 +42725,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -41562,6 +42774,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -41589,6 +42802,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -41616,6 +42830,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -41643,6 +42858,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -41670,6 +42886,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -41697,6 +42914,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -41724,6 +42942,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -41751,6 +42970,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -41778,6 +42998,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -41847,6 +43068,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -41874,6 +43096,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -41901,6 +43124,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -41928,6 +43152,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -41976,6 +43201,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -42003,6 +43229,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -42037,6 +43264,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -42071,6 +43299,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -42105,6 +43334,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -42132,6 +43362,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -42159,6 +43390,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -42186,6 +43418,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -42220,6 +43453,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -42247,6 +43481,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -42274,6 +43509,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -42301,6 +43537,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -42335,6 +43572,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -42369,6 +43607,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -42396,6 +43635,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -42423,6 +43663,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -42464,6 +43705,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -42533,6 +43775,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -42560,6 +43803,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -42587,6 +43831,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -42614,6 +43859,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -42641,6 +43887,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -42668,6 +43915,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -42695,6 +43943,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -42729,6 +43978,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -42756,6 +44006,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -42783,6 +44034,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -42852,6 +44104,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -42879,6 +44132,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -42906,6 +44160,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -42933,6 +44188,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -43002,6 +44258,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x6296adbe389d693b6c1800010bb23fb3db044e63f2c3e6097c58b6f5d34bbc96.json
+++ b/test/testData/testPools/0x6296adbe389d693b6c1800010bb23fb3db044e63f2c3e6097c58b6f5d34bbc96.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x63a9c56abf0e49661923eda4aeb8dd3af1ad1c6dae981d6f1c6465d9e44d306c.json
+++ b/test/testData/testPools/0x63a9c56abf0e49661923eda4aeb8dd3af1ad1c6dae981d6f1c6465d9e44d306c.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x6458ba03bd9707104c86c9ead2fcf6fcfdcb0b83d6fac5c683a0b687be4aa7fd.json
+++ b/test/testData/testPools/0x6458ba03bd9707104c86c9ead2fcf6fcfdcb0b83d6fac5c683a0b687be4aa7fd.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x676403139165aad1c8e251350b30306d823562a63699cf51c55a6f28eb8c1aed.json
+++ b/test/testData/testPools/0x676403139165aad1c8e251350b30306d823562a63699cf51c55a6f28eb8c1aed.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x6910af6d48b1eb1a33c3de6f53f809aad315179f12d49b757f74c687b16d71aa.json
+++ b/test/testData/testPools/0x6910af6d48b1eb1a33c3de6f53f809aad315179f12d49b757f74c687b16d71aa.json
@@ -1188,6 +1188,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2494,6 +2495,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5886,6 +5888,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8161,6 +8164,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8474,6 +8478,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14698,6 +14703,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -20232,6 +20238,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -33567,6 +33574,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",

--- a/test/testData/testPools/0x6abfd063a04f0badbb10d021c3a9fbdb2836f5c953af8c18cd89e940cccd4199.json
+++ b/test/testData/testPools/0x6abfd063a04f0badbb10d021c3a9fbdb2836f5c953af8c18cd89e940cccd4199.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x6b4011c5e4c17293c0db18fb63e334544107b6451d7e74ce9c88b0b1c07b8fda.json
+++ b/test/testData/testPools/0x6b4011c5e4c17293c0db18fb63e334544107b6451d7e74ce9c88b0b1c07b8fda.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -94,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -169,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -196,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -230,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -257,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -284,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -311,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -338,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -365,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -392,6 +405,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -419,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -467,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -508,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -535,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -562,6 +580,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +608,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -616,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -643,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -691,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -718,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -745,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -800,6 +825,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -848,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -875,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -902,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -929,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -956,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -997,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1024,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1065,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1092,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1161,6 +1196,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1230,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1257,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1284,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1311,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1338,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1365,6 +1406,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1392,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1419,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1467,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1494,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1542,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1569,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1596,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1623,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1664,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1691,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1718,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1745,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1772,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1799,6 +1854,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1826,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1867,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1894,6 +1952,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1987,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -1976,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2004,6 +2065,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2051,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2169,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2168,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2216,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2243,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2270,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2325,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2352,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2379,6 +2449,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2477,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2440,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2467,6 +2540,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2494,6 +2569,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2528,6 +2604,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2555,6 +2632,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2582,6 +2660,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2609,6 +2688,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2657,6 +2737,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2684,6 +2765,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2718,6 +2800,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2745,6 +2828,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2772,6 +2856,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2799,6 +2884,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2826,6 +2912,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2860,6 +2947,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2887,6 +2975,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2914,6 +3003,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2941,6 +3031,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -2975,6 +3066,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3044,6 +3136,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3078,6 +3171,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3105,6 +3199,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3132,6 +3227,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3159,6 +3255,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3200,6 +3297,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3227,6 +3325,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3254,6 +3353,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3281,6 +3381,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3308,6 +3409,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3335,6 +3437,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3376,6 +3479,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3424,6 +3528,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3451,6 +3556,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3478,6 +3584,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3505,6 +3612,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3532,6 +3640,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3601,6 +3710,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3628,6 +3738,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3655,6 +3766,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3682,6 +3794,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3709,6 +3822,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3736,6 +3850,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3763,6 +3878,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3790,6 +3906,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3824,6 +3941,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3851,6 +3969,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3878,6 +3997,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3905,6 +4025,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3939,6 +4060,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3966,6 +4088,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -3993,6 +4116,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4020,6 +4144,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4047,6 +4172,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4088,6 +4214,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4115,6 +4242,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4163,6 +4291,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4190,6 +4319,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4238,6 +4368,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4265,6 +4396,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4292,6 +4424,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4319,6 +4452,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4346,6 +4480,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4373,6 +4508,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4428,6 +4564,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4469,6 +4606,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4496,6 +4634,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4523,6 +4662,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4550,6 +4690,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4577,6 +4718,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4604,6 +4746,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4774,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4658,6 +4802,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4685,6 +4830,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4712,6 +4858,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4739,6 +4886,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4808,6 +4956,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4835,6 +4984,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4862,6 +5012,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4889,6 +5040,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -4930,6 +5082,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5152,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5026,6 +5180,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5053,6 +5208,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5080,6 +5236,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5114,6 +5271,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5141,6 +5299,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5168,6 +5327,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5195,6 +5355,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5222,6 +5383,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5249,6 +5411,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5276,6 +5439,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5303,6 +5467,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5495,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5357,6 +5523,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5412,6 +5579,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5439,6 +5607,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5473,6 +5642,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5500,6 +5670,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5527,6 +5698,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5554,6 +5726,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5581,6 +5754,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5608,6 +5782,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5635,6 +5810,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5669,6 +5845,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5696,6 +5873,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5723,6 +5901,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5778,6 +5957,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5805,6 +5985,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5832,6 +6013,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5859,6 +6041,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -5886,6 +6070,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5913,6 +6098,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5940,6 +6126,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5967,6 +6154,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5994,6 +6182,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6021,6 +6210,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6069,6 +6259,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6096,6 +6287,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6137,6 +6329,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6185,6 +6378,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6212,6 +6406,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6239,6 +6434,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6294,6 +6490,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6328,6 +6525,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6369,6 +6567,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6438,6 +6637,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6465,6 +6665,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6499,6 +6700,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6526,6 +6728,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6553,6 +6756,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6580,6 +6784,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6607,6 +6812,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6634,6 +6840,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6661,6 +6868,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6688,6 +6896,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6750,6 +6959,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6819,6 +7029,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6846,6 +7057,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6873,6 +7085,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6900,6 +7113,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6927,6 +7141,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6954,6 +7169,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -6988,6 +7204,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7015,6 +7232,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7042,6 +7260,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7069,6 +7288,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7103,6 +7323,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7130,6 +7351,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7157,6 +7379,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7184,6 +7407,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7239,6 +7463,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7266,6 +7491,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7293,6 +7519,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7320,6 +7547,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7347,6 +7575,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7374,6 +7603,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7401,6 +7631,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7428,6 +7659,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7455,6 +7687,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7482,6 +7715,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7551,6 +7785,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7827,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7855,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7646,6 +7883,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7673,6 +7911,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7700,6 +7939,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7727,6 +7967,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7761,6 +8002,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7788,6 +8030,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7822,6 +8065,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7849,6 +8093,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7876,6 +8121,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7924,6 +8170,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7951,6 +8198,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -7978,6 +8226,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8005,6 +8254,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8032,6 +8282,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8059,6 +8310,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8086,6 +8338,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8134,6 +8387,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8161,6 +8416,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8188,6 +8444,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8222,6 +8479,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8249,6 +8507,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8276,6 +8535,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8317,6 +8577,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8344,6 +8605,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8378,6 +8640,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8447,6 +8710,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8474,6 +8738,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8501,6 +8766,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8528,6 +8794,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8597,6 +8864,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8624,6 +8892,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8651,6 +8920,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8678,6 +8948,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8712,6 +8983,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8739,6 +9011,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8787,6 +9060,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8835,6 +9109,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8862,6 +9137,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +9165,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8916,6 +9193,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8943,6 +9221,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -8970,6 +9249,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8997,6 +9277,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9066,6 +9347,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9093,6 +9375,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9120,6 +9403,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9147,6 +9431,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9174,6 +9459,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9215,6 +9501,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9242,6 +9529,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -9311,6 +9599,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9359,6 +9648,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9386,6 +9676,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9455,6 +9746,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9503,6 +9795,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9530,6 +9823,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9557,6 +9851,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9584,6 +9879,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9611,6 +9907,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9638,6 +9935,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9665,6 +9963,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9692,6 +9991,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9719,6 +10019,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9746,6 +10047,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9773,6 +10075,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9800,6 +10103,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9827,6 +10131,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9854,6 +10159,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9881,6 +10187,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9908,6 +10215,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9935,6 +10243,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -9962,6 +10271,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10003,6 +10313,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10030,6 +10341,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10057,6 +10369,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10112,6 +10425,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10139,6 +10453,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10166,6 +10481,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10200,6 +10516,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10227,6 +10544,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10254,6 +10572,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10281,6 +10600,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10308,6 +10628,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10335,6 +10656,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10362,6 +10684,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10389,6 +10712,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10437,6 +10761,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10464,6 +10789,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10491,6 +10817,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10518,6 +10845,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10545,6 +10873,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10572,6 +10901,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10599,6 +10929,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10626,6 +10957,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10653,6 +10985,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10715,6 +11048,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10742,6 +11076,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10769,6 +11104,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10796,6 +11132,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10865,6 +11202,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10899,6 +11237,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -10926,6 +11265,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11293,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -10980,6 +11321,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11007,6 +11349,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11055,6 +11398,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11082,6 +11426,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11130,6 +11475,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11157,6 +11503,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11184,6 +11531,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11246,6 +11594,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11287,6 +11636,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11314,6 +11664,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11341,6 +11692,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11368,6 +11720,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11395,6 +11748,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11464,6 +11818,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11491,6 +11846,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11518,6 +11874,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11545,6 +11902,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11579,6 +11937,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11613,6 +11972,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11640,6 +12000,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11667,6 +12028,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11694,6 +12056,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11721,6 +12084,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11748,6 +12112,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11775,6 +12140,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11802,6 +12168,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11829,6 +12196,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11856,6 +12224,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11883,6 +12252,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -11910,6 +12280,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -11937,6 +12308,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -11964,6 +12336,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -11991,6 +12364,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12053,6 +12427,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12087,6 +12462,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12114,6 +12490,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12141,6 +12518,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12168,6 +12546,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12195,6 +12574,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12250,6 +12630,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12277,6 +12658,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12304,6 +12686,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12331,6 +12714,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12358,6 +12742,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12385,6 +12770,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12412,6 +12798,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12439,6 +12826,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12508,6 +12896,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12535,6 +12924,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12562,6 +12952,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12596,6 +12987,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12623,6 +13015,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +13043,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +13092,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12725,6 +13120,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +13162,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12821,6 +13218,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12855,6 +13253,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12924,6 +13323,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -12951,6 +13351,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -12978,6 +13379,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13005,6 +13407,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13032,6 +13435,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13059,6 +13463,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13086,6 +13491,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13113,6 +13519,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13140,6 +13547,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13188,6 +13596,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13257,6 +13666,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13284,6 +13694,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13325,6 +13736,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13352,6 +13764,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13386,6 +13799,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13841,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13496,6 +13911,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13523,6 +13939,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13550,6 +13967,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13577,6 +13995,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13604,6 +14023,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13659,6 +14079,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13686,6 +14107,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13713,6 +14135,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13740,6 +14163,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13767,6 +14191,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13794,6 +14219,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13821,6 +14247,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13848,6 +14275,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13875,6 +14303,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -13902,6 +14331,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13964,6 +14394,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -13991,6 +14422,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14018,6 +14450,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14045,6 +14478,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14072,6 +14506,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14534,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14604,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14195,6 +14632,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14222,6 +14660,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14249,6 +14688,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14276,6 +14716,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14317,6 +14758,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14344,6 +14786,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14371,6 +14814,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14398,6 +14842,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14425,6 +14870,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14452,6 +14898,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14479,6 +14926,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14506,6 +14954,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14575,6 +15024,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14602,6 +15052,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14629,6 +15080,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14656,6 +15108,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14683,6 +15136,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14710,6 +15164,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14737,6 +15192,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14764,6 +15220,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14798,6 +15255,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14825,6 +15283,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14852,6 +15311,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14879,6 +15339,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14906,6 +15367,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -14933,6 +15395,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -14960,6 +15423,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -14987,6 +15451,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15056,6 +15521,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15083,6 +15549,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15110,6 +15577,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15137,6 +15605,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15164,6 +15633,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15191,6 +15661,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15218,6 +15689,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15259,6 +15731,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15801,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15355,6 +15829,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15382,6 +15857,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15409,6 +15885,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15436,6 +15913,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15463,6 +15941,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15504,6 +15983,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15531,6 +16011,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15558,6 +16039,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15585,6 +16067,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15612,6 +16095,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15646,6 +16130,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15673,6 +16158,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15700,6 +16186,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15727,6 +16214,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -15796,6 +16284,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15823,6 +16312,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15850,6 +16340,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15877,6 +16368,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15904,6 +16396,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -15931,6 +16424,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15958,6 +16452,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -15985,6 +16480,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16012,6 +16508,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16039,6 +16536,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16066,6 +16564,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16107,6 +16606,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16134,6 +16634,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16161,6 +16662,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16223,6 +16725,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16250,6 +16753,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16277,6 +16781,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16304,6 +16809,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16331,6 +16837,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16358,6 +16865,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16385,6 +16893,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16412,6 +16921,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16439,6 +16949,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16466,6 +16977,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16493,6 +17005,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16548,6 +17061,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16582,6 +17096,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16609,6 +17124,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16636,6 +17152,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16663,6 +17180,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16690,6 +17208,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16717,6 +17236,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16744,6 +17264,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16785,6 +17306,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +17376,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -16888,6 +17411,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16915,6 +17439,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -16942,6 +17467,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16969,6 +17495,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -16996,6 +17523,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17030,6 +17558,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17057,6 +17586,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17084,6 +17614,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17153,6 +17684,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17180,6 +17712,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17207,6 +17740,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17234,6 +17768,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17261,6 +17796,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17288,6 +17824,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17315,6 +17852,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17342,6 +17880,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17404,6 +17943,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17431,6 +17971,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17458,6 +17999,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17485,6 +18027,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17512,6 +18055,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17560,6 +18104,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17601,6 +18146,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17628,6 +18174,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17655,6 +18202,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17689,6 +18237,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17716,6 +18265,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17743,6 +18293,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17784,6 +18335,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17811,6 +18363,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17845,6 +18398,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17872,6 +18426,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17899,6 +18454,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17926,6 +18482,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17953,6 +18510,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -17980,6 +18538,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18007,6 +18566,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18076,6 +18636,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18103,6 +18664,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18130,6 +18692,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18157,6 +18720,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18184,6 +18748,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -18211,6 +18776,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18280,6 +18846,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18307,6 +18874,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18376,6 +18944,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18403,6 +18972,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18430,6 +19000,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18457,6 +19028,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18484,6 +19056,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18511,6 +19084,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18538,6 +19112,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18572,6 +19147,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18606,6 +19182,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18633,6 +19210,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18660,6 +19238,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18715,6 +19294,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18742,6 +19322,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18769,6 +19350,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18796,6 +19378,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18830,6 +19413,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18857,6 +19441,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18884,6 +19469,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18911,6 +19497,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18938,6 +19525,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -18972,6 +19560,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18999,6 +19588,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19026,6 +19616,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19053,6 +19644,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19080,6 +19672,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19107,6 +19700,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19728,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19161,6 +19756,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19195,6 +19791,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19222,6 +19819,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19249,6 +19847,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19276,6 +19875,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19303,6 +19903,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19330,6 +19931,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19364,6 +19966,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19398,6 +20001,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19425,6 +20029,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19452,6 +20057,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19479,6 +20085,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19506,6 +20113,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -19533,6 +20141,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19560,6 +20169,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19587,6 +20197,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19635,6 +20246,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19662,6 +20274,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19689,6 +20302,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19716,6 +20330,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19743,6 +20358,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19770,6 +20386,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19797,6 +20414,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19824,6 +20442,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19851,6 +20470,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -19920,6 +20540,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19947,6 +20568,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19974,6 +20596,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20001,6 +20624,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20035,6 +20659,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20062,6 +20687,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20089,6 +20715,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20116,6 +20743,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20143,6 +20771,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20184,6 +20813,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20211,6 +20841,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20252,6 +20883,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20279,6 +20911,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20348,6 +20981,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20410,6 +21044,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20437,6 +21072,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20506,6 +21142,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20533,6 +21170,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20560,6 +21198,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20587,6 +21226,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20614,6 +21254,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20641,6 +21282,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20668,6 +21310,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20695,6 +21338,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20729,6 +21373,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20756,6 +21401,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -20818,6 +21464,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20845,6 +21492,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20872,6 +21520,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -20906,6 +21555,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20940,6 +21590,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -20981,6 +21632,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21036,6 +21688,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21063,6 +21716,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21090,6 +21744,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21159,6 +21814,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21186,6 +21842,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21227,6 +21884,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21254,6 +21912,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21281,6 +21940,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21308,6 +21968,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21335,6 +21996,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21369,6 +22031,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21396,6 +22059,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21423,6 +22087,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21450,6 +22115,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21477,6 +22143,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21504,6 +22171,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21545,6 +22213,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21572,6 +22241,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21599,6 +22269,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21626,6 +22297,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21653,6 +22325,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -21701,6 +22374,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21728,6 +22402,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21755,6 +22430,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21782,6 +22458,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21809,6 +22486,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21836,6 +22514,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21884,6 +22563,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -21918,6 +22598,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21945,6 +22626,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -21972,6 +22654,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21999,6 +22682,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22026,6 +22710,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22053,6 +22738,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22080,6 +22766,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22121,6 +22808,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22148,6 +22836,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22175,6 +22864,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22202,6 +22892,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22920,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22962,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22311,6 +23004,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22352,6 +23046,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22379,6 +23074,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22413,6 +23109,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22440,6 +23137,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -22467,6 +23165,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22494,6 +23193,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22521,6 +23221,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22569,6 +23270,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22610,6 +23312,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22637,6 +23340,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22664,6 +23368,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22733,6 +23438,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22767,6 +23473,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22794,6 +23501,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22828,6 +23536,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22862,6 +23571,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22889,6 +23599,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22916,6 +23627,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -22943,6 +23655,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22970,6 +23683,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22997,6 +23711,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23024,6 +23739,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23051,6 +23767,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23078,6 +23795,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23105,6 +23823,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23160,6 +23879,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23187,6 +23907,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23221,6 +23942,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23248,6 +23970,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23275,6 +23998,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23316,6 +24040,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23343,6 +24068,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23370,6 +24096,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23397,6 +24124,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23424,6 +24152,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23451,6 +24180,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23485,6 +24215,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23512,6 +24243,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23546,6 +24278,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23573,6 +24306,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23621,6 +24355,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23648,6 +24383,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23675,6 +24411,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23702,6 +24439,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23729,6 +24467,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23756,6 +24495,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23783,6 +24523,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23810,6 +24551,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23837,6 +24579,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23864,6 +24607,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -23891,6 +24635,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -23918,6 +24663,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -23966,6 +24712,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24014,6 +24761,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24041,6 +24789,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24068,6 +24817,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24095,6 +24845,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24122,6 +24873,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24149,6 +24901,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24176,6 +24929,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24203,6 +24957,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24230,6 +24985,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24257,6 +25013,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24284,6 +25041,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24311,6 +25069,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24338,6 +25097,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24372,6 +25132,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24434,6 +25195,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24461,6 +25223,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24488,6 +25251,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24515,6 +25279,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +25321,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -24625,6 +25391,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24694,6 +25461,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24721,6 +25489,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24748,6 +25517,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24817,6 +25587,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24844,6 +25615,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24871,6 +25643,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24898,6 +25671,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -24932,6 +25706,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24973,6 +25748,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25000,6 +25776,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25027,6 +25804,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25054,6 +25832,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25081,6 +25860,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25108,6 +25888,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25135,6 +25916,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25162,6 +25944,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25189,6 +25972,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25230,6 +26014,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25257,6 +26042,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25284,6 +26070,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25318,6 +26105,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25345,6 +26133,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25393,6 +26182,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25427,6 +26217,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25454,6 +26245,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25481,6 +26273,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25508,6 +26301,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25535,6 +26329,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25562,6 +26357,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25589,6 +26385,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25616,6 +26413,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25650,6 +26448,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25677,6 +26476,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25704,6 +26504,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25738,6 +26539,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25765,6 +26567,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25792,6 +26595,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25840,6 +26644,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25867,6 +26672,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -25894,6 +26700,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25921,6 +26728,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25955,6 +26763,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25996,6 +26805,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26833,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26050,6 +26861,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26077,6 +26889,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26139,6 +26952,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26166,6 +26980,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26193,6 +27008,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26220,6 +27036,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26247,6 +27064,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26274,6 +27092,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26301,6 +27120,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26335,6 +27155,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26362,6 +27183,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26431,6 +27253,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26458,6 +27281,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26527,6 +27351,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26554,6 +27379,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26581,6 +27407,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26608,6 +27435,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26635,6 +27463,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26662,6 +27491,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26689,6 +27519,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26716,6 +27547,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26743,6 +27575,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26770,6 +27603,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26797,6 +27631,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +27694,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27764,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -26955,6 +27792,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -26982,6 +27820,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27009,6 +27848,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27036,6 +27876,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27070,6 +27911,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27097,6 +27939,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27124,6 +27967,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27172,6 +28016,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27199,6 +28044,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27240,6 +28086,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27267,6 +28114,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27308,6 +28156,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27335,6 +28184,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +28212,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27396,6 +28247,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27423,6 +28275,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27450,6 +28303,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27477,6 +28331,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27504,6 +28359,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27531,6 +28387,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27558,6 +28415,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27585,6 +28443,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27612,6 +28471,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27639,6 +28499,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27666,6 +28527,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27693,6 +28555,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27720,6 +28583,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27747,6 +28611,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27774,6 +28639,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +28667,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27849,6 +28716,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -27876,6 +28744,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27903,6 +28772,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -27930,6 +28800,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -27957,6 +28828,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27984,6 +28856,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28011,6 +28884,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28038,6 +28912,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28065,6 +28940,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28092,6 +28968,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28119,6 +28996,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28146,6 +29024,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28180,6 +29059,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28207,6 +29087,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28234,6 +29115,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28261,6 +29143,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28288,6 +29171,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28357,6 +29241,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28384,6 +29269,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28411,6 +29297,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28438,6 +29325,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28465,6 +29353,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28492,6 +29381,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28519,6 +29409,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28546,6 +29437,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28573,6 +29465,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28600,6 +29493,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28627,6 +29521,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28654,6 +29549,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28688,6 +29584,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28715,6 +29612,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28749,6 +29647,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28776,6 +29675,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28803,6 +29703,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28830,6 +29731,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -28857,6 +29759,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28912,6 +29815,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28939,6 +29843,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29008,6 +29913,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29077,6 +29983,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29104,6 +30011,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29131,6 +30039,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29158,6 +30067,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29185,6 +30095,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29226,6 +30137,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29253,6 +30165,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29280,6 +30193,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29335,6 +30249,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29362,6 +30277,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29389,6 +30305,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29416,6 +30333,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29457,6 +30375,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29484,6 +30403,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29518,6 +30438,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29545,6 +30466,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29572,6 +30494,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29599,6 +30522,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29626,6 +30550,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29660,6 +30585,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29687,6 +30613,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29714,6 +30641,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29741,6 +30669,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29768,6 +30697,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29795,6 +30725,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29822,6 +30753,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -29849,6 +30781,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29918,6 +30851,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -29945,6 +30879,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -29972,6 +30907,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -29999,6 +30935,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30026,6 +30963,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30053,6 +30991,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30080,6 +31019,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30107,6 +31047,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30148,6 +31089,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30175,6 +31117,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30202,6 +31145,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30229,6 +31173,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30256,6 +31201,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30283,6 +31229,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30310,6 +31257,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30337,6 +31285,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30364,6 +31313,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30391,6 +31341,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30418,6 +31369,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30445,6 +31397,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -30472,6 +31425,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30499,6 +31453,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30533,6 +31488,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30595,6 +31551,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30622,6 +31579,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30649,6 +31607,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30676,6 +31635,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30703,6 +31663,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30730,6 +31691,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30757,6 +31719,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30784,6 +31747,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30811,6 +31775,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30866,6 +31831,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -30893,6 +31859,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30920,6 +31887,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30947,6 +31915,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -30974,6 +31943,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31001,6 +31971,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31035,6 +32006,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31062,6 +32034,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31089,6 +32062,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31116,6 +32090,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31143,6 +32118,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31170,6 +32146,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31197,6 +32174,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31224,6 +32202,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31251,6 +32230,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31278,6 +32258,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31305,6 +32286,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31346,6 +32328,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +32384,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31428,6 +32412,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31455,6 +32440,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31482,6 +32468,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31509,6 +32496,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31536,6 +32524,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31563,6 +32552,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31590,6 +32580,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31645,6 +32636,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31672,6 +32664,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31699,6 +32692,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31754,6 +32748,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31788,6 +32783,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31843,6 +32839,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31877,6 +32874,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31904,6 +32902,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -31938,6 +32937,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31986,6 +32986,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32027,6 +33028,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32054,6 +33056,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32081,6 +33084,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32108,6 +33112,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32135,6 +33140,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32162,6 +33168,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32196,6 +33203,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32223,6 +33231,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32250,6 +33259,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32277,6 +33287,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32304,6 +33315,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32331,6 +33343,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32358,6 +33371,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32385,6 +33399,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32412,6 +33427,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32439,6 +33455,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32466,6 +33483,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32493,6 +33511,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32520,6 +33539,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32547,6 +33567,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32574,6 +33595,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32601,6 +33623,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32628,6 +33651,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32655,6 +33679,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32682,6 +33707,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32730,6 +33756,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32771,6 +33798,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32798,6 +33826,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32825,6 +33854,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32852,6 +33882,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32914,6 +33945,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -32941,6 +33973,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -32968,6 +34001,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32995,6 +34029,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33029,6 +34064,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33056,6 +34092,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33083,6 +34120,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33124,6 +34162,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33151,6 +34190,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33178,6 +34218,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33205,6 +34246,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33232,6 +34274,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33301,6 +34344,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33328,6 +34372,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33376,6 +34421,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33403,6 +34449,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33451,6 +34498,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +34526,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +34555,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33539,6 +34590,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33580,6 +34632,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33621,6 +34674,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33648,6 +34702,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33675,6 +34730,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33702,6 +34758,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33736,6 +34793,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33763,6 +34821,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33790,6 +34849,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +34877,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -33844,6 +34905,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -33871,6 +34933,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -33898,6 +34961,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33925,6 +34989,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +35017,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -33979,6 +35045,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34020,6 +35087,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34047,6 +35115,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34116,6 +35185,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34143,6 +35213,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34170,6 +35241,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34197,6 +35269,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34224,6 +35297,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34251,6 +35325,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34285,6 +35360,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34319,6 +35395,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34346,6 +35423,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34415,6 +35493,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34442,6 +35521,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34469,6 +35549,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34496,6 +35577,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34523,6 +35605,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34550,6 +35633,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34605,6 +35689,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34632,6 +35717,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34666,6 +35752,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +35780,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34720,6 +35808,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34747,6 +35836,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34774,6 +35864,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34801,6 +35892,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34828,6 +35920,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -34855,6 +35948,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -34903,6 +35997,7 @@
         {
             "id": "0xe02e8ddecbe302ba1a40107c726e3ee889b0ff10",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
@@ -34937,6 +36032,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34964,6 +36060,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34991,6 +36088,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35018,6 +36116,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +36144,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +36193,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35120,6 +36221,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35147,6 +36249,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35174,6 +36277,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35201,6 +36305,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35228,6 +36333,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35255,6 +36361,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35282,6 +36389,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35309,6 +36417,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35336,6 +36445,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35363,6 +36473,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35425,6 +36536,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35473,6 +36585,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35500,6 +36613,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35527,6 +36641,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35554,6 +36669,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35581,6 +36697,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35615,6 +36732,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35642,6 +36760,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35669,6 +36788,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35696,6 +36816,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35723,6 +36844,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35771,6 +36893,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35798,6 +36921,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -35825,6 +36949,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35852,6 +36977,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -35879,6 +37005,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35913,6 +37040,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -35940,6 +37068,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36009,6 +37138,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36057,6 +37187,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36112,6 +37243,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36153,6 +37285,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36180,6 +37313,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36249,6 +37383,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36276,6 +37411,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36303,6 +37439,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36330,6 +37467,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36357,6 +37495,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +37523,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36432,6 +37572,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36459,6 +37600,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36486,6 +37628,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36513,6 +37656,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36582,6 +37726,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36609,6 +37754,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36636,6 +37782,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36663,6 +37810,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36690,6 +37838,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36717,6 +37866,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36744,6 +37894,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36771,6 +37922,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36798,6 +37950,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36825,6 +37978,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36852,6 +38006,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -36886,6 +38041,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -36913,6 +38069,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -36940,6 +38097,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36967,6 +38125,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -36994,6 +38153,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37021,6 +38181,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37048,6 +38209,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37103,6 +38265,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37130,6 +38293,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37185,6 +38349,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37212,6 +38377,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37239,6 +38405,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37287,6 +38454,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37314,6 +38482,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37341,6 +38510,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37368,6 +38538,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37409,6 +38580,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37436,6 +38608,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37470,6 +38643,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37497,6 +38671,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37531,6 +38706,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37558,6 +38734,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37585,6 +38762,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37612,6 +38790,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37639,6 +38818,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37687,6 +38867,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37721,6 +38902,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37748,6 +38930,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -37782,6 +38965,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37809,6 +38993,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37836,6 +39021,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -37884,6 +39070,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37911,6 +39098,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37938,6 +39126,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -37986,6 +39175,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38013,6 +39203,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38040,6 +39231,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +39273,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38122,6 +39315,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38149,6 +39343,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38176,6 +39371,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38203,6 +39399,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38251,6 +39448,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38278,6 +39476,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38319,6 +39518,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38346,6 +39546,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38373,6 +39574,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38400,6 +39602,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38427,6 +39630,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38454,6 +39658,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38481,6 +39686,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38508,6 +39714,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38535,6 +39742,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38562,6 +39770,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38596,6 +39805,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38623,6 +39833,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38650,6 +39861,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38698,6 +39910,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38725,6 +39938,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38752,6 +39966,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38779,6 +39994,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38806,6 +40022,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -38833,6 +40050,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -38860,6 +40078,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -38887,6 +40106,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -38914,6 +40134,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38983,6 +40204,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39010,6 +40232,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39037,6 +40260,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39064,6 +40288,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39112,6 +40337,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39139,6 +40365,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39173,6 +40400,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39207,6 +40435,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39241,6 +40470,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39268,6 +40498,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39295,6 +40526,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39322,6 +40554,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39356,6 +40589,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39383,6 +40617,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39410,6 +40645,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39437,6 +40673,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39471,6 +40708,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39505,6 +40743,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39532,6 +40771,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39559,6 +40799,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39600,6 +40841,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39669,6 +40911,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39696,6 +40939,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39723,6 +40967,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39750,6 +40995,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39777,6 +41023,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39804,6 +41051,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39831,6 +41079,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39865,6 +41114,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39892,6 +41142,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -39919,6 +41170,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39988,6 +41240,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40015,6 +41268,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40042,6 +41296,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40069,6 +41324,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40138,6 +41394,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x6b4011c5e4c17293c0db18fb63e334544107b6451d7e74ce9c88b0b1c07b8fda.json
+++ b/test/testData/testPools/0x6b4011c5e4c17293c0db18fb63e334544107b6451d7e74ce9c88b0b1c07b8fda.json
@@ -2541,7 +2541,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6042,7 +6041,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8387,7 +8385,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -34526,7 +34523,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0x6b5a3751269a952a6a8e1765d755e97e403f2e03078405d38c17691a3d136af6.json
+++ b/test/testData/testPools/0x6b5a3751269a952a6a8e1765d755e97e403f2e03078405d38c17691a3d136af6.json
@@ -1161,6 +1161,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2468,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5859,6 +5861,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8134,6 +8137,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8451,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14575,6 +14580,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -20143,6 +20149,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -33478,6 +33485,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",

--- a/test/testData/testPools/0x6df803d2dd8373a443e7fb58e8d867e38b074bb25c7d47e709b310a90d4ba648.json
+++ b/test/testData/testPools/0x6df803d2dd8373a443e7fb58e8d867e38b074bb25c7d47e709b310a90d4ba648.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x72492628b146d079a8a7801aafccc1a0de2d0c888efc00609cf82316fac86f2a.json
+++ b/test/testData/testPools/0x72492628b146d079a8a7801aafccc1a0de2d0c888efc00609cf82316fac86f2a.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x726355cd7b33332ea32101ecc1fe0b0c214328d6fb6d277b0bbc14360e7ddd71.json
+++ b/test/testData/testPools/0x726355cd7b33332ea32101ecc1fe0b0c214328d6fb6d277b0bbc14360e7ddd71.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x7e68f4beedf0a844a83e989121a8179785a3c45ea731cd086cde8391992c1d5b.json
+++ b/test/testData/testPools/0x7e68f4beedf0a844a83e989121a8179785a3c45ea731cd086cde8391992c1d5b.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x80422d69eb9272c7b786f602bbce7caad3559a2bd714b5eafb254cfbdd26361c.json
+++ b/test/testData/testPools/0x80422d69eb9272c7b786f602bbce7caad3559a2bd714b5eafb254cfbdd26361c.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x80422d69eb9272c7b786f602bbce7caad3559a2bd714b5eafb254cfbdd26361c.json
+++ b/test/testData/testPools/0x80422d69eb9272c7b786f602bbce7caad3559a2bd714b5eafb254cfbdd26361c.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -171,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -198,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -232,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -259,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -286,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -313,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -340,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -367,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -422,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -470,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -511,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -538,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -621,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -648,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -696,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -723,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -750,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -854,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -881,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -908,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -935,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -962,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1003,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1030,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1071,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1098,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1237,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1264,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1291,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1318,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1345,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1400,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1427,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1475,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1502,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1550,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1577,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1604,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1631,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1672,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1699,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1726,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1753,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1780,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1835,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1876,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1987,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2063,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2181,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2229,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2256,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2283,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2338,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2365,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2455,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2510,6 +2568,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2544,6 +2603,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2571,6 +2631,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2598,6 +2659,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2674,6 +2736,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2701,6 +2764,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2735,6 +2799,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2762,6 +2827,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2789,6 +2855,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2816,6 +2883,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2843,6 +2911,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2877,6 +2946,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2904,6 +2974,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2931,6 +3002,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2958,6 +3030,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3062,6 +3135,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3096,6 +3170,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3123,6 +3198,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3150,6 +3226,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3177,6 +3254,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3218,6 +3296,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3245,6 +3324,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3272,6 +3352,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3299,6 +3380,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3326,6 +3408,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3395,6 +3478,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3443,6 +3527,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3470,6 +3555,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3497,6 +3583,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3524,6 +3611,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3551,6 +3639,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3620,6 +3709,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3647,6 +3737,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3674,6 +3765,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3701,6 +3793,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3728,6 +3821,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3755,6 +3849,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3782,6 +3877,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3809,6 +3905,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3843,6 +3940,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3870,6 +3968,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3897,6 +3996,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3924,6 +4024,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3958,6 +4059,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3985,6 +4087,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4012,6 +4115,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4067,6 +4171,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4108,6 +4213,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4135,6 +4241,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4183,6 +4290,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4259,6 +4367,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4286,6 +4395,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4341,6 +4451,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4368,6 +4479,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4451,6 +4563,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4492,6 +4605,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4519,6 +4633,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4546,6 +4661,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4573,6 +4689,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4600,6 +4717,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4627,6 +4745,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4654,6 +4773,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4681,6 +4801,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4708,6 +4829,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4763,6 +4885,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4832,6 +4955,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4859,6 +4983,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4886,6 +5011,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4913,6 +5039,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5052,6 +5179,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5107,6 +5235,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5141,6 +5270,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5168,6 +5298,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5195,6 +5326,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5222,6 +5354,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5277,6 +5410,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5304,6 +5438,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5359,6 +5494,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5386,6 +5522,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5441,6 +5578,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5503,6 +5641,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5530,6 +5669,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5557,6 +5697,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5584,6 +5725,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5611,6 +5753,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5666,6 +5809,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5700,6 +5844,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5727,6 +5872,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5754,6 +5900,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5809,6 +5956,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5836,6 +5984,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5863,6 +6012,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5918,6 +6068,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5945,6 +6096,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5972,6 +6124,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5999,6 +6152,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6026,6 +6180,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6053,6 +6208,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6101,6 +6257,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6128,6 +6285,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6169,6 +6327,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6217,6 +6376,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6244,6 +6404,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6271,6 +6432,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6326,6 +6488,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6402,6 +6565,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6471,6 +6635,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6498,6 +6663,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6532,6 +6698,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6559,6 +6726,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6586,6 +6754,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6613,6 +6782,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6640,6 +6810,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6667,6 +6838,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6694,6 +6866,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6721,6 +6894,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6783,6 +6957,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6852,6 +7027,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6879,6 +7055,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6934,6 +7111,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6961,6 +7139,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7023,6 +7202,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7050,6 +7230,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7077,6 +7258,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7104,6 +7286,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7138,6 +7321,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7193,6 +7377,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7220,6 +7405,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7275,6 +7461,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7302,6 +7489,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7357,6 +7545,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7384,6 +7573,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7411,6 +7601,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7438,6 +7629,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7493,6 +7685,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7520,6 +7713,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7659,6 +7853,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7686,6 +7881,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7713,6 +7909,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7740,6 +7937,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7767,6 +7965,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7829,6 +8028,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7863,6 +8063,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7890,6 +8091,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7917,6 +8119,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7965,6 +8168,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7992,6 +8196,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8019,6 +8224,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8046,6 +8252,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8073,6 +8280,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8100,6 +8308,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8127,6 +8336,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8203,6 +8413,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8230,6 +8441,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8264,6 +8476,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8291,6 +8504,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8318,6 +8532,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8359,6 +8574,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8386,6 +8602,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8420,6 +8637,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8517,6 +8735,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8544,6 +8763,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8571,6 +8791,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8668,6 +8889,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8695,6 +8917,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8722,6 +8945,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8756,6 +8980,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8783,6 +9008,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8831,6 +9057,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8879,6 +9106,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8934,6 +9162,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8961,6 +9190,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8988,6 +9218,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9015,6 +9246,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9042,6 +9274,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9111,6 +9344,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9138,6 +9372,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9165,6 +9400,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9220,6 +9456,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9261,6 +9498,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9358,6 +9596,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9406,6 +9645,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9433,6 +9673,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9502,6 +9743,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9550,6 +9792,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9577,6 +9820,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9604,6 +9848,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9631,6 +9876,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9658,6 +9904,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9685,6 +9932,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9712,6 +9960,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9739,6 +9988,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9766,6 +10016,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9793,6 +10044,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9820,6 +10072,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9847,6 +10100,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9874,6 +10128,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9901,6 +10156,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9928,6 +10184,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9955,6 +10212,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9982,6 +10240,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10009,6 +10268,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10050,6 +10310,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10077,6 +10338,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10104,6 +10366,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10159,6 +10422,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10186,6 +10450,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10213,6 +10478,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10247,6 +10513,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10274,6 +10541,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10301,6 +10569,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10328,6 +10597,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10355,6 +10625,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10410,6 +10681,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10437,6 +10709,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10485,6 +10758,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10540,6 +10814,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10567,6 +10842,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10594,6 +10870,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10649,6 +10926,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10676,6 +10954,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10766,6 +11045,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10793,6 +11073,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10820,6 +11101,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10847,6 +11129,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10916,6 +11199,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10950,6 +11234,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11033,6 +11318,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11060,6 +11346,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11108,6 +11395,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11135,6 +11423,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11183,6 +11472,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11210,6 +11500,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11237,6 +11528,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11299,6 +11591,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11340,6 +11633,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11367,6 +11661,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11394,6 +11689,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11421,6 +11717,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11448,6 +11745,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11517,6 +11815,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11544,6 +11843,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11571,6 +11871,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11633,6 +11934,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11667,6 +11969,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11694,6 +11997,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11721,6 +12025,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11748,6 +12053,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11775,6 +12081,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11802,6 +12109,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11829,6 +12137,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11856,6 +12165,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11883,6 +12193,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11910,6 +12221,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11965,6 +12277,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -11992,6 +12305,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12019,6 +12333,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12046,6 +12361,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12108,6 +12424,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12142,6 +12459,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12169,6 +12487,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12196,6 +12515,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12251,6 +12571,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12306,6 +12627,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12333,6 +12655,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12360,6 +12683,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12387,6 +12711,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12414,6 +12739,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12441,6 +12767,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12496,6 +12823,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12565,6 +12893,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12592,6 +12921,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12619,6 +12949,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12653,6 +12984,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12785,6 +13117,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12882,6 +13215,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12916,6 +13250,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12985,6 +13320,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13012,6 +13348,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13039,6 +13376,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13066,6 +13404,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13093,6 +13432,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13120,6 +13460,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13175,6 +13516,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13202,6 +13544,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13250,6 +13593,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13347,6 +13691,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13416,6 +13761,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13562,6 +13908,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13617,6 +13964,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13644,6 +13992,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13671,6 +14020,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13726,6 +14076,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13753,6 +14104,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13780,6 +14132,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13807,6 +14160,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13834,6 +14188,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13861,6 +14216,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13888,6 +14244,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13915,6 +14272,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13942,6 +14300,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -14032,6 +14391,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14059,6 +14419,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14086,6 +14447,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14113,6 +14475,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14266,6 +14629,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14293,6 +14657,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14320,6 +14685,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14347,6 +14713,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14388,6 +14755,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14415,6 +14783,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14442,6 +14811,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14469,6 +14839,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14524,6 +14895,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14551,6 +14923,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14578,6 +14951,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14675,6 +15049,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14702,6 +15077,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14729,6 +15105,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14784,6 +15161,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14811,6 +15189,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14873,6 +15252,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14900,6 +15280,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14927,6 +15308,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14954,6 +15336,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14981,6 +15364,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15008,6 +15392,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15063,6 +15448,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15132,6 +15518,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15159,6 +15546,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15186,6 +15574,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15213,6 +15602,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15240,6 +15630,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15267,6 +15658,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15294,6 +15686,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15433,6 +15826,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15460,6 +15854,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15487,6 +15882,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15514,6 +15910,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15541,6 +15938,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15582,6 +15980,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15609,6 +16008,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15636,6 +16036,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15663,6 +16064,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15690,6 +16092,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15724,6 +16127,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15751,6 +16155,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15778,6 +16183,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15875,6 +16281,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15902,6 +16309,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15929,6 +16337,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15956,6 +16365,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15983,6 +16393,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16010,6 +16421,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16037,6 +16449,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16064,6 +16477,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16091,6 +16505,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16118,6 +16533,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16145,6 +16561,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16186,6 +16603,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16213,6 +16631,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16240,6 +16659,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16302,6 +16722,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16329,6 +16750,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16356,6 +16778,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16383,6 +16806,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16410,6 +16834,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16465,6 +16890,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16492,6 +16918,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16519,6 +16946,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16546,6 +16974,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16573,6 +17002,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16663,6 +17093,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16690,6 +17121,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16717,6 +17149,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16744,6 +17177,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16771,6 +17205,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16798,6 +17233,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16825,6 +17261,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16971,6 +17408,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16998,6 +17436,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17025,6 +17464,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17052,6 +17492,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17079,6 +17520,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17113,6 +17555,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17168,6 +17611,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17237,6 +17681,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17264,6 +17709,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17291,6 +17737,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17318,6 +17765,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17345,6 +17793,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17372,6 +17821,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17399,6 +17849,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17489,6 +17940,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17516,6 +17968,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17543,6 +17996,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17570,6 +18024,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17597,6 +18052,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17645,6 +18101,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17686,6 +18143,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17713,6 +18171,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17740,6 +18199,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17774,6 +18234,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17801,6 +18262,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17870,6 +18332,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17897,6 +18360,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17931,6 +18395,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17958,6 +18423,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17985,6 +18451,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18040,6 +18507,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18095,6 +18563,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18164,6 +18633,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18191,6 +18661,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18218,6 +18689,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18245,6 +18717,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18300,6 +18773,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18369,6 +18843,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18396,6 +18871,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18465,6 +18941,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18492,6 +18969,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18519,6 +18997,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18546,6 +19025,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18573,6 +19053,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18600,6 +19081,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18627,6 +19109,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18661,6 +19144,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18695,6 +19179,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18722,6 +19207,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18749,6 +19235,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18804,6 +19291,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18831,6 +19319,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18858,6 +19347,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18885,6 +19375,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18919,6 +19410,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18946,6 +19438,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18973,6 +19466,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19000,6 +19494,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19027,6 +19522,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19061,6 +19557,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19088,6 +19585,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19143,6 +19641,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19170,6 +19669,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19253,6 +19753,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19287,6 +19788,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19342,6 +19844,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19369,6 +19872,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19396,6 +19900,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19423,6 +19928,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19457,6 +19963,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19491,6 +19998,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19518,6 +20026,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19545,6 +20054,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19572,6 +20082,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19627,6 +20138,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19654,6 +20166,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19681,6 +20194,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19729,6 +20243,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19756,6 +20271,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19783,6 +20299,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19810,6 +20327,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19837,6 +20355,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19864,6 +20383,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19891,6 +20411,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19918,6 +20439,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19945,6 +20467,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -20014,6 +20537,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20041,6 +20565,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20068,6 +20593,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20095,6 +20621,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20129,6 +20656,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20156,6 +20684,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20183,6 +20712,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20210,6 +20740,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20279,6 +20810,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20306,6 +20838,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20347,6 +20880,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20374,6 +20908,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20443,6 +20978,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20505,6 +21041,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20532,6 +21069,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20601,6 +21139,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20628,6 +21167,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20655,6 +21195,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20682,6 +21223,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20709,6 +21251,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20736,6 +21279,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20763,6 +21307,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20790,6 +21335,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20824,6 +21370,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20914,6 +21461,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20941,6 +21489,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20968,6 +21517,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -21002,6 +21552,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21036,6 +21587,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21077,6 +21629,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21132,6 +21685,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21159,6 +21713,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21186,6 +21741,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21255,6 +21811,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21282,6 +21839,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21323,6 +21881,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21378,6 +21937,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21405,6 +21965,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21432,6 +21993,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21466,6 +22028,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21493,6 +22056,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21520,6 +22084,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21547,6 +22112,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21574,6 +22140,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21601,6 +22168,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21642,6 +22210,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21669,6 +22238,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21696,6 +22266,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21723,6 +22294,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21799,6 +22371,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21826,6 +22399,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21853,6 +22427,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21880,6 +22455,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21907,6 +22483,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21934,6 +22511,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21982,6 +22560,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22016,6 +22595,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22043,6 +22623,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22070,6 +22651,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22097,6 +22679,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22124,6 +22707,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22151,6 +22735,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22178,6 +22763,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22219,6 +22805,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22246,6 +22833,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22273,6 +22861,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22412,6 +23001,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22453,6 +23043,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22480,6 +23071,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22514,6 +23106,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22569,6 +23162,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22596,6 +23190,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22623,6 +23218,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22671,6 +23267,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22712,6 +23309,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22739,6 +23337,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22766,6 +23365,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22835,6 +23435,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22869,6 +23470,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22896,6 +23498,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22930,6 +23533,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22964,6 +23568,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22991,6 +23596,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -23018,6 +23624,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23045,6 +23652,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23072,6 +23680,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23099,6 +23708,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23126,6 +23736,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23181,6 +23792,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23208,6 +23820,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23263,6 +23876,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23325,6 +23939,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23352,6 +23967,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23379,6 +23995,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23420,6 +24037,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23475,6 +24093,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23502,6 +24121,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23529,6 +24149,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23556,6 +24177,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23590,6 +24212,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23617,6 +24240,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23651,6 +24275,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23678,6 +24303,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23726,6 +24352,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23753,6 +24380,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23780,6 +24408,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23807,6 +24436,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23834,6 +24464,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23889,6 +24520,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23916,6 +24548,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23943,6 +24576,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23998,6 +24632,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -24025,6 +24660,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24073,6 +24709,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24121,6 +24758,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24148,6 +24786,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24175,6 +24814,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24202,6 +24842,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24229,6 +24870,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24256,6 +24898,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24283,6 +24926,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24310,6 +24954,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24337,6 +24982,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24364,6 +25010,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24391,6 +25038,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24418,6 +25066,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24445,6 +25094,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24479,6 +25129,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24541,6 +25192,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24568,6 +25220,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24595,6 +25248,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24734,6 +25388,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24803,6 +25458,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24830,6 +25486,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24857,6 +25514,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24926,6 +25584,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24953,6 +25612,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24980,6 +25640,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -25007,6 +25668,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -25041,6 +25703,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25082,6 +25745,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25109,6 +25773,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25136,6 +25801,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25163,6 +25829,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25190,6 +25857,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25217,6 +25885,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25244,6 +25913,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25271,6 +25941,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25340,6 +26011,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25367,6 +26039,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25394,6 +26067,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25428,6 +26102,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25455,6 +26130,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25503,6 +26179,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25537,6 +26214,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25564,6 +26242,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25591,6 +26270,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25618,6 +26298,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25645,6 +26326,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25672,6 +26354,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25699,6 +26382,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25726,6 +26410,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25788,6 +26473,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25815,6 +26501,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25849,6 +26536,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25876,6 +26564,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25903,6 +26592,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25951,6 +26641,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25978,6 +26669,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -26005,6 +26697,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26032,6 +26725,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26066,6 +26760,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26163,6 +26858,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26190,6 +26886,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26252,6 +26949,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26279,6 +26977,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26306,6 +27005,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26333,6 +27033,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26360,6 +27061,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26387,6 +27089,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26414,6 +27117,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26448,6 +27152,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26475,6 +27180,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26544,6 +27250,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26571,6 +27278,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26668,6 +27376,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26695,6 +27404,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26722,6 +27432,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26749,6 +27460,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26776,6 +27488,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26803,6 +27516,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26858,6 +27572,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26885,6 +27600,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27073,6 +27789,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27100,6 +27817,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27127,6 +27845,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27154,6 +27873,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27188,6 +27908,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27215,6 +27936,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27291,6 +28013,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27318,6 +28041,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27359,6 +28083,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27386,6 +28111,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27427,6 +28153,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27517,6 +28244,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27544,6 +28272,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27571,6 +28300,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27598,6 +28328,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27625,6 +28356,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27652,6 +28384,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27679,6 +28412,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27706,6 +28440,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27733,6 +28468,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27760,6 +28496,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27787,6 +28524,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27814,6 +28552,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27841,6 +28580,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27868,6 +28608,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27972,6 +28713,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -28027,6 +28769,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -28054,6 +28797,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -28081,6 +28825,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28108,6 +28853,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28135,6 +28881,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28162,6 +28909,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28217,6 +28965,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28244,6 +28993,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28271,6 +29021,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28305,6 +29056,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28360,6 +29112,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28387,6 +29140,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28414,6 +29168,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28483,6 +29238,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28510,6 +29266,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28537,6 +29294,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28564,6 +29322,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28591,6 +29350,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28618,6 +29378,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28645,6 +29406,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28672,6 +29434,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28727,6 +29490,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28754,6 +29518,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28781,6 +29546,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28815,6 +29581,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28842,6 +29609,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28876,6 +29644,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28903,6 +29672,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28930,6 +29700,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28957,6 +29728,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -29040,6 +29812,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29067,6 +29840,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29136,6 +29910,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29233,6 +30008,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29260,6 +30036,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29287,6 +30064,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29314,6 +30092,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29383,6 +30162,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29410,6 +30190,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29465,6 +30246,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29492,6 +30274,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29519,6 +30302,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29546,6 +30330,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29587,6 +30372,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29614,6 +30400,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29648,6 +30435,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29675,6 +30463,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29702,6 +30491,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29729,6 +30519,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29756,6 +30547,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29790,6 +30582,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29817,6 +30610,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29844,6 +30638,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29871,6 +30666,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29898,6 +30694,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29925,6 +30722,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29952,6 +30750,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -30049,6 +30848,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -30076,6 +30876,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -30103,6 +30904,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30130,6 +30932,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30157,6 +30960,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30184,6 +30988,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30211,6 +31016,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30238,6 +31044,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30279,6 +31086,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30306,6 +31114,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30333,6 +31142,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30388,6 +31198,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30415,6 +31226,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30442,6 +31254,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30469,6 +31282,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30496,6 +31310,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30523,6 +31338,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30550,6 +31366,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30605,6 +31422,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30632,6 +31450,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30666,6 +31485,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30728,6 +31548,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30755,6 +31576,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30782,6 +31604,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30809,6 +31632,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30836,6 +31660,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30863,6 +31688,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30890,6 +31716,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30917,6 +31744,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30944,6 +31772,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30999,6 +31828,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -31026,6 +31856,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -31053,6 +31884,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31080,6 +31912,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -31107,6 +31940,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31134,6 +31968,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31168,6 +32003,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31195,6 +32031,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31250,6 +32087,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31277,6 +32115,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31304,6 +32143,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31331,6 +32171,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31358,6 +32199,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31385,6 +32227,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31412,6 +32255,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31439,6 +32283,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31564,6 +32409,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31591,6 +32437,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31618,6 +32465,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31645,6 +32493,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31700,6 +32549,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31727,6 +32577,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31782,6 +32633,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31809,6 +32661,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31836,6 +32689,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31891,6 +32745,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31925,6 +32780,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32015,6 +32871,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32042,6 +32899,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -32125,6 +32983,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32166,6 +33025,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32193,6 +33053,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32248,6 +33109,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32275,6 +33137,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32302,6 +33165,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32336,6 +33200,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32363,6 +33228,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32390,6 +33256,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32417,6 +33284,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32444,6 +33312,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32471,6 +33340,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32498,6 +33368,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32525,6 +33396,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32552,6 +33424,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32607,6 +33480,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32634,6 +33508,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32661,6 +33536,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32688,6 +33564,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32715,6 +33592,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32742,6 +33620,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32769,6 +33648,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32824,6 +33704,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32872,6 +33753,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32913,6 +33795,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32940,6 +33823,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32967,6 +33851,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32994,6 +33879,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33084,6 +33970,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33111,6 +33998,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33138,6 +34026,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33172,6 +34061,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33199,6 +34089,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33226,6 +34117,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33267,6 +34159,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33322,6 +34215,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33349,6 +34243,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33446,6 +34341,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33522,6 +34418,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33598,6 +34495,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33688,6 +34586,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33729,6 +34628,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33770,6 +34670,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33825,6 +34726,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33852,6 +34754,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33886,6 +34789,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33913,6 +34817,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33996,6 +34901,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -34023,6 +34929,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -34050,6 +34957,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34077,6 +34985,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34104,6 +35013,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -34131,6 +35041,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34172,6 +35083,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34199,6 +35111,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34268,6 +35181,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34295,6 +35209,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34322,6 +35237,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34349,6 +35265,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34376,6 +35293,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34403,6 +35321,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34437,6 +35356,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34471,6 +35391,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34568,6 +35489,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34595,6 +35517,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34622,6 +35545,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34649,6 +35573,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34676,6 +35601,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34703,6 +35629,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34758,6 +35685,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34785,6 +35713,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34875,6 +35804,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34930,6 +35860,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34957,6 +35888,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34984,6 +35916,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35011,6 +35944,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -35059,6 +35993,7 @@
         {
             "id": "0xe02e8ddecbe302ba1a40107c726e3ee889b0ff10",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
@@ -35093,6 +36028,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35120,6 +36056,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35147,6 +36084,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35279,6 +36217,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35306,6 +36245,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35333,6 +36273,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35360,6 +36301,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35387,6 +36329,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35414,6 +36357,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35441,6 +36385,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35468,6 +36413,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35495,6 +36441,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35522,6 +36469,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35584,6 +36532,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35632,6 +36581,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35659,6 +36609,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35686,6 +36637,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35713,6 +36665,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35740,6 +36693,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35774,6 +36728,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35801,6 +36756,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35828,6 +36784,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35855,6 +36812,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35882,6 +36840,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35930,6 +36889,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35985,6 +36945,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -36012,6 +36973,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -36039,6 +37001,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36073,6 +37036,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -36100,6 +37064,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36169,6 +37134,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36217,6 +37183,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36272,6 +37239,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36313,6 +37281,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36340,6 +37309,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36409,6 +37379,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36436,6 +37407,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36463,6 +37435,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36490,6 +37463,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36594,6 +37568,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36621,6 +37596,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36648,6 +37624,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36745,6 +37722,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36772,6 +37750,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36799,6 +37778,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36826,6 +37806,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36853,6 +37834,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36880,6 +37862,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36907,6 +37890,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36934,6 +37918,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36961,6 +37946,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36988,6 +37974,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -37015,6 +38002,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -37049,6 +38037,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -37076,6 +38065,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -37103,6 +38093,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37158,6 +38149,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37185,6 +38177,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37212,6 +38205,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37267,6 +38261,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37294,6 +38289,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37349,6 +38345,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37376,6 +38373,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37403,6 +38401,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37451,6 +38450,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37478,6 +38478,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37505,6 +38506,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37532,6 +38534,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37573,6 +38576,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37600,6 +38604,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37634,6 +38639,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37661,6 +38667,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37695,6 +38702,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37750,6 +38758,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37777,6 +38786,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37804,6 +38814,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37852,6 +38863,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37886,6 +38898,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37948,6 +38961,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37975,6 +38989,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -38002,6 +39017,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38050,6 +39066,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -38077,6 +39094,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38104,6 +39122,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -38152,6 +39171,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38179,6 +39199,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38290,6 +39311,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38345,6 +39367,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38372,6 +39395,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38420,6 +39444,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38447,6 +39472,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38516,6 +39542,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38543,6 +39570,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38598,6 +39626,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38625,6 +39654,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38652,6 +39682,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38679,6 +39710,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38706,6 +39738,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38733,6 +39766,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38795,6 +39829,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38822,6 +39857,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38870,6 +39906,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38897,6 +39934,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38924,6 +39962,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38951,6 +39990,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -39006,6 +40046,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39033,6 +40074,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -39060,6 +40102,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -39087,6 +40130,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -39156,6 +40200,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39183,6 +40228,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39210,6 +40256,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39286,6 +40333,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39313,6 +40361,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39347,6 +40396,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39381,6 +40431,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39415,6 +40466,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39442,6 +40494,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39469,6 +40522,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39496,6 +40550,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39530,6 +40585,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39557,6 +40613,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39584,6 +40641,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39611,6 +40669,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39645,6 +40704,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39679,6 +40739,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39706,6 +40767,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39733,6 +40795,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39844,6 +40907,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39871,6 +40935,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39898,6 +40963,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39925,6 +40991,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39980,6 +41047,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -40007,6 +41075,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40041,6 +41110,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40068,6 +41138,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -40165,6 +41236,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40192,6 +41264,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40219,6 +41292,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40246,6 +41320,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40315,6 +41390,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x81ddc85bdd36b0e8d21f340615d37e151017b516be2f6f20213654c45d75d6a9.json
+++ b/test/testData/testPools/0x81ddc85bdd36b0e8d21f340615d37e151017b516be2f6f20213654c45d75d6a9.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x820b13539ec5117e04380b53c766de9aa604bfb5d751392d3df3d1beff26e30a.json
+++ b/test/testData/testPools/0x820b13539ec5117e04380b53c766de9aa604bfb5d751392d3df3d1beff26e30a.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -827,6 +832,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1392,6 +1399,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1826,6 +1834,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1921,6 +1930,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1955,6 +1965,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2031,6 +2042,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2133,6 +2145,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2406,6 +2419,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2433,6 +2447,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2494,6 +2509,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2636,6 +2652,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3002,6 +3019,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3362,6 +3380,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4047,6 +4066,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4217,6 +4237,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4319,6 +4340,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4400,6 +4422,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4739,6 +4762,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4957,6 +4981,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5026,6 +5051,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5080,6 +5106,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5249,6 +5276,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5358,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5466,6 +5495,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5635,6 +5665,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5886,6 +5917,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6355,6 +6387,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6900,6 +6933,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6981,6 +7015,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7157,6 +7192,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7320,6 +7356,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7455,6 +7492,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7578,6 +7616,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7658,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7788,6 +7828,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8161,6 +8202,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8474,6 +8516,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8624,6 +8667,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +8933,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9174,6 +9219,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9269,6 +9315,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10362,6 +10409,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10491,6 +10539,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10599,6 +10648,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10680,6 +10730,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10953,6 +11004,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10980,6 +11032,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11641,6 +11694,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11979,6 +12033,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12264,6 +12319,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12508,6 +12564,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12719,6 +12776,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12746,6 +12804,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12794,6 +12853,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12862,6 +12922,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13182,6 +13243,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13353,6 +13415,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13421,6 +13484,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13482,6 +13546,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13523,6 +13588,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13619,6 +13685,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13998,6 +14065,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14195,6 +14263,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14222,6 +14291,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14291,6 +14361,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14548,6 +14619,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14698,6 +14770,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14806,6 +14879,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14887,6 +14961,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15083,6 +15158,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15382,6 +15458,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15451,6 +15528,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15850,6 +15928,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16481,6 +16560,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16671,6 +16751,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16908,6 +16989,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16977,6 +17059,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17180,6 +17263,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17465,6 +17549,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17866,6 +17951,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18049,6 +18135,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18103,6 +18190,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18307,6 +18395,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19149,6 +19238,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19230,6 +19320,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19257,6 +19348,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19345,6 +19437,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19595,6 +19688,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20232,6 +20326,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20845,6 +20940,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21343,6 +21439,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21742,6 +21839,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22291,6 +22389,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22318,6 +22417,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22359,6 +22459,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22529,6 +22630,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23140,6 +23242,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23276,6 +23379,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23432,6 +23536,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23845,6 +23950,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23953,6 +24059,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24604,6 +24711,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24645,6 +24753,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25278,6 +25387,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25739,6 +25849,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26085,6 +26196,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26112,6 +26224,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26616,6 +26729,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26805,6 +26919,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26886,6 +27001,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26948,6 +27064,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27017,6 +27134,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27213,6 +27331,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27424,6 +27543,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27451,6 +27571,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27863,6 +27984,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27890,6 +28012,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27965,6 +28088,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28154,6 +28278,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28296,6 +28421,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28662,6 +28788,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28946,6 +29073,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29166,6 +29294,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29315,6 +29444,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29911,6 +30041,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30291,6 +30422,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30534,6 +30666,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31178,6 +31311,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31435,6 +31569,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31490,6 +31625,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31625,6 +31761,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31932,6 +32069,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32027,6 +32165,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32170,6 +32309,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32528,6 +32668,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32744,6 +32885,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33003,6 +33145,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33240,6 +33383,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33321,6 +33465,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33417,6 +33562,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33492,6 +33638,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33567,6 +33714,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33594,6 +33742,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33737,6 +33886,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33764,6 +33914,7 @@
         {
             "id": "0xd8e72a62e214864cbd9381cc04fa1006a8c8fb10",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23b608675a2b2fb1890d3abbd85c5775c51691d5",
@@ -33948,6 +34099,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33975,6 +34127,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34504,6 +34657,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34824,6 +34978,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34851,6 +35006,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34905,6 +35061,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35142,6 +35299,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35169,6 +35327,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35217,6 +35376,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35922,6 +36082,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36481,6 +36642,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36508,6 +36670,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36637,6 +36800,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37091,6 +37255,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37682,6 +37847,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37872,6 +38038,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38164,6 +38331,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38205,6 +38373,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38273,6 +38442,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38443,6 +38613,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38524,6 +38695,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38720,6 +38892,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38930,6 +39103,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39188,6 +39362,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39724,6 +39899,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39901,6 +40077,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40043,6 +40220,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x8401ce3cdc364d96f6f2722521215d05d2e52033b225456fb32e82620d51a925.json
+++ b/test/testData/testPools/0x8401ce3cdc364d96f6f2722521215d05d2e52033b225456fb32e82620d51a925.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -94,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -169,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -196,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -230,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -257,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -284,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -311,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -338,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -365,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -392,6 +405,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -419,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -467,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -508,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -535,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -562,6 +580,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +608,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -616,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -643,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -691,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -718,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -745,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -800,6 +825,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -848,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -875,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -902,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -929,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -956,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -997,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1024,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1065,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1092,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1161,6 +1196,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1230,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1257,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1284,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1311,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1338,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1365,6 +1406,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1392,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1419,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1467,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1494,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1542,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1569,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1596,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1623,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1664,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1691,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1718,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1745,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1772,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1799,6 +1854,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1826,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1867,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1894,6 +1952,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1987,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -1976,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2004,6 +2065,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2051,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2169,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2168,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2216,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2243,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2270,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2325,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2352,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2379,6 +2449,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2477,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2440,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2467,6 +2540,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2494,6 +2569,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2528,6 +2604,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2555,6 +2632,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2582,6 +2660,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2609,6 +2688,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2657,6 +2737,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2684,6 +2765,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2718,6 +2800,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2745,6 +2828,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2772,6 +2856,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2799,6 +2884,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2826,6 +2912,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2860,6 +2947,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2887,6 +2975,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2914,6 +3003,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2941,6 +3031,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -2975,6 +3066,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3044,6 +3136,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3078,6 +3171,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3105,6 +3199,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3132,6 +3227,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3159,6 +3255,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3200,6 +3297,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3227,6 +3325,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3254,6 +3353,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3281,6 +3381,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3308,6 +3409,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3335,6 +3437,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3376,6 +3479,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3424,6 +3528,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3451,6 +3556,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3478,6 +3584,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3505,6 +3612,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3532,6 +3640,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3601,6 +3710,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3628,6 +3738,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3655,6 +3766,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3682,6 +3794,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3709,6 +3822,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3736,6 +3850,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3763,6 +3878,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3790,6 +3906,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3824,6 +3941,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3851,6 +3969,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3878,6 +3997,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3905,6 +4025,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3939,6 +4060,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3966,6 +4088,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -3993,6 +4116,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4020,6 +4144,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4047,6 +4172,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4088,6 +4214,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4115,6 +4242,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4163,6 +4291,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4190,6 +4319,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4238,6 +4368,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4265,6 +4396,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4292,6 +4424,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4319,6 +4452,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4346,6 +4480,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4373,6 +4508,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4428,6 +4564,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4469,6 +4606,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4496,6 +4634,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4523,6 +4662,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4550,6 +4690,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4577,6 +4718,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4604,6 +4746,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4774,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4658,6 +4802,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4685,6 +4830,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4712,6 +4858,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4739,6 +4886,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4808,6 +4956,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4835,6 +4984,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4862,6 +5012,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4889,6 +5040,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -4930,6 +5082,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5152,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5026,6 +5180,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5053,6 +5208,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5080,6 +5236,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5114,6 +5271,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5141,6 +5299,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5168,6 +5327,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5195,6 +5355,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5222,6 +5383,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5249,6 +5411,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5276,6 +5439,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5303,6 +5467,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5495,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5357,6 +5523,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5412,6 +5579,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5439,6 +5607,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5473,6 +5642,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5500,6 +5670,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5527,6 +5698,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5554,6 +5726,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5581,6 +5754,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5608,6 +5782,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5635,6 +5810,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5669,6 +5845,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5696,6 +5873,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5723,6 +5901,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5778,6 +5957,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5805,6 +5985,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5832,6 +6013,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5859,6 +6041,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -5886,6 +6070,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5913,6 +6098,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5940,6 +6126,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5967,6 +6154,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5994,6 +6182,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6021,6 +6210,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6069,6 +6259,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6096,6 +6287,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6137,6 +6329,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6185,6 +6378,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6212,6 +6406,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6239,6 +6434,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6294,6 +6490,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6328,6 +6525,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6369,6 +6567,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6438,6 +6637,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6465,6 +6665,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6499,6 +6700,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6526,6 +6728,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6553,6 +6756,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6580,6 +6784,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6607,6 +6812,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6634,6 +6840,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6661,6 +6868,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6688,6 +6896,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6750,6 +6959,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6819,6 +7029,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6846,6 +7057,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6873,6 +7085,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6900,6 +7113,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6927,6 +7141,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6954,6 +7169,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -6988,6 +7204,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7015,6 +7232,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7042,6 +7260,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7069,6 +7288,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7103,6 +7323,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7130,6 +7351,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7157,6 +7379,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7184,6 +7407,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7239,6 +7463,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7266,6 +7491,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7293,6 +7519,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7320,6 +7547,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7347,6 +7575,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7374,6 +7603,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7401,6 +7631,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7428,6 +7659,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7455,6 +7687,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7482,6 +7715,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7551,6 +7785,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7827,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7855,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7646,6 +7883,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7673,6 +7911,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7700,6 +7939,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7727,6 +7967,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7761,6 +8002,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7788,6 +8030,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7822,6 +8065,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7849,6 +8093,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7876,6 +8121,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7924,6 +8170,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7951,6 +8198,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -7978,6 +8226,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8005,6 +8254,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8032,6 +8282,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8059,6 +8310,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8086,6 +8338,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8134,6 +8387,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8161,6 +8416,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8188,6 +8444,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8222,6 +8479,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8249,6 +8507,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8276,6 +8535,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8317,6 +8577,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8344,6 +8605,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8378,6 +8640,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8447,6 +8710,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8474,6 +8738,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8501,6 +8766,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8528,6 +8794,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8597,6 +8864,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8624,6 +8892,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8651,6 +8920,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8678,6 +8948,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8712,6 +8983,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8739,6 +9011,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8787,6 +9060,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8835,6 +9109,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8862,6 +9137,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +9165,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8916,6 +9193,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8943,6 +9221,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -8970,6 +9249,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8997,6 +9277,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9066,6 +9347,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9093,6 +9375,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9120,6 +9403,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9147,6 +9431,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9174,6 +9459,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9215,6 +9501,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9242,6 +9529,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -9311,6 +9599,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9359,6 +9648,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9386,6 +9676,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9455,6 +9746,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9503,6 +9795,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9530,6 +9823,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9557,6 +9851,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9584,6 +9879,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9611,6 +9907,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9638,6 +9935,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9665,6 +9963,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9692,6 +9991,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9719,6 +10019,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9746,6 +10047,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9773,6 +10075,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9800,6 +10103,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9827,6 +10131,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9854,6 +10159,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9881,6 +10187,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9908,6 +10215,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9935,6 +10243,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -9962,6 +10271,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10003,6 +10313,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10030,6 +10341,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10057,6 +10369,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10112,6 +10425,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10139,6 +10453,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10166,6 +10481,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10200,6 +10516,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10227,6 +10544,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10254,6 +10572,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10281,6 +10600,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10308,6 +10628,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10335,6 +10656,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10362,6 +10684,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10389,6 +10712,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10437,6 +10761,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10464,6 +10789,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10491,6 +10817,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10518,6 +10845,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10545,6 +10873,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10572,6 +10901,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10599,6 +10929,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10626,6 +10957,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10653,6 +10985,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10715,6 +11048,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10742,6 +11076,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10769,6 +11104,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10796,6 +11132,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10865,6 +11202,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10899,6 +11237,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -10926,6 +11265,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11293,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -10980,6 +11321,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11007,6 +11349,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11055,6 +11398,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11082,6 +11426,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11130,6 +11475,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11157,6 +11503,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11184,6 +11531,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11246,6 +11594,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11287,6 +11636,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11314,6 +11664,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11341,6 +11692,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11368,6 +11720,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11395,6 +11748,7 @@
         {
             "id": "0x4b3fa856cef9aa85ed9bbfa8992d6138c5f150e6",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -11464,6 +11818,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11533,6 +11888,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11560,6 +11916,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11587,6 +11944,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11614,6 +11972,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11648,6 +12007,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11682,6 +12042,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11709,6 +12070,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11736,6 +12098,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11763,6 +12126,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11790,6 +12154,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11817,6 +12182,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11844,6 +12210,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11871,6 +12238,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11898,6 +12266,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11925,6 +12294,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11952,6 +12322,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -11979,6 +12350,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12006,6 +12378,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12033,6 +12406,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12060,6 +12434,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12122,6 +12497,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12156,6 +12532,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12183,6 +12560,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12210,6 +12588,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12237,6 +12616,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12264,6 +12644,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12319,6 +12700,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12346,6 +12728,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12373,6 +12756,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12400,6 +12784,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12427,6 +12812,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12454,6 +12840,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12481,6 +12868,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12508,6 +12896,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12577,6 +12966,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12604,6 +12994,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12631,6 +13022,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12665,6 +13057,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12692,6 +13085,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +13113,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +13162,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12794,6 +13190,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +13232,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12890,6 +13288,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12924,6 +13323,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12993,6 +13393,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13020,6 +13421,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13047,6 +13449,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13074,6 +13477,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13101,6 +13505,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13128,6 +13533,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13155,6 +13561,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13182,6 +13589,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13209,6 +13617,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13257,6 +13666,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13326,6 +13736,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13353,6 +13764,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13394,6 +13806,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13421,6 +13834,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13455,6 +13869,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13911,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13565,6 +13981,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13592,6 +14009,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13619,6 +14037,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13646,6 +14065,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13673,6 +14093,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13728,6 +14149,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13755,6 +14177,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13782,6 +14205,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13809,6 +14233,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13836,6 +14261,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13863,6 +14289,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13890,6 +14317,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13917,6 +14345,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13944,6 +14373,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -13971,6 +14401,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14033,6 +14464,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14060,6 +14492,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14087,6 +14520,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14114,6 +14548,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14141,6 +14576,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14604,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14674,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14264,6 +14702,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14291,6 +14730,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14318,6 +14758,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14345,6 +14786,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14386,6 +14828,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14413,6 +14856,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14440,6 +14884,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14467,6 +14912,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14494,6 +14940,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14521,6 +14968,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14548,6 +14996,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14575,6 +15024,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14644,6 +15094,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14671,6 +15122,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14698,6 +15150,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14725,6 +15178,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14752,6 +15206,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14779,6 +15234,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14806,6 +15262,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14833,6 +15290,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14867,6 +15325,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14894,6 +15353,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14921,6 +15381,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14948,6 +15409,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14975,6 +15437,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15002,6 +15465,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15029,6 +15493,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15056,6 +15521,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15125,6 +15591,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15152,6 +15619,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15179,6 +15647,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15206,6 +15675,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15233,6 +15703,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15260,6 +15731,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15287,6 +15759,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15328,6 +15801,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15871,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15424,6 +15899,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15451,6 +15927,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15478,6 +15955,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15505,6 +15983,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15532,6 +16011,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15573,6 +16053,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15600,6 +16081,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15627,6 +16109,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15654,6 +16137,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15681,6 +16165,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15715,6 +16200,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15742,6 +16228,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15769,6 +16256,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15796,6 +16284,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -15865,6 +16354,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15892,6 +16382,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15919,6 +16410,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15946,6 +16438,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15973,6 +16466,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16000,6 +16494,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16027,6 +16522,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16054,6 +16550,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16081,6 +16578,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16108,6 +16606,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16135,6 +16634,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16176,6 +16676,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16203,6 +16704,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16230,6 +16732,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16292,6 +16795,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16319,6 +16823,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16346,6 +16851,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16373,6 +16879,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16400,6 +16907,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16427,6 +16935,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16454,6 +16963,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16481,6 +16991,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16508,6 +17019,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16535,6 +17047,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16562,6 +17075,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16617,6 +17131,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16651,6 +17166,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16678,6 +17194,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16705,6 +17222,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16732,6 +17250,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16759,6 +17278,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16786,6 +17306,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16813,6 +17334,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16854,6 +17376,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17446,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -16957,6 +17481,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16984,6 +17509,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17011,6 +17537,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17038,6 +17565,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17065,6 +17593,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17099,6 +17628,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17126,6 +17656,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17153,6 +17684,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17222,6 +17754,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17249,6 +17782,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17276,6 +17810,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17303,6 +17838,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17330,6 +17866,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17357,6 +17894,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17384,6 +17922,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17411,6 +17950,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17473,6 +18013,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17500,6 +18041,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17527,6 +18069,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17554,6 +18097,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17581,6 +18125,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17629,6 +18174,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17670,6 +18216,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17697,6 +18244,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17724,6 +18272,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17758,6 +18307,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17785,6 +18335,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17812,6 +18363,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17853,6 +18405,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17880,6 +18433,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17914,6 +18468,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17941,6 +18496,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17968,6 +18524,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17995,6 +18552,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18022,6 +18580,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18049,6 +18608,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18076,6 +18636,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18145,6 +18706,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18172,6 +18734,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18199,6 +18762,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18226,6 +18790,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18253,6 +18818,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -18280,6 +18846,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18349,6 +18916,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18376,6 +18944,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18445,6 +19014,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18472,6 +19042,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18499,6 +19070,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18526,6 +19098,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18553,6 +19126,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18580,6 +19154,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18607,6 +19182,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18641,6 +19217,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18675,6 +19252,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18702,6 +19280,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18729,6 +19308,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18784,6 +19364,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18811,6 +19392,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18838,6 +19420,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18865,6 +19448,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18899,6 +19483,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18926,6 +19511,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18953,6 +19539,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18980,6 +19567,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19007,6 +19595,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19041,6 +19630,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19068,6 +19658,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19095,6 +19686,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19122,6 +19714,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19149,6 +19742,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19176,6 +19770,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19798,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19230,6 +19826,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19264,6 +19861,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19291,6 +19889,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19318,6 +19917,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19345,6 +19945,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19372,6 +19973,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19399,6 +20001,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19433,6 +20036,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19460,6 +20064,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19487,6 +20092,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19514,6 +20120,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19541,6 +20148,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -19568,6 +20176,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19595,6 +20204,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19622,6 +20232,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19670,6 +20281,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19697,6 +20309,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19724,6 +20337,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19751,6 +20365,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19778,6 +20393,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19805,6 +20421,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19832,6 +20449,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19859,6 +20477,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19886,6 +20505,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -19955,6 +20575,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19982,6 +20603,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20009,6 +20631,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20036,6 +20659,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20070,6 +20694,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20097,6 +20722,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20124,6 +20750,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20151,6 +20778,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20178,6 +20806,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20219,6 +20848,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20246,6 +20876,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20287,6 +20918,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20314,6 +20946,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20383,6 +21016,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20445,6 +21079,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20472,6 +21107,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20541,6 +21177,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20568,6 +21205,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20595,6 +21233,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20622,6 +21261,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20649,6 +21289,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20676,6 +21317,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20703,6 +21345,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20730,6 +21373,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20764,6 +21408,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20791,6 +21436,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -20853,6 +21499,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20880,6 +21527,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20907,6 +21555,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -20941,6 +21590,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20975,6 +21625,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21016,6 +21667,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21071,6 +21723,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21098,6 +21751,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21125,6 +21779,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21194,6 +21849,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21221,6 +21877,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21262,6 +21919,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21289,6 +21947,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21316,6 +21975,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21343,6 +22003,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21370,6 +22031,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21404,6 +22066,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21431,6 +22094,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21458,6 +22122,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21485,6 +22150,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21512,6 +22178,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21539,6 +22206,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21580,6 +22248,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21607,6 +22276,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21634,6 +22304,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21661,6 +22332,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21688,6 +22360,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -21736,6 +22409,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21763,6 +22437,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21790,6 +22465,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21817,6 +22493,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21844,6 +22521,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21871,6 +22549,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21919,6 +22598,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -21953,6 +22633,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21980,6 +22661,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22007,6 +22689,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22034,6 +22717,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22061,6 +22745,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22088,6 +22773,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22115,6 +22801,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22156,6 +22843,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22183,6 +22871,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22210,6 +22899,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22237,6 +22927,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22955,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22997,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22346,6 +23039,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22387,6 +23081,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22414,6 +23109,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22448,6 +23144,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22475,6 +23172,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -22502,6 +23200,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22529,6 +23228,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22556,6 +23256,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22604,6 +23305,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22645,6 +23347,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22672,6 +23375,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22699,6 +23403,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22768,6 +23473,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22802,6 +23508,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22829,6 +23536,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22863,6 +23571,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22897,6 +23606,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22924,6 +23634,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22951,6 +23662,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -22978,6 +23690,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23005,6 +23718,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23032,6 +23746,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23059,6 +23774,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23086,6 +23802,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23113,6 +23830,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23140,6 +23858,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23195,6 +23914,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23222,6 +23942,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23256,6 +23977,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23283,6 +24005,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23310,6 +24033,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23351,6 +24075,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23378,6 +24103,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23405,6 +24131,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23432,6 +24159,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23459,6 +24187,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23486,6 +24215,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23520,6 +24250,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23547,6 +24278,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23581,6 +24313,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23608,6 +24341,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23656,6 +24390,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23683,6 +24418,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23710,6 +24446,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23737,6 +24474,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23764,6 +24502,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23791,6 +24530,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23818,6 +24558,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23845,6 +24586,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23872,6 +24614,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23899,6 +24642,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -23926,6 +24670,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -23953,6 +24698,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24001,6 +24747,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24049,6 +24796,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24076,6 +24824,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24103,6 +24852,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24130,6 +24880,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24157,6 +24908,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24184,6 +24936,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24211,6 +24964,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24238,6 +24992,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24265,6 +25020,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24292,6 +25048,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24319,6 +25076,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24346,6 +25104,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24373,6 +25132,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24407,6 +25167,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24469,6 +25230,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24496,6 +25258,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24523,6 +25286,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24550,6 +25314,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +25356,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -24660,6 +25426,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24729,6 +25496,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24756,6 +25524,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24783,6 +25552,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24852,6 +25622,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24879,6 +25650,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24906,6 +25678,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24933,6 +25706,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -24967,6 +25741,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25008,6 +25783,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25035,6 +25811,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25062,6 +25839,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25089,6 +25867,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25116,6 +25895,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25143,6 +25923,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25170,6 +25951,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25197,6 +25979,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25224,6 +26007,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25265,6 +26049,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25292,6 +26077,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25319,6 +26105,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25353,6 +26140,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25380,6 +26168,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25428,6 +26217,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25462,6 +26252,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25489,6 +26280,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25516,6 +26308,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25543,6 +26336,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25570,6 +26364,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25597,6 +26392,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25624,6 +26420,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25651,6 +26448,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25685,6 +26483,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25712,6 +26511,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25739,6 +26539,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25773,6 +26574,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25800,6 +26602,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25827,6 +26630,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25875,6 +26679,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25902,6 +26707,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -25929,6 +26735,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25956,6 +26763,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25990,6 +26798,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26031,6 +26840,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26868,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26085,6 +26896,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26112,6 +26924,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26174,6 +26987,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26201,6 +27015,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26228,6 +27043,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26255,6 +27071,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26282,6 +27099,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26309,6 +27127,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26336,6 +27155,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26370,6 +27190,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26397,6 +27218,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26466,6 +27288,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26493,6 +27316,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26562,6 +27386,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26589,6 +27414,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26616,6 +27442,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26643,6 +27470,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26670,6 +27498,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26697,6 +27526,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26724,6 +27554,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26751,6 +27582,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26778,6 +27610,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26805,6 +27638,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26832,6 +27666,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27729,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27799,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -26990,6 +27827,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27017,6 +27855,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27044,6 +27883,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27071,6 +27911,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27105,6 +27946,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27132,6 +27974,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27159,6 +28002,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27207,6 +28051,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27234,6 +28079,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27275,6 +28121,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27302,6 +28149,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27343,6 +28191,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27370,6 +28219,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +28247,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27431,6 +28282,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +28310,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27485,6 +28338,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27512,6 +28366,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27539,6 +28394,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27566,6 +28422,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27593,6 +28450,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27620,6 +28478,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27647,6 +28506,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27674,6 +28534,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27701,6 +28562,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27728,6 +28590,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27755,6 +28618,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27782,6 +28646,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27809,6 +28674,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +28702,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27884,6 +28751,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -27911,6 +28779,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27938,6 +28807,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -27965,6 +28835,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -27992,6 +28863,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28019,6 +28891,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28046,6 +28919,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28073,6 +28947,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28100,6 +28975,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28127,6 +29003,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28154,6 +29031,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28181,6 +29059,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28215,6 +29094,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28242,6 +29122,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28269,6 +29150,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28296,6 +29178,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28323,6 +29206,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28392,6 +29276,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28419,6 +29304,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28446,6 +29332,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28473,6 +29360,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28500,6 +29388,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28527,6 +29416,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28554,6 +29444,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28581,6 +29472,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28608,6 +29500,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28635,6 +29528,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28662,6 +29556,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28689,6 +29584,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28723,6 +29619,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28750,6 +29647,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28784,6 +29682,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28811,6 +29710,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28838,6 +29738,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28865,6 +29766,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -28892,6 +29794,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28947,6 +29850,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28974,6 +29878,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29043,6 +29948,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29112,6 +30018,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29139,6 +30046,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29166,6 +30074,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29193,6 +30102,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29220,6 +30130,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29261,6 +30172,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29288,6 +30200,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29315,6 +30228,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29370,6 +30284,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29397,6 +30312,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29424,6 +30340,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29451,6 +30368,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29492,6 +30410,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29519,6 +30438,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29553,6 +30473,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29580,6 +30501,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29607,6 +30529,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29634,6 +30557,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29661,6 +30585,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29695,6 +30620,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29722,6 +30648,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29749,6 +30676,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29776,6 +30704,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29803,6 +30732,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29830,6 +30760,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29857,6 +30788,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29926,6 +30858,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -29953,6 +30886,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -29980,6 +30914,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30007,6 +30942,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30034,6 +30970,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30061,6 +30998,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30088,6 +31026,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30115,6 +31054,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30156,6 +31096,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30183,6 +31124,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30210,6 +31152,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30237,6 +31180,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30264,6 +31208,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30291,6 +31236,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30318,6 +31264,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30345,6 +31292,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30372,6 +31320,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30399,6 +31348,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30426,6 +31376,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30453,6 +31404,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -30480,6 +31432,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30507,6 +31460,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30541,6 +31495,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30603,6 +31558,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30630,6 +31586,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30657,6 +31614,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30684,6 +31642,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30711,6 +31670,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30738,6 +31698,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30765,6 +31726,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30792,6 +31754,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30819,6 +31782,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30874,6 +31838,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -30901,6 +31866,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30928,6 +31894,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30955,6 +31922,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -30982,6 +31950,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31009,6 +31978,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31043,6 +32013,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31070,6 +32041,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31097,6 +32069,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31124,6 +32097,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31151,6 +32125,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31178,6 +32153,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31205,6 +32181,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31232,6 +32209,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31259,6 +32237,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31286,6 +32265,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31313,6 +32293,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31354,6 +32335,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +32391,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31436,6 +32419,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31463,6 +32447,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31490,6 +32475,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31517,6 +32503,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31544,6 +32531,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31571,6 +32559,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31598,6 +32587,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31653,6 +32643,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31680,6 +32671,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31707,6 +32699,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31762,6 +32755,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31796,6 +32790,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31851,6 +32846,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31885,6 +32881,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31912,6 +32909,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -31946,6 +32944,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31994,6 +32993,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32035,6 +33035,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32062,6 +33063,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32089,6 +33091,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32116,6 +33119,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32143,6 +33147,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32170,6 +33175,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32204,6 +33210,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32231,6 +33238,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32258,6 +33266,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32285,6 +33294,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32312,6 +33322,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32339,6 +33350,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32366,6 +33378,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32393,6 +33406,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32420,6 +33434,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32447,6 +33462,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32474,6 +33490,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32501,6 +33518,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32528,6 +33546,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32555,6 +33574,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32582,6 +33602,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32609,6 +33630,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32636,6 +33658,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32663,6 +33686,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32690,6 +33714,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32738,6 +33763,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32779,6 +33805,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32806,6 +33833,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32833,6 +33861,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32860,6 +33889,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32922,6 +33952,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -32949,6 +33980,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -32976,6 +34008,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33003,6 +34036,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33037,6 +34071,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33064,6 +34099,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33091,6 +34127,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33132,6 +34169,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33159,6 +34197,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33186,6 +34225,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33213,6 +34253,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33240,6 +34281,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33309,6 +34351,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33336,6 +34379,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33384,6 +34428,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33411,6 +34456,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33459,6 +34505,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +34533,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +34562,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33547,6 +34597,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33588,6 +34639,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33629,6 +34681,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33656,6 +34709,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33683,6 +34737,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33710,6 +34765,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33744,6 +34800,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33771,6 +34828,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33798,6 +34856,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +34884,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -33852,6 +34912,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -33879,6 +34940,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -33906,6 +34968,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33933,6 +34996,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33960,6 +35024,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -33987,6 +35052,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34028,6 +35094,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34055,6 +35122,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34124,6 +35192,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34151,6 +35220,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34178,6 +35248,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34205,6 +35276,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34232,6 +35304,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34259,6 +35332,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34293,6 +35367,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34327,6 +35402,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34354,6 +35430,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34423,6 +35500,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34450,6 +35528,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34477,6 +35556,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34504,6 +35584,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +35612,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34558,6 +35640,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34613,6 +35696,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34640,6 +35724,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34674,6 +35759,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +35787,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34728,6 +35815,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34755,6 +35843,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34782,6 +35871,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34809,6 +35899,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34836,6 +35927,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -34863,6 +35955,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -34911,6 +36004,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34938,6 +36032,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34965,6 +36060,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34992,6 +36088,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +36116,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +36165,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35094,6 +36193,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35121,6 +36221,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35148,6 +36249,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35175,6 +36277,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35202,6 +36305,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35229,6 +36333,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35256,6 +36361,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35283,6 +36389,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35310,6 +36417,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35337,6 +36445,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35399,6 +36508,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35447,6 +36557,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35474,6 +36585,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35501,6 +36613,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35528,6 +36641,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35555,6 +36669,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35589,6 +36704,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35616,6 +36732,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35643,6 +36760,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35670,6 +36788,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35697,6 +36816,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35745,6 +36865,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35772,6 +36893,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -35799,6 +36921,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35826,6 +36949,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -35853,6 +36977,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35887,6 +37012,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -35914,6 +37040,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -35983,6 +37110,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36031,6 +37159,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36086,6 +37215,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36127,6 +37257,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36154,6 +37285,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36223,6 +37355,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36250,6 +37383,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36277,6 +37411,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36304,6 +37439,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36331,6 +37467,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +37495,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36406,6 +37544,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36433,6 +37572,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36460,6 +37600,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36487,6 +37628,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36556,6 +37698,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36583,6 +37726,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36610,6 +37754,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36637,6 +37782,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36664,6 +37810,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36691,6 +37838,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36718,6 +37866,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36745,6 +37894,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36772,6 +37922,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36799,6 +37950,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36826,6 +37978,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -36860,6 +38013,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -36887,6 +38041,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -36914,6 +38069,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36941,6 +38097,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -36968,6 +38125,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -36995,6 +38153,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37022,6 +38181,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37077,6 +38237,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37104,6 +38265,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37159,6 +38321,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37186,6 +38349,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37213,6 +38377,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37261,6 +38426,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37288,6 +38454,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37315,6 +38482,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37342,6 +38510,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37383,6 +38552,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37410,6 +38580,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37444,6 +38615,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37471,6 +38643,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37505,6 +38678,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37532,6 +38706,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37559,6 +38734,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37586,6 +38762,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37613,6 +38790,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37661,6 +38839,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37695,6 +38874,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37722,6 +38902,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -37756,6 +38937,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37783,6 +38965,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37810,6 +38993,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -37858,6 +39042,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37885,6 +39070,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37912,6 +39098,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -37960,6 +39147,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -37987,6 +39175,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38014,6 +39203,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +39245,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38096,6 +39287,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38123,6 +39315,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38150,6 +39343,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38177,6 +39371,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38225,6 +39420,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38252,6 +39448,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38293,6 +39490,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38320,6 +39518,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38347,6 +39546,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38374,6 +39574,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38401,6 +39602,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38428,6 +39630,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38455,6 +39658,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38482,6 +39686,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38509,6 +39714,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38536,6 +39742,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38570,6 +39777,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38597,6 +39805,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38624,6 +39833,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38672,6 +39882,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38699,6 +39910,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38726,6 +39938,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38753,6 +39966,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38780,6 +39994,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -38807,6 +40022,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -38834,6 +40050,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -38861,6 +40078,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -38888,6 +40106,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38957,6 +40176,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38984,6 +40204,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39011,6 +40232,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39038,6 +40260,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39086,6 +40309,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39113,6 +40337,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39147,6 +40372,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39181,6 +40407,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39215,6 +40442,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39242,6 +40470,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39269,6 +40498,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39296,6 +40526,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39330,6 +40561,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39357,6 +40589,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39384,6 +40617,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39411,6 +40645,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39445,6 +40680,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39479,6 +40715,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39506,6 +40743,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39533,6 +40771,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39574,6 +40813,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39643,6 +40883,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39670,6 +40911,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39697,6 +40939,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39724,6 +40967,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39751,6 +40995,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39778,6 +41023,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39805,6 +41051,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39839,6 +41086,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39866,6 +41114,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -39893,6 +41142,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39962,6 +41212,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -39989,6 +41240,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40016,6 +41268,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40043,6 +41296,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40112,6 +41366,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x8401ce3cdc364d96f6f2722521215d05d2e52033b225456fb32e82620d51a925.json
+++ b/test/testData/testPools/0x8401ce3cdc364d96f6f2722521215d05d2e52033b225456fb32e82620d51a925.json
@@ -2541,7 +2541,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6042,7 +6041,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8387,7 +8385,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -34533,7 +34530,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0x855d140758a5d0e8839d772ffa8e3afecc522bfbae621cdc91069bfeaaac490c.json
+++ b/test/testData/testPools/0x855d140758a5d0e8839d772ffa8e3afecc522bfbae621cdc91069bfeaaac490c.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x855d140758a5d0e8839d772ffa8e3afecc522bfbae621cdc91069bfeaaac490c.json
+++ b/test/testData/testPools/0x855d140758a5d0e8839d772ffa8e3afecc522bfbae621cdc91069bfeaaac490c.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -171,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -198,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -232,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -259,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -286,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -313,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -340,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -367,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -422,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -470,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -511,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -538,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -621,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -648,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -696,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -723,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -750,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -854,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -881,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -908,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -935,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -962,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1003,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1030,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1071,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1098,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1237,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1264,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1291,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1318,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1345,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1400,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1427,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1475,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1502,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1550,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1577,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1604,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1631,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1672,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1699,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1726,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1753,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1780,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1835,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1876,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1987,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2063,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2181,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2229,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2256,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2283,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2338,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2365,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2455,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2510,6 +2568,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2544,6 +2603,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2571,6 +2631,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2598,6 +2659,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2674,6 +2736,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2701,6 +2764,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2735,6 +2799,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2762,6 +2827,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2789,6 +2855,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2816,6 +2883,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2843,6 +2911,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2877,6 +2946,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2904,6 +2974,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2931,6 +3002,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2958,6 +3030,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3062,6 +3135,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3096,6 +3170,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3123,6 +3198,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3150,6 +3226,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3177,6 +3254,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3218,6 +3296,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3245,6 +3324,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3272,6 +3352,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3299,6 +3380,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3326,6 +3408,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3395,6 +3478,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3443,6 +3527,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3470,6 +3555,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3497,6 +3583,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3524,6 +3611,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3551,6 +3639,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3620,6 +3709,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3647,6 +3737,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3674,6 +3765,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3701,6 +3793,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3728,6 +3821,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3755,6 +3849,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3782,6 +3877,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3809,6 +3905,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3843,6 +3940,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3870,6 +3968,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3897,6 +3996,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3924,6 +4024,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3958,6 +4059,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3985,6 +4087,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4012,6 +4115,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4067,6 +4171,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4108,6 +4213,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4135,6 +4241,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4183,6 +4290,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4259,6 +4367,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4286,6 +4395,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4341,6 +4451,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4368,6 +4479,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4451,6 +4563,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4492,6 +4605,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4519,6 +4633,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4546,6 +4661,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4573,6 +4689,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4600,6 +4717,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4627,6 +4745,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4654,6 +4773,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4681,6 +4801,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4708,6 +4829,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4763,6 +4885,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4832,6 +4955,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4859,6 +4983,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4886,6 +5011,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4913,6 +5039,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5052,6 +5179,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5107,6 +5235,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5141,6 +5270,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5168,6 +5298,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5195,6 +5326,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5222,6 +5354,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5277,6 +5410,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5304,6 +5438,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5359,6 +5494,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5386,6 +5522,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5441,6 +5578,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5503,6 +5641,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5530,6 +5669,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5557,6 +5697,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5584,6 +5725,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5611,6 +5753,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5666,6 +5809,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5700,6 +5844,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5727,6 +5872,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5754,6 +5900,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5809,6 +5956,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5836,6 +5984,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5863,6 +6012,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5918,6 +6068,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5945,6 +6096,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5972,6 +6124,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5999,6 +6152,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6026,6 +6180,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6053,6 +6208,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6101,6 +6257,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6128,6 +6285,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6169,6 +6327,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6217,6 +6376,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6244,6 +6404,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6271,6 +6432,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6326,6 +6488,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6402,6 +6565,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6471,6 +6635,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6498,6 +6663,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6532,6 +6698,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6559,6 +6726,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6586,6 +6754,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6613,6 +6782,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6640,6 +6810,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6667,6 +6838,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6694,6 +6866,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6721,6 +6894,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6783,6 +6957,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6852,6 +7027,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6879,6 +7055,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6934,6 +7111,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6961,6 +7139,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7023,6 +7202,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7050,6 +7230,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7077,6 +7258,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7104,6 +7286,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7138,6 +7321,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7193,6 +7377,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7220,6 +7405,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7275,6 +7461,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7302,6 +7489,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7357,6 +7545,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7384,6 +7573,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7411,6 +7601,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7438,6 +7629,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7493,6 +7685,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7520,6 +7713,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7659,6 +7853,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7686,6 +7881,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7713,6 +7909,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7740,6 +7937,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7767,6 +7965,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7829,6 +8028,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7863,6 +8063,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7890,6 +8091,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7917,6 +8119,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7965,6 +8168,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7992,6 +8196,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8019,6 +8224,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8046,6 +8252,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8073,6 +8280,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8100,6 +8308,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8127,6 +8336,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8203,6 +8413,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8230,6 +8441,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8264,6 +8476,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8291,6 +8504,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8318,6 +8532,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8359,6 +8574,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8386,6 +8602,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8420,6 +8637,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8517,6 +8735,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8544,6 +8763,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8571,6 +8791,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8668,6 +8889,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8695,6 +8917,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8722,6 +8945,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8756,6 +8980,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8783,6 +9008,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8831,6 +9057,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8879,6 +9106,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8934,6 +9162,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8961,6 +9190,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8988,6 +9218,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9015,6 +9246,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9042,6 +9274,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9111,6 +9344,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9138,6 +9372,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9165,6 +9400,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9220,6 +9456,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9261,6 +9498,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9358,6 +9596,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9406,6 +9645,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9433,6 +9673,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9502,6 +9743,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9550,6 +9792,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9577,6 +9820,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9604,6 +9848,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9631,6 +9876,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9658,6 +9904,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9685,6 +9932,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9712,6 +9960,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9739,6 +9988,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9766,6 +10016,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9793,6 +10044,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9820,6 +10072,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9847,6 +10100,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9874,6 +10128,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9901,6 +10156,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9928,6 +10184,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9955,6 +10212,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9982,6 +10240,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10009,6 +10268,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10050,6 +10310,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10077,6 +10338,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10104,6 +10366,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10159,6 +10422,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10186,6 +10450,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10213,6 +10478,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10247,6 +10513,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10274,6 +10541,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10301,6 +10569,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10328,6 +10597,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10355,6 +10625,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10410,6 +10681,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10437,6 +10709,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10485,6 +10758,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10540,6 +10814,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10567,6 +10842,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10594,6 +10870,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10649,6 +10926,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10676,6 +10954,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10766,6 +11045,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10793,6 +11073,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10820,6 +11101,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10847,6 +11129,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10916,6 +11199,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10950,6 +11234,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11033,6 +11318,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11060,6 +11346,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11108,6 +11395,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11135,6 +11423,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11183,6 +11472,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11210,6 +11500,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11237,6 +11528,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11299,6 +11591,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11340,6 +11633,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11367,6 +11661,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11394,6 +11689,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11421,6 +11717,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11448,6 +11745,7 @@
         {
             "id": "0x4b3fa856cef9aa85ed9bbfa8992d6138c5f150e6",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -11517,6 +11815,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11586,6 +11885,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11613,6 +11913,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11640,6 +11941,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11702,6 +12004,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11736,6 +12039,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11763,6 +12067,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11790,6 +12095,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11817,6 +12123,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11844,6 +12151,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11871,6 +12179,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11898,6 +12207,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11925,6 +12235,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11952,6 +12263,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11979,6 +12291,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12034,6 +12347,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12061,6 +12375,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12088,6 +12403,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12115,6 +12431,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12177,6 +12494,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12211,6 +12529,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12238,6 +12557,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12265,6 +12585,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12320,6 +12641,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12375,6 +12697,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12402,6 +12725,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12429,6 +12753,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12456,6 +12781,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12483,6 +12809,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12510,6 +12837,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12565,6 +12893,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12634,6 +12963,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12661,6 +12991,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12688,6 +13019,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12722,6 +13054,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12854,6 +13187,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12951,6 +13285,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12985,6 +13320,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -13054,6 +13390,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13081,6 +13418,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13108,6 +13446,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13135,6 +13474,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13162,6 +13502,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13189,6 +13530,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13244,6 +13586,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13271,6 +13614,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13319,6 +13663,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13416,6 +13761,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13485,6 +13831,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13631,6 +13978,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13686,6 +14034,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13713,6 +14062,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13740,6 +14090,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13795,6 +14146,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13822,6 +14174,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13849,6 +14202,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13876,6 +14230,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13903,6 +14258,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13930,6 +14286,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13957,6 +14314,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13984,6 +14342,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -14011,6 +14370,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -14101,6 +14461,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14128,6 +14489,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14155,6 +14517,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14182,6 +14545,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14335,6 +14699,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14362,6 +14727,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14389,6 +14755,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14416,6 +14783,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14457,6 +14825,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14484,6 +14853,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14511,6 +14881,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14538,6 +14909,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14593,6 +14965,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14620,6 +14993,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14647,6 +15021,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14744,6 +15119,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14771,6 +15147,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14798,6 +15175,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14853,6 +15231,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14880,6 +15259,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14942,6 +15322,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14969,6 +15350,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14996,6 +15378,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -15023,6 +15406,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15050,6 +15434,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15077,6 +15462,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15132,6 +15518,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15201,6 +15588,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15228,6 +15616,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15255,6 +15644,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15282,6 +15672,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15309,6 +15700,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15336,6 +15728,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15363,6 +15756,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15502,6 +15896,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15529,6 +15924,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15556,6 +15952,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15583,6 +15980,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15610,6 +16008,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15651,6 +16050,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15678,6 +16078,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15705,6 +16106,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15732,6 +16134,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15759,6 +16162,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15793,6 +16197,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15820,6 +16225,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15847,6 +16253,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15944,6 +16351,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15971,6 +16379,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15998,6 +16407,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -16025,6 +16435,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -16052,6 +16463,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16079,6 +16491,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16106,6 +16519,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16133,6 +16547,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16160,6 +16575,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16187,6 +16603,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16214,6 +16631,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16255,6 +16673,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16282,6 +16701,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16309,6 +16729,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16371,6 +16792,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16398,6 +16820,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16425,6 +16848,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16452,6 +16876,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16479,6 +16904,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16534,6 +16960,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16561,6 +16988,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16588,6 +17016,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16615,6 +17044,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16642,6 +17072,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16732,6 +17163,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16759,6 +17191,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16786,6 +17219,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16813,6 +17247,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16840,6 +17275,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16867,6 +17303,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16894,6 +17331,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -17040,6 +17478,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17067,6 +17506,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17094,6 +17534,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17121,6 +17562,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17148,6 +17590,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17182,6 +17625,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17237,6 +17681,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17306,6 +17751,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17333,6 +17779,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17360,6 +17807,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17387,6 +17835,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17414,6 +17863,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17441,6 +17891,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17468,6 +17919,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17558,6 +18010,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17585,6 +18038,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17612,6 +18066,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17639,6 +18094,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17666,6 +18122,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17714,6 +18171,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17755,6 +18213,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17782,6 +18241,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17809,6 +18269,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17843,6 +18304,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17870,6 +18332,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17939,6 +18402,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17966,6 +18430,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -18000,6 +18465,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -18027,6 +18493,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -18054,6 +18521,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18109,6 +18577,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18164,6 +18633,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18233,6 +18703,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18260,6 +18731,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18287,6 +18759,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18314,6 +18787,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18369,6 +18843,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18438,6 +18913,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18465,6 +18941,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18534,6 +19011,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18561,6 +19039,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18588,6 +19067,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18615,6 +19095,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18642,6 +19123,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18669,6 +19151,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18696,6 +19179,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18730,6 +19214,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18764,6 +19249,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18791,6 +19277,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18818,6 +19305,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18873,6 +19361,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18900,6 +19389,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18927,6 +19417,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18954,6 +19445,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18988,6 +19480,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -19015,6 +19508,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -19042,6 +19536,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19069,6 +19564,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19096,6 +19592,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19130,6 +19627,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19157,6 +19655,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19212,6 +19711,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19239,6 +19739,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19322,6 +19823,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19356,6 +19858,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19411,6 +19914,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19438,6 +19942,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19465,6 +19970,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19492,6 +19998,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19526,6 +20033,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19553,6 +20061,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19580,6 +20089,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19607,6 +20117,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19662,6 +20173,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19689,6 +20201,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19716,6 +20229,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19764,6 +20278,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19791,6 +20306,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19818,6 +20334,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19845,6 +20362,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19872,6 +20390,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19899,6 +20418,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19926,6 +20446,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19953,6 +20474,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19980,6 +20502,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -20049,6 +20572,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20076,6 +20600,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20103,6 +20628,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20130,6 +20656,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20164,6 +20691,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20191,6 +20719,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20218,6 +20747,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20245,6 +20775,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20314,6 +20845,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20341,6 +20873,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20382,6 +20915,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20409,6 +20943,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20478,6 +21013,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20540,6 +21076,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20567,6 +21104,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20636,6 +21174,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20663,6 +21202,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20690,6 +21230,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20717,6 +21258,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20744,6 +21286,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20771,6 +21314,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20798,6 +21342,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20825,6 +21370,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20859,6 +21405,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20949,6 +21496,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20976,6 +21524,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -21003,6 +21552,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -21037,6 +21587,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21071,6 +21622,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21112,6 +21664,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21167,6 +21720,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21194,6 +21748,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21221,6 +21776,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21290,6 +21846,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21317,6 +21874,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21358,6 +21916,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21413,6 +21972,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21440,6 +22000,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21467,6 +22028,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21501,6 +22063,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21528,6 +22091,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21555,6 +22119,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21582,6 +22147,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21609,6 +22175,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21636,6 +22203,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21677,6 +22245,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21704,6 +22273,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21731,6 +22301,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21758,6 +22329,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21834,6 +22406,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21861,6 +22434,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21888,6 +22462,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21915,6 +22490,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21942,6 +22518,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21969,6 +22546,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22017,6 +22595,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22051,6 +22630,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22078,6 +22658,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22105,6 +22686,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22132,6 +22714,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22159,6 +22742,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22186,6 +22770,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22213,6 +22798,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22254,6 +22840,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22281,6 +22868,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22308,6 +22896,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22447,6 +23036,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22488,6 +23078,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22515,6 +23106,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22549,6 +23141,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22604,6 +23197,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22631,6 +23225,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22658,6 +23253,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22706,6 +23302,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22747,6 +23344,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22774,6 +23372,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22801,6 +23400,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22870,6 +23470,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22904,6 +23505,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22931,6 +23533,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22965,6 +23568,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22999,6 +23603,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -23026,6 +23631,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -23053,6 +23659,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23080,6 +23687,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23107,6 +23715,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23134,6 +23743,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23161,6 +23771,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23216,6 +23827,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23243,6 +23855,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23298,6 +23911,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23360,6 +23974,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23387,6 +24002,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23414,6 +24030,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23455,6 +24072,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23510,6 +24128,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23537,6 +24156,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23564,6 +24184,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23591,6 +24212,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23625,6 +24247,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23652,6 +24275,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23686,6 +24310,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23713,6 +24338,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23761,6 +24387,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23788,6 +24415,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23815,6 +24443,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23842,6 +24471,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23869,6 +24499,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23924,6 +24555,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23951,6 +24583,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23978,6 +24611,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -24033,6 +24667,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -24060,6 +24695,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24108,6 +24744,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24156,6 +24793,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24183,6 +24821,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24210,6 +24849,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24237,6 +24877,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24264,6 +24905,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24291,6 +24933,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24318,6 +24961,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24345,6 +24989,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24372,6 +25017,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24399,6 +25045,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24426,6 +25073,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24453,6 +25101,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24480,6 +25129,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24514,6 +25164,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24576,6 +25227,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24603,6 +25255,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24630,6 +25283,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24769,6 +25423,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24838,6 +25493,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24865,6 +25521,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24892,6 +25549,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24961,6 +25619,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24988,6 +25647,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25015,6 +25675,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -25042,6 +25703,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -25076,6 +25738,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25117,6 +25780,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25144,6 +25808,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25171,6 +25836,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25198,6 +25864,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25225,6 +25892,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25252,6 +25920,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25279,6 +25948,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25306,6 +25976,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25375,6 +26046,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25402,6 +26074,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25429,6 +26102,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25463,6 +26137,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25490,6 +26165,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25538,6 +26214,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25572,6 +26249,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25599,6 +26277,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25626,6 +26305,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25653,6 +26333,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25680,6 +26361,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25707,6 +26389,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25734,6 +26417,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25761,6 +26445,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25823,6 +26508,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25850,6 +26536,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25884,6 +26571,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25911,6 +26599,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25938,6 +26627,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25986,6 +26676,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26013,6 +26704,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -26040,6 +26732,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26067,6 +26760,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26101,6 +26795,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26198,6 +26893,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26225,6 +26921,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26287,6 +26984,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26314,6 +27012,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26341,6 +27040,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26368,6 +27068,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26395,6 +27096,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26422,6 +27124,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26449,6 +27152,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26483,6 +27187,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26510,6 +27215,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26579,6 +27285,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26606,6 +27313,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26703,6 +27411,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26730,6 +27439,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26757,6 +27467,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26784,6 +27495,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26811,6 +27523,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26838,6 +27551,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26893,6 +27607,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26920,6 +27635,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27108,6 +27824,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27135,6 +27852,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27162,6 +27880,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27189,6 +27908,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27223,6 +27943,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27250,6 +27971,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27326,6 +28048,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27353,6 +28076,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27394,6 +28118,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27421,6 +28146,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27462,6 +28188,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27552,6 +28279,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27579,6 +28307,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27606,6 +28335,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27633,6 +28363,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27660,6 +28391,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27687,6 +28419,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27714,6 +28447,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27741,6 +28475,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27768,6 +28503,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27795,6 +28531,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27822,6 +28559,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27849,6 +28587,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27876,6 +28615,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27903,6 +28643,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -28007,6 +28748,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -28062,6 +28804,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -28089,6 +28832,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -28116,6 +28860,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28143,6 +28888,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28170,6 +28916,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28197,6 +28944,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28252,6 +29000,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28279,6 +29028,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28306,6 +29056,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28340,6 +29091,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28395,6 +29147,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28422,6 +29175,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28449,6 +29203,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28518,6 +29273,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28545,6 +29301,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28572,6 +29329,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28599,6 +29357,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28626,6 +29385,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28653,6 +29413,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28680,6 +29441,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28707,6 +29469,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28762,6 +29525,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28789,6 +29553,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28816,6 +29581,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28850,6 +29616,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28877,6 +29644,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28911,6 +29679,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28938,6 +29707,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28965,6 +29735,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28992,6 +29763,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -29075,6 +29847,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29102,6 +29875,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29171,6 +29945,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29268,6 +30043,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29295,6 +30071,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29322,6 +30099,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29349,6 +30127,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29418,6 +30197,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29445,6 +30225,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29500,6 +30281,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29527,6 +30309,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29554,6 +30337,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29581,6 +30365,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29622,6 +30407,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29649,6 +30435,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29683,6 +30470,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29710,6 +30498,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29737,6 +30526,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29764,6 +30554,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29791,6 +30582,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29825,6 +30617,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29852,6 +30645,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29879,6 +30673,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29906,6 +30701,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29933,6 +30729,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29960,6 +30757,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -30057,6 +30855,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -30084,6 +30883,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -30111,6 +30911,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30138,6 +30939,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30165,6 +30967,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30192,6 +30995,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30219,6 +31023,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30246,6 +31051,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30287,6 +31093,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30314,6 +31121,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30341,6 +31149,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30396,6 +31205,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30423,6 +31233,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30450,6 +31261,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30477,6 +31289,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30504,6 +31317,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30531,6 +31345,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30558,6 +31373,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30613,6 +31429,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30640,6 +31457,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30674,6 +31492,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30736,6 +31555,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30763,6 +31583,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30790,6 +31611,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30817,6 +31639,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30844,6 +31667,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30871,6 +31695,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30898,6 +31723,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30925,6 +31751,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30952,6 +31779,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31007,6 +31835,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -31034,6 +31863,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -31061,6 +31891,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31088,6 +31919,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -31115,6 +31947,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31142,6 +31975,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31176,6 +32010,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31203,6 +32038,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31258,6 +32094,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31285,6 +32122,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31312,6 +32150,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31339,6 +32178,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31366,6 +32206,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31393,6 +32234,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31420,6 +32262,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31447,6 +32290,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31572,6 +32416,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31599,6 +32444,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31626,6 +32472,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31653,6 +32500,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31708,6 +32556,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31735,6 +32584,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31790,6 +32640,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31817,6 +32668,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31844,6 +32696,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31899,6 +32752,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31933,6 +32787,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32023,6 +32878,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32050,6 +32906,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -32133,6 +32990,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32174,6 +33032,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32201,6 +33060,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32256,6 +33116,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32283,6 +33144,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32310,6 +33172,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32344,6 +33207,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32371,6 +33235,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32398,6 +33263,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32425,6 +33291,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32452,6 +33319,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32479,6 +33347,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32506,6 +33375,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32533,6 +33403,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32560,6 +33431,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32615,6 +33487,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32642,6 +33515,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32669,6 +33543,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32696,6 +33571,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32723,6 +33599,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32750,6 +33627,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32777,6 +33655,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32832,6 +33711,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32880,6 +33760,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32921,6 +33802,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32948,6 +33830,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32975,6 +33858,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -33002,6 +33886,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33092,6 +33977,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33119,6 +34005,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33146,6 +34033,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33180,6 +34068,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33207,6 +34096,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33234,6 +34124,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33275,6 +34166,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33330,6 +34222,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33357,6 +34250,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33454,6 +34348,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33530,6 +34425,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33606,6 +34502,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33696,6 +34593,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33737,6 +34635,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33778,6 +34677,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33833,6 +34733,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33860,6 +34761,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33894,6 +34796,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33921,6 +34824,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -34004,6 +34908,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -34031,6 +34936,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -34058,6 +34964,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34085,6 +34992,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34112,6 +35020,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -34139,6 +35048,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34180,6 +35090,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34207,6 +35118,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34276,6 +35188,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34303,6 +35216,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34330,6 +35244,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34357,6 +35272,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34384,6 +35300,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34411,6 +35328,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34445,6 +35363,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34479,6 +35398,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34576,6 +35496,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34603,6 +35524,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34630,6 +35552,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34657,6 +35580,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34684,6 +35608,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34711,6 +35636,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34766,6 +35692,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34793,6 +35720,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34883,6 +35811,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34938,6 +35867,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34965,6 +35895,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34992,6 +35923,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35019,6 +35951,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -35067,6 +36000,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35094,6 +36028,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35121,6 +36056,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35253,6 +36189,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35280,6 +36217,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35307,6 +36245,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35334,6 +36273,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35361,6 +36301,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35388,6 +36329,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35415,6 +36357,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35442,6 +36385,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35469,6 +36413,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35496,6 +36441,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35558,6 +36504,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35606,6 +36553,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35633,6 +36581,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35660,6 +36609,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35687,6 +36637,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35714,6 +36665,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35748,6 +36700,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35775,6 +36728,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35802,6 +36756,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35829,6 +36784,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35856,6 +36812,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35904,6 +36861,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35959,6 +36917,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35986,6 +36945,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -36013,6 +36973,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36047,6 +37008,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -36074,6 +37036,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36143,6 +37106,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36191,6 +37155,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36246,6 +37211,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36287,6 +37253,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36314,6 +37281,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36383,6 +37351,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36410,6 +37379,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36437,6 +37407,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36464,6 +37435,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36568,6 +37540,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36595,6 +37568,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36622,6 +37596,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36719,6 +37694,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36746,6 +37722,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36773,6 +37750,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36800,6 +37778,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36827,6 +37806,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36854,6 +37834,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36881,6 +37862,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36908,6 +37890,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36935,6 +37918,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36962,6 +37946,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36989,6 +37974,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -37023,6 +38009,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -37050,6 +38037,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -37077,6 +38065,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37132,6 +38121,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37159,6 +38149,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37186,6 +38177,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37241,6 +38233,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37268,6 +38261,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37323,6 +38317,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37350,6 +38345,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37377,6 +38373,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37425,6 +38422,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37452,6 +38450,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37479,6 +38478,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37506,6 +38506,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37547,6 +38548,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37574,6 +38576,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37608,6 +38611,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37635,6 +38639,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37669,6 +38674,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37724,6 +38730,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37751,6 +38758,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37778,6 +38786,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37826,6 +38835,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37860,6 +38870,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37922,6 +38933,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37949,6 +38961,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37976,6 +38989,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38024,6 +39038,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -38051,6 +39066,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38078,6 +39094,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -38126,6 +39143,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38153,6 +39171,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38264,6 +39283,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38319,6 +39339,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38346,6 +39367,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38394,6 +39416,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38421,6 +39444,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38490,6 +39514,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38517,6 +39542,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38572,6 +39598,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38599,6 +39626,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38626,6 +39654,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38653,6 +39682,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38680,6 +39710,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38707,6 +39738,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38769,6 +39801,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38796,6 +39829,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38844,6 +39878,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38871,6 +39906,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38898,6 +39934,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38925,6 +39962,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38980,6 +40018,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39007,6 +40046,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -39034,6 +40074,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -39061,6 +40102,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -39130,6 +40172,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39157,6 +40200,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39184,6 +40228,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39260,6 +40305,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39287,6 +40333,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39321,6 +40368,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39355,6 +40403,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39389,6 +40438,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39416,6 +40466,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39443,6 +40494,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39470,6 +40522,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39504,6 +40557,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39531,6 +40585,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39558,6 +40613,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39585,6 +40641,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39619,6 +40676,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39653,6 +40711,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39680,6 +40739,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39707,6 +40767,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39818,6 +40879,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39845,6 +40907,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39872,6 +40935,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39899,6 +40963,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39954,6 +41019,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39981,6 +41047,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40015,6 +41082,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40042,6 +41110,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -40139,6 +41208,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40166,6 +41236,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40193,6 +41264,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40220,6 +41292,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40289,6 +41362,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x86ee8f4eaf4819a362e1a3cd856df827de1fe95140bdcadc6915fa0964296b95.json
+++ b/test/testData/testPools/0x86ee8f4eaf4819a362e1a3cd856df827de1fe95140bdcadc6915fa0964296b95.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -94,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -169,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -196,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -230,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -257,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -284,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -311,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -338,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -365,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -392,6 +405,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -419,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -467,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -508,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -535,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -562,6 +580,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +608,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -616,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -643,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -691,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -718,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -745,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -800,6 +825,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -848,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -875,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -902,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -929,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -956,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -997,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1024,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1065,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1092,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1161,6 +1196,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1230,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1257,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1284,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1311,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1338,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1365,6 +1406,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1392,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1419,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1467,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1494,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1542,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1569,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1596,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1623,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1664,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1691,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1718,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1745,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1772,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1799,6 +1854,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1826,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1867,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1894,6 +1952,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1987,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -1976,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2004,6 +2065,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2051,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2169,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2168,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2216,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2243,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2270,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2325,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2352,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2379,6 +2449,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2477,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2440,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2467,6 +2540,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2494,6 +2569,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2528,6 +2604,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2555,6 +2632,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2582,6 +2660,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2609,6 +2688,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2657,6 +2737,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2684,6 +2765,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2718,6 +2800,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2745,6 +2828,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2772,6 +2856,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2799,6 +2884,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2826,6 +2912,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2860,6 +2947,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2887,6 +2975,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2914,6 +3003,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2941,6 +3031,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -2975,6 +3066,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3044,6 +3136,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3078,6 +3171,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3105,6 +3199,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3132,6 +3227,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3159,6 +3255,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3200,6 +3297,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3227,6 +3325,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3254,6 +3353,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3281,6 +3381,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3308,6 +3409,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3335,6 +3437,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3376,6 +3479,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3424,6 +3528,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3451,6 +3556,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3478,6 +3584,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3505,6 +3612,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3532,6 +3640,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3601,6 +3710,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3628,6 +3738,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3655,6 +3766,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3682,6 +3794,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3709,6 +3822,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3736,6 +3850,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3763,6 +3878,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3790,6 +3906,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3824,6 +3941,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3851,6 +3969,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3878,6 +3997,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3905,6 +4025,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3939,6 +4060,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3966,6 +4088,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -3993,6 +4116,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4020,6 +4144,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4047,6 +4172,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4088,6 +4214,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4115,6 +4242,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4163,6 +4291,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4190,6 +4319,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4238,6 +4368,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4265,6 +4396,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4292,6 +4424,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4319,6 +4452,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4346,6 +4480,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4373,6 +4508,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4428,6 +4564,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4469,6 +4606,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4496,6 +4634,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4523,6 +4662,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4550,6 +4690,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4577,6 +4718,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4604,6 +4746,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4774,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4658,6 +4802,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4685,6 +4830,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4712,6 +4858,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4739,6 +4886,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4808,6 +4956,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4835,6 +4984,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4862,6 +5012,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4889,6 +5040,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -4930,6 +5082,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5152,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5026,6 +5180,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5053,6 +5208,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5080,6 +5236,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5114,6 +5271,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5141,6 +5299,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5168,6 +5327,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5195,6 +5355,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5222,6 +5383,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5249,6 +5411,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5276,6 +5439,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5303,6 +5467,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5495,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5357,6 +5523,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5412,6 +5579,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5439,6 +5607,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5473,6 +5642,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5500,6 +5670,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5527,6 +5698,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5554,6 +5726,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5581,6 +5754,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5608,6 +5782,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5635,6 +5810,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5669,6 +5845,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5696,6 +5873,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5723,6 +5901,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5778,6 +5957,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5805,6 +5985,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5832,6 +6013,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5859,6 +6041,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -5886,6 +6070,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5913,6 +6098,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5940,6 +6126,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5967,6 +6154,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5994,6 +6182,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6021,6 +6210,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6069,6 +6259,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6096,6 +6287,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6137,6 +6329,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6185,6 +6378,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6212,6 +6406,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6239,6 +6434,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6294,6 +6490,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6328,6 +6525,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6369,6 +6567,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6438,6 +6637,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6465,6 +6665,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6499,6 +6700,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6526,6 +6728,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6553,6 +6756,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6580,6 +6784,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6607,6 +6812,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6634,6 +6840,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6661,6 +6868,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6688,6 +6896,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6750,6 +6959,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6819,6 +7029,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6846,6 +7057,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6873,6 +7085,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6900,6 +7113,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6927,6 +7141,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6954,6 +7169,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -6988,6 +7204,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7015,6 +7232,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7042,6 +7260,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7069,6 +7288,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7103,6 +7323,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7130,6 +7351,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7157,6 +7379,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7184,6 +7407,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7239,6 +7463,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7266,6 +7491,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7293,6 +7519,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7320,6 +7547,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7347,6 +7575,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7374,6 +7603,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7401,6 +7631,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7428,6 +7659,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7455,6 +7687,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7482,6 +7715,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7551,6 +7785,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7827,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7855,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7646,6 +7883,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7673,6 +7911,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7700,6 +7939,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7727,6 +7967,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7761,6 +8002,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7788,6 +8030,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7822,6 +8065,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7849,6 +8093,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7876,6 +8121,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7924,6 +8170,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7951,6 +8198,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -7978,6 +8226,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8005,6 +8254,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8032,6 +8282,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8059,6 +8310,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8086,6 +8338,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8134,6 +8387,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8161,6 +8416,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8188,6 +8444,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8222,6 +8479,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8249,6 +8507,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8276,6 +8535,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8317,6 +8577,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8344,6 +8605,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8378,6 +8640,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8447,6 +8710,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8474,6 +8738,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8501,6 +8766,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8528,6 +8794,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8597,6 +8864,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8624,6 +8892,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8651,6 +8920,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8678,6 +8948,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8712,6 +8983,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8739,6 +9011,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8787,6 +9060,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8835,6 +9109,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8862,6 +9137,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +9165,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8916,6 +9193,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8943,6 +9221,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -8970,6 +9249,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8997,6 +9277,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9066,6 +9347,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9093,6 +9375,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9120,6 +9403,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9147,6 +9431,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9174,6 +9459,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9215,6 +9501,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9242,6 +9529,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -9311,6 +9599,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9359,6 +9648,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9386,6 +9676,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9455,6 +9746,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9503,6 +9795,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9530,6 +9823,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9557,6 +9851,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9584,6 +9879,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9611,6 +9907,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9638,6 +9935,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9665,6 +9963,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9692,6 +9991,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9719,6 +10019,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9746,6 +10047,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9773,6 +10075,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9800,6 +10103,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9827,6 +10131,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9854,6 +10159,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9881,6 +10187,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9908,6 +10215,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9935,6 +10243,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -9962,6 +10271,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10003,6 +10313,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10030,6 +10341,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10057,6 +10369,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10112,6 +10425,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10139,6 +10453,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10166,6 +10481,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10200,6 +10516,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10227,6 +10544,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10254,6 +10572,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10281,6 +10600,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10308,6 +10628,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10335,6 +10656,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10362,6 +10684,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10389,6 +10712,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10437,6 +10761,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10464,6 +10789,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10491,6 +10817,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10518,6 +10845,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10545,6 +10873,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10572,6 +10901,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10599,6 +10929,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10626,6 +10957,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10653,6 +10985,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10715,6 +11048,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10742,6 +11076,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10769,6 +11104,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10796,6 +11132,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10865,6 +11202,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10899,6 +11237,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -10926,6 +11265,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11293,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -10980,6 +11321,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11007,6 +11349,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11055,6 +11398,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11082,6 +11426,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11130,6 +11475,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11157,6 +11503,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11184,6 +11531,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11246,6 +11594,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11287,6 +11636,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11314,6 +11664,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11341,6 +11692,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11368,6 +11720,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11395,6 +11748,7 @@
         {
             "id": "0x4b3fa856cef9aa85ed9bbfa8992d6138c5f150e6",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -11464,6 +11818,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11533,6 +11888,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11560,6 +11916,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11587,6 +11944,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11614,6 +11972,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11648,6 +12007,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11682,6 +12042,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11709,6 +12070,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11736,6 +12098,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11763,6 +12126,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11790,6 +12154,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11817,6 +12182,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11844,6 +12210,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11871,6 +12238,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11898,6 +12266,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11925,6 +12294,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11952,6 +12322,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -11979,6 +12350,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12006,6 +12378,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12033,6 +12406,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12060,6 +12434,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12122,6 +12497,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12156,6 +12532,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12183,6 +12560,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12210,6 +12588,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12237,6 +12616,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12264,6 +12644,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12319,6 +12700,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12346,6 +12728,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12373,6 +12756,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12400,6 +12784,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12427,6 +12812,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12454,6 +12840,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12481,6 +12868,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12508,6 +12896,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12577,6 +12966,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12604,6 +12994,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12631,6 +13022,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12665,6 +13057,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12692,6 +13085,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +13113,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +13162,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12794,6 +13190,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +13232,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12890,6 +13288,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12924,6 +13323,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12993,6 +13393,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13020,6 +13421,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13047,6 +13449,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13074,6 +13477,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13101,6 +13505,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13128,6 +13533,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13155,6 +13561,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13182,6 +13589,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13209,6 +13617,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13257,6 +13666,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13326,6 +13736,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13353,6 +13764,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13394,6 +13806,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13421,6 +13834,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13455,6 +13869,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13911,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13565,6 +13981,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13592,6 +14009,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13619,6 +14037,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13646,6 +14065,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13673,6 +14093,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13728,6 +14149,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13755,6 +14177,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13782,6 +14205,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13809,6 +14233,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13836,6 +14261,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13863,6 +14289,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13890,6 +14317,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13917,6 +14345,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13944,6 +14373,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -13971,6 +14401,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14033,6 +14464,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14060,6 +14492,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14087,6 +14520,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14114,6 +14548,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14141,6 +14576,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14604,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14674,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14264,6 +14702,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14291,6 +14730,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14318,6 +14758,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14345,6 +14786,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14386,6 +14828,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14413,6 +14856,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14440,6 +14884,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14467,6 +14912,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14494,6 +14940,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14521,6 +14968,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14548,6 +14996,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14575,6 +15024,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14644,6 +15094,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14671,6 +15122,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14698,6 +15150,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14725,6 +15178,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14752,6 +15206,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14779,6 +15234,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14806,6 +15262,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14833,6 +15290,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14867,6 +15325,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14894,6 +15353,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14921,6 +15381,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14948,6 +15409,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14975,6 +15437,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15002,6 +15465,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15029,6 +15493,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15056,6 +15521,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15125,6 +15591,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15152,6 +15619,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15179,6 +15647,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15206,6 +15675,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15233,6 +15703,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15260,6 +15731,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15287,6 +15759,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15328,6 +15801,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15871,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15424,6 +15899,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15451,6 +15927,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15478,6 +15955,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15505,6 +15983,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15532,6 +16011,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15573,6 +16053,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15600,6 +16081,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15627,6 +16109,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15654,6 +16137,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15681,6 +16165,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15715,6 +16200,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15742,6 +16228,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15769,6 +16256,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15796,6 +16284,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -15865,6 +16354,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15892,6 +16382,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15919,6 +16410,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15946,6 +16438,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15973,6 +16466,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16000,6 +16494,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16027,6 +16522,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16054,6 +16550,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16081,6 +16578,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16108,6 +16606,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16135,6 +16634,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16176,6 +16676,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16203,6 +16704,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16230,6 +16732,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16292,6 +16795,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16319,6 +16823,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16346,6 +16851,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16373,6 +16879,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16400,6 +16907,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16427,6 +16935,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16454,6 +16963,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16481,6 +16991,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16508,6 +17019,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16535,6 +17047,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16562,6 +17075,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16617,6 +17131,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16651,6 +17166,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16678,6 +17194,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16705,6 +17222,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16732,6 +17250,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16759,6 +17278,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16786,6 +17306,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16813,6 +17334,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16854,6 +17376,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17446,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -16957,6 +17481,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16984,6 +17509,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17011,6 +17537,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17038,6 +17565,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17065,6 +17593,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17099,6 +17628,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17126,6 +17656,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17153,6 +17684,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17222,6 +17754,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17249,6 +17782,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17276,6 +17810,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17303,6 +17838,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17330,6 +17866,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17357,6 +17894,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17384,6 +17922,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17411,6 +17950,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17473,6 +18013,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17500,6 +18041,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17527,6 +18069,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17554,6 +18097,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17581,6 +18125,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17629,6 +18174,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17670,6 +18216,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17697,6 +18244,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17724,6 +18272,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17758,6 +18307,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17785,6 +18335,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17812,6 +18363,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17853,6 +18405,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17880,6 +18433,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17914,6 +18468,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17941,6 +18496,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17968,6 +18524,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17995,6 +18552,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18022,6 +18580,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18049,6 +18608,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18076,6 +18636,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18145,6 +18706,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18172,6 +18734,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18199,6 +18762,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18226,6 +18790,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18253,6 +18818,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -18280,6 +18846,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18349,6 +18916,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18376,6 +18944,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18445,6 +19014,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18472,6 +19042,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18499,6 +19070,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18526,6 +19098,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18553,6 +19126,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18580,6 +19154,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18607,6 +19182,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18641,6 +19217,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18675,6 +19252,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18702,6 +19280,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18729,6 +19308,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18784,6 +19364,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18811,6 +19392,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18838,6 +19420,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18865,6 +19448,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18899,6 +19483,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18926,6 +19511,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18953,6 +19539,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18980,6 +19567,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19007,6 +19595,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19041,6 +19630,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19068,6 +19658,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19095,6 +19686,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19122,6 +19714,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19149,6 +19742,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19176,6 +19770,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19798,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19230,6 +19826,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19264,6 +19861,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19291,6 +19889,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19318,6 +19917,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19345,6 +19945,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19372,6 +19973,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19399,6 +20001,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19433,6 +20036,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19460,6 +20064,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19487,6 +20092,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19514,6 +20120,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19541,6 +20148,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -19568,6 +20176,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19595,6 +20204,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19622,6 +20232,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19670,6 +20281,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19697,6 +20309,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19724,6 +20337,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19751,6 +20365,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19778,6 +20393,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19805,6 +20421,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19832,6 +20449,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19859,6 +20477,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19886,6 +20505,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -19955,6 +20575,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19982,6 +20603,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20009,6 +20631,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20036,6 +20659,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20070,6 +20694,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20097,6 +20722,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20124,6 +20750,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20151,6 +20778,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20178,6 +20806,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20219,6 +20848,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20246,6 +20876,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20287,6 +20918,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20314,6 +20946,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20383,6 +21016,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20445,6 +21079,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20472,6 +21107,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20541,6 +21177,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20568,6 +21205,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20595,6 +21233,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20622,6 +21261,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20649,6 +21289,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20676,6 +21317,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20703,6 +21345,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20730,6 +21373,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20764,6 +21408,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20791,6 +21436,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -20853,6 +21499,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20880,6 +21527,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20907,6 +21555,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -20941,6 +21590,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20975,6 +21625,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21016,6 +21667,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21071,6 +21723,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21098,6 +21751,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21125,6 +21779,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21194,6 +21849,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21221,6 +21877,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21262,6 +21919,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21289,6 +21947,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21316,6 +21975,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21343,6 +22003,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21370,6 +22031,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21404,6 +22066,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21431,6 +22094,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21458,6 +22122,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21485,6 +22150,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21512,6 +22178,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21539,6 +22206,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21580,6 +22248,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21607,6 +22276,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21634,6 +22304,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21661,6 +22332,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21688,6 +22360,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -21736,6 +22409,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21763,6 +22437,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21790,6 +22465,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21817,6 +22493,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21844,6 +22521,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21871,6 +22549,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21919,6 +22598,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -21953,6 +22633,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21980,6 +22661,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22007,6 +22689,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22034,6 +22717,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22061,6 +22745,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22088,6 +22773,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22115,6 +22801,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22156,6 +22843,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22183,6 +22871,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22210,6 +22899,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22237,6 +22927,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22955,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22997,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22346,6 +23039,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22387,6 +23081,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22414,6 +23109,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22448,6 +23144,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22475,6 +23172,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -22502,6 +23200,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22529,6 +23228,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22556,6 +23256,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22604,6 +23305,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22645,6 +23347,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22672,6 +23375,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22699,6 +23403,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22768,6 +23473,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22802,6 +23508,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22829,6 +23536,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22863,6 +23571,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22897,6 +23606,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22924,6 +23634,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22951,6 +23662,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -22978,6 +23690,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23005,6 +23718,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23032,6 +23746,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23059,6 +23774,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23086,6 +23802,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23113,6 +23830,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23140,6 +23858,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23195,6 +23914,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23222,6 +23942,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23256,6 +23977,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23283,6 +24005,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23310,6 +24033,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23351,6 +24075,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23378,6 +24103,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23405,6 +24131,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23432,6 +24159,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23459,6 +24187,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23486,6 +24215,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23520,6 +24250,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23547,6 +24278,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23581,6 +24313,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23608,6 +24341,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23656,6 +24390,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23683,6 +24418,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23710,6 +24446,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23737,6 +24474,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23764,6 +24502,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23791,6 +24530,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23818,6 +24558,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23845,6 +24586,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23872,6 +24614,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23899,6 +24642,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -23926,6 +24670,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -23953,6 +24698,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24001,6 +24747,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24049,6 +24796,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24076,6 +24824,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24103,6 +24852,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24130,6 +24880,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24157,6 +24908,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24184,6 +24936,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24211,6 +24964,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24238,6 +24992,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24265,6 +25020,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24292,6 +25048,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24319,6 +25076,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24346,6 +25104,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24373,6 +25132,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24407,6 +25167,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24469,6 +25230,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24496,6 +25258,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24523,6 +25286,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24550,6 +25314,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +25356,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -24660,6 +25426,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24729,6 +25496,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24756,6 +25524,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24783,6 +25552,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24852,6 +25622,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24879,6 +25650,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24906,6 +25678,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24933,6 +25706,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -24967,6 +25741,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25008,6 +25783,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25035,6 +25811,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25062,6 +25839,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25089,6 +25867,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25116,6 +25895,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25143,6 +25923,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25170,6 +25951,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25197,6 +25979,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25224,6 +26007,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25265,6 +26049,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25292,6 +26077,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25319,6 +26105,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25353,6 +26140,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25380,6 +26168,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25428,6 +26217,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25462,6 +26252,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25489,6 +26280,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25516,6 +26308,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25543,6 +26336,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25570,6 +26364,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25597,6 +26392,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25624,6 +26420,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25651,6 +26448,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25685,6 +26483,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25712,6 +26511,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25739,6 +26539,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25773,6 +26574,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25800,6 +26602,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25827,6 +26630,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25875,6 +26679,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25902,6 +26707,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -25929,6 +26735,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25956,6 +26763,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25990,6 +26798,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26031,6 +26840,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26868,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26085,6 +26896,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26112,6 +26924,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26174,6 +26987,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26201,6 +27015,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26228,6 +27043,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26255,6 +27071,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26282,6 +27099,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26309,6 +27127,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26336,6 +27155,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26370,6 +27190,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26397,6 +27218,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26466,6 +27288,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26493,6 +27316,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26562,6 +27386,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26589,6 +27414,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26616,6 +27442,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26643,6 +27470,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26670,6 +27498,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26697,6 +27526,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26724,6 +27554,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26751,6 +27582,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26778,6 +27610,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26805,6 +27638,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26832,6 +27666,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27729,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27799,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -26990,6 +27827,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27017,6 +27855,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27044,6 +27883,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27071,6 +27911,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27105,6 +27946,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27132,6 +27974,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27159,6 +28002,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27207,6 +28051,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27234,6 +28079,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27275,6 +28121,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27302,6 +28149,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27343,6 +28191,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27370,6 +28219,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +28247,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27431,6 +28282,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +28310,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27485,6 +28338,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27512,6 +28366,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27539,6 +28394,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27566,6 +28422,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27593,6 +28450,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27620,6 +28478,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27647,6 +28506,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27674,6 +28534,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27701,6 +28562,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27728,6 +28590,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27755,6 +28618,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27782,6 +28646,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27809,6 +28674,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +28702,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27884,6 +28751,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -27911,6 +28779,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27938,6 +28807,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -27965,6 +28835,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -27992,6 +28863,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28019,6 +28891,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28046,6 +28919,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28073,6 +28947,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28100,6 +28975,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28127,6 +29003,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28154,6 +29031,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28181,6 +29059,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28215,6 +29094,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28242,6 +29122,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28269,6 +29150,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28296,6 +29178,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28323,6 +29206,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28392,6 +29276,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28419,6 +29304,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28446,6 +29332,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28473,6 +29360,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28500,6 +29388,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28527,6 +29416,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28554,6 +29444,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28581,6 +29472,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28608,6 +29500,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28635,6 +29528,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28662,6 +29556,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28689,6 +29584,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28723,6 +29619,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28750,6 +29647,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28784,6 +29682,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28811,6 +29710,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28838,6 +29738,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28865,6 +29766,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -28892,6 +29794,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28947,6 +29850,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28974,6 +29878,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29043,6 +29948,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29112,6 +30018,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29139,6 +30046,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29166,6 +30074,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29193,6 +30102,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29220,6 +30130,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29261,6 +30172,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29288,6 +30200,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29315,6 +30228,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29370,6 +30284,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29397,6 +30312,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29424,6 +30340,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29451,6 +30368,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29492,6 +30410,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29519,6 +30438,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29553,6 +30473,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29580,6 +30501,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29607,6 +30529,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29634,6 +30557,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29661,6 +30585,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29695,6 +30620,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29722,6 +30648,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29749,6 +30676,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29776,6 +30704,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29803,6 +30732,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29830,6 +30760,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29857,6 +30788,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29926,6 +30858,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -29953,6 +30886,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -29980,6 +30914,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30007,6 +30942,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30034,6 +30970,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30061,6 +30998,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30088,6 +31026,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30115,6 +31054,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30156,6 +31096,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30183,6 +31124,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30210,6 +31152,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30237,6 +31180,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30264,6 +31208,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30291,6 +31236,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30318,6 +31264,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30345,6 +31292,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30372,6 +31320,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30399,6 +31348,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30426,6 +31376,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30453,6 +31404,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -30480,6 +31432,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30507,6 +31460,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30541,6 +31495,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30603,6 +31558,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30630,6 +31586,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30657,6 +31614,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30684,6 +31642,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30711,6 +31670,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30738,6 +31698,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30765,6 +31726,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30792,6 +31754,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30819,6 +31782,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30874,6 +31838,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -30901,6 +31866,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30928,6 +31894,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30955,6 +31922,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -30982,6 +31950,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31009,6 +31978,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31043,6 +32013,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31070,6 +32041,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31097,6 +32069,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31124,6 +32097,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31151,6 +32125,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31178,6 +32153,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31205,6 +32181,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31232,6 +32209,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31259,6 +32237,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31286,6 +32265,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31313,6 +32293,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31354,6 +32335,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +32391,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31436,6 +32419,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31463,6 +32447,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31490,6 +32475,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31517,6 +32503,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31544,6 +32531,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31571,6 +32559,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31598,6 +32587,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31653,6 +32643,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31680,6 +32671,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31707,6 +32699,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31762,6 +32755,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31796,6 +32790,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31851,6 +32846,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31885,6 +32881,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31912,6 +32909,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -31946,6 +32944,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31994,6 +32993,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32035,6 +33035,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32062,6 +33063,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32089,6 +33091,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32116,6 +33119,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32143,6 +33147,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32170,6 +33175,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32204,6 +33210,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32231,6 +33238,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32258,6 +33266,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32285,6 +33294,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32312,6 +33322,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32339,6 +33350,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32366,6 +33378,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32393,6 +33406,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32420,6 +33434,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32447,6 +33462,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32474,6 +33490,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32501,6 +33518,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32528,6 +33546,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32555,6 +33574,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32582,6 +33602,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32609,6 +33630,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32636,6 +33658,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32663,6 +33686,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32690,6 +33714,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32738,6 +33763,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32779,6 +33805,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32806,6 +33833,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32833,6 +33861,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32860,6 +33889,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32922,6 +33952,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -32949,6 +33980,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -32976,6 +34008,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33003,6 +34036,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33037,6 +34071,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33064,6 +34099,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33091,6 +34127,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33132,6 +34169,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33159,6 +34197,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33186,6 +34225,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33213,6 +34253,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33240,6 +34281,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33309,6 +34351,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33336,6 +34379,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33384,6 +34428,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33411,6 +34456,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33459,6 +34505,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +34533,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +34562,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33547,6 +34597,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33588,6 +34639,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33629,6 +34681,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33656,6 +34709,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33683,6 +34737,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33710,6 +34765,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33744,6 +34800,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33771,6 +34828,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33798,6 +34856,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +34884,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -33852,6 +34912,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -33879,6 +34940,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -33906,6 +34968,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33933,6 +34996,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33960,6 +35024,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -33987,6 +35052,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34028,6 +35094,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34055,6 +35122,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34124,6 +35192,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34151,6 +35220,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34178,6 +35248,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34205,6 +35276,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34232,6 +35304,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34259,6 +35332,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34293,6 +35367,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34327,6 +35402,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34354,6 +35430,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34423,6 +35500,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34450,6 +35528,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34477,6 +35556,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34504,6 +35584,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +35612,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34558,6 +35640,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34613,6 +35696,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34640,6 +35724,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34674,6 +35759,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +35787,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34728,6 +35815,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34755,6 +35843,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34782,6 +35871,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34809,6 +35899,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34836,6 +35927,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -34863,6 +35955,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -34911,6 +36004,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34938,6 +36032,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34965,6 +36060,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34992,6 +36088,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +36116,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +36165,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35094,6 +36193,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35121,6 +36221,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35148,6 +36249,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35175,6 +36277,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35202,6 +36305,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35229,6 +36333,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35256,6 +36361,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35283,6 +36389,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35310,6 +36417,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35337,6 +36445,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35399,6 +36508,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35447,6 +36557,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35474,6 +36585,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35501,6 +36613,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35528,6 +36641,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35555,6 +36669,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35589,6 +36704,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35616,6 +36732,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35643,6 +36760,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35670,6 +36788,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35697,6 +36816,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35745,6 +36865,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35772,6 +36893,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -35799,6 +36921,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35826,6 +36949,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -35853,6 +36977,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35887,6 +37012,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -35914,6 +37040,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -35983,6 +37110,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36031,6 +37159,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36086,6 +37215,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36127,6 +37257,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36154,6 +37285,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36223,6 +37355,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36250,6 +37383,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36277,6 +37411,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36304,6 +37439,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36331,6 +37467,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +37495,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36406,6 +37544,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36433,6 +37572,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36460,6 +37600,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36487,6 +37628,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36556,6 +37698,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36583,6 +37726,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36610,6 +37754,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36637,6 +37782,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36664,6 +37810,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36691,6 +37838,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36718,6 +37866,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36745,6 +37894,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36772,6 +37922,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36799,6 +37950,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36826,6 +37978,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -36860,6 +38013,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -36887,6 +38041,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -36914,6 +38069,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36941,6 +38097,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -36968,6 +38125,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -36995,6 +38153,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37022,6 +38181,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37077,6 +38237,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37104,6 +38265,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37159,6 +38321,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37186,6 +38349,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37213,6 +38377,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37261,6 +38426,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37288,6 +38454,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37315,6 +38482,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37342,6 +38510,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37383,6 +38552,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37410,6 +38580,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37444,6 +38615,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37471,6 +38643,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37505,6 +38678,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37532,6 +38706,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37559,6 +38734,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37586,6 +38762,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37613,6 +38790,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37661,6 +38839,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37695,6 +38874,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37722,6 +38902,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -37756,6 +38937,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37783,6 +38965,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37810,6 +38993,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -37858,6 +39042,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37885,6 +39070,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37912,6 +39098,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -37960,6 +39147,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -37987,6 +39175,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38014,6 +39203,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +39245,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38096,6 +39287,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38123,6 +39315,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38150,6 +39343,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38177,6 +39371,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38225,6 +39420,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38252,6 +39448,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38293,6 +39490,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38320,6 +39518,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38347,6 +39546,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38374,6 +39574,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38401,6 +39602,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38428,6 +39630,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38455,6 +39658,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38482,6 +39686,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38509,6 +39714,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38536,6 +39742,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38570,6 +39777,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38597,6 +39805,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38624,6 +39833,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38672,6 +39882,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38699,6 +39910,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38726,6 +39938,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38753,6 +39966,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38780,6 +39994,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -38807,6 +40022,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -38834,6 +40050,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -38861,6 +40078,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -38888,6 +40106,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38957,6 +40176,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38984,6 +40204,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39011,6 +40232,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39038,6 +40260,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39086,6 +40309,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39113,6 +40337,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39147,6 +40372,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39181,6 +40407,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39215,6 +40442,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39242,6 +40470,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39269,6 +40498,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39296,6 +40526,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39330,6 +40561,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39357,6 +40589,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39384,6 +40617,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39411,6 +40645,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39445,6 +40680,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39479,6 +40715,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39506,6 +40743,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39533,6 +40771,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39574,6 +40813,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39643,6 +40883,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39670,6 +40911,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39697,6 +40939,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39724,6 +40967,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39751,6 +40995,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39778,6 +41023,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39805,6 +41051,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39839,6 +41086,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39866,6 +41114,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -39893,6 +41142,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39962,6 +41212,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -39989,6 +41240,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40016,6 +41268,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40043,6 +41296,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40112,6 +41366,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x86ee8f4eaf4819a362e1a3cd856df827de1fe95140bdcadc6915fa0964296b95.json
+++ b/test/testData/testPools/0x86ee8f4eaf4819a362e1a3cd856df827de1fe95140bdcadc6915fa0964296b95.json
@@ -2541,7 +2541,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6042,7 +6041,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8387,7 +8385,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -34533,7 +34530,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0x873ce8165a03b39bd25cb0b6e44397fa8a811247488e4ed7a6cdf0bcbf709410.json
+++ b/test/testData/testPools/0x873ce8165a03b39bd25cb0b6e44397fa8a811247488e4ed7a6cdf0bcbf709410.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x8be6f8c9c2e92d3d20504e7c6c26fe2fddb5c1ec32dc72ec8d9d8c18e223819b.json
+++ b/test/testData/testPools/0x8be6f8c9c2e92d3d20504e7c6c26fe2fddb5c1ec32dc72ec8d9d8c18e223819b.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x8c5e8f7df8206b50f669e44c6ed9f2f88944ab27d46c898218a02fbed21ad1d6.json
+++ b/test/testData/testPools/0x8c5e8f7df8206b50f669e44c6ed9f2f88944ab27d46c898218a02fbed21ad1d6.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x8cfbf4b745e94ee26f1649a7a8bc05636b607085e63519a5280fee2380815e55.json
+++ b/test/testData/testPools/0x8cfbf4b745e94ee26f1649a7a8bc05636b607085e63519a5280fee2380815e55.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x8d2d92e19a8ee728eeaf68a1ece8694fa5fbe11806ab14a81c814729e4afcf7d.json
+++ b/test/testData/testPools/0x8d2d92e19a8ee728eeaf68a1ece8694fa5fbe11806ab14a81c814729e4afcf7d.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x8dded375a2a8bc1bb60049ef482931657fc0fffc79233394edf5dc830426a91e.json
+++ b/test/testData/testPools/0x8dded375a2a8bc1bb60049ef482931657fc0fffc79233394edf5dc830426a91e.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x8ff899ff6a8729bb4b2600f6a491d1262001a4a591f11eac532bb20c30cb0074.json
+++ b/test/testData/testPools/0x8ff899ff6a8729bb4b2600f6a491d1262001a4a591f11eac532bb20c30cb0074.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x9308920064cab0e15ca98444ec9f91092d24aba03dd383c168f6cc2e45954e0e.json
+++ b/test/testData/testPools/0x9308920064cab0e15ca98444ec9f91092d24aba03dd383c168f6cc2e45954e0e.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x9308920064cab0e15ca98444ec9f91092d24aba03dd383c168f6cc2e45954e0e.json
+++ b/test/testData/testPools/0x9308920064cab0e15ca98444ec9f91092d24aba03dd383c168f6cc2e45954e0e.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -171,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -198,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -232,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -259,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -286,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -313,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -340,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -367,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -422,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -470,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -511,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -538,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -621,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -648,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -696,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -723,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -750,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -854,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -881,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -908,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -935,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -962,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1003,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1030,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1071,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1098,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1237,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1264,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1291,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1318,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1345,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1400,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1427,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1475,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1502,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1550,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1577,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1604,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1631,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1672,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1699,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1726,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1753,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1780,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1835,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1876,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1987,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2063,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2181,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2229,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2256,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2283,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2338,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2365,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2455,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2510,6 +2568,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2544,6 +2603,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2571,6 +2631,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2598,6 +2659,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2674,6 +2736,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2701,6 +2764,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2735,6 +2799,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2762,6 +2827,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2789,6 +2855,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2816,6 +2883,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2843,6 +2911,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2877,6 +2946,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2904,6 +2974,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2931,6 +3002,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2958,6 +3030,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3062,6 +3135,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3096,6 +3170,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3123,6 +3198,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3150,6 +3226,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3177,6 +3254,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3218,6 +3296,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3245,6 +3324,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3272,6 +3352,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3299,6 +3380,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3326,6 +3408,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3395,6 +3478,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3443,6 +3527,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3470,6 +3555,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3497,6 +3583,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3524,6 +3611,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3551,6 +3639,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3620,6 +3709,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3647,6 +3737,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3674,6 +3765,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3701,6 +3793,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3728,6 +3821,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3755,6 +3849,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3782,6 +3877,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3809,6 +3905,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3843,6 +3940,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3870,6 +3968,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3897,6 +3996,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3924,6 +4024,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3958,6 +4059,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3985,6 +4087,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4012,6 +4115,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4067,6 +4171,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4108,6 +4213,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4135,6 +4241,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4183,6 +4290,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4259,6 +4367,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4286,6 +4395,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4341,6 +4451,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4368,6 +4479,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4451,6 +4563,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4492,6 +4605,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4519,6 +4633,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4546,6 +4661,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4573,6 +4689,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4600,6 +4717,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4627,6 +4745,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4654,6 +4773,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4681,6 +4801,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4708,6 +4829,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4763,6 +4885,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4832,6 +4955,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4859,6 +4983,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4886,6 +5011,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4913,6 +5039,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5052,6 +5179,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5107,6 +5235,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5141,6 +5270,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5168,6 +5298,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5195,6 +5326,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5222,6 +5354,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5277,6 +5410,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5304,6 +5438,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5359,6 +5494,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5386,6 +5522,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5441,6 +5578,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5503,6 +5641,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5530,6 +5669,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5557,6 +5697,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5584,6 +5725,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5611,6 +5753,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5666,6 +5809,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5700,6 +5844,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5727,6 +5872,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5754,6 +5900,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5809,6 +5956,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5836,6 +5984,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5863,6 +6012,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5918,6 +6068,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5945,6 +6096,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5972,6 +6124,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5999,6 +6152,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6026,6 +6180,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6053,6 +6208,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6101,6 +6257,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6128,6 +6285,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6169,6 +6327,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6217,6 +6376,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6244,6 +6404,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6271,6 +6432,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6326,6 +6488,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6402,6 +6565,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6471,6 +6635,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6498,6 +6663,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6532,6 +6698,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6559,6 +6726,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6586,6 +6754,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6613,6 +6782,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6640,6 +6810,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6667,6 +6838,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6694,6 +6866,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6721,6 +6894,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6783,6 +6957,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6852,6 +7027,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6879,6 +7055,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6934,6 +7111,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6961,6 +7139,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7023,6 +7202,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7050,6 +7230,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7077,6 +7258,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7104,6 +7286,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7138,6 +7321,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7193,6 +7377,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7220,6 +7405,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7275,6 +7461,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7302,6 +7489,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7357,6 +7545,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7384,6 +7573,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7411,6 +7601,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7438,6 +7629,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7493,6 +7685,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7520,6 +7713,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7659,6 +7853,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7686,6 +7881,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7713,6 +7909,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7740,6 +7937,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7767,6 +7965,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7829,6 +8028,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7863,6 +8063,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7890,6 +8091,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7917,6 +8119,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7965,6 +8168,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7992,6 +8196,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8019,6 +8224,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8046,6 +8252,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8073,6 +8280,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8100,6 +8308,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8127,6 +8336,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8203,6 +8413,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8230,6 +8441,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8264,6 +8476,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8291,6 +8504,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8318,6 +8532,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8359,6 +8574,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8386,6 +8602,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8420,6 +8637,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8517,6 +8735,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8544,6 +8763,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8571,6 +8791,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8668,6 +8889,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8695,6 +8917,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8722,6 +8945,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8756,6 +8980,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8783,6 +9008,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8831,6 +9057,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8879,6 +9106,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8934,6 +9162,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8961,6 +9190,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8988,6 +9218,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9015,6 +9246,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9042,6 +9274,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9111,6 +9344,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9138,6 +9372,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9165,6 +9400,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9220,6 +9456,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9261,6 +9498,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9358,6 +9596,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9406,6 +9645,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9433,6 +9673,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9502,6 +9743,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9550,6 +9792,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9577,6 +9820,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9604,6 +9848,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9631,6 +9876,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9658,6 +9904,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9685,6 +9932,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9712,6 +9960,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9739,6 +9988,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9766,6 +10016,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9793,6 +10044,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9820,6 +10072,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9847,6 +10100,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9874,6 +10128,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9901,6 +10156,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9928,6 +10184,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9955,6 +10212,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9982,6 +10240,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10009,6 +10268,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10050,6 +10310,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10077,6 +10338,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10104,6 +10366,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10159,6 +10422,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10186,6 +10450,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10213,6 +10478,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10247,6 +10513,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10274,6 +10541,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10301,6 +10569,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10328,6 +10597,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10355,6 +10625,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10410,6 +10681,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10437,6 +10709,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10485,6 +10758,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10540,6 +10814,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10567,6 +10842,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10594,6 +10870,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10649,6 +10926,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10676,6 +10954,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10766,6 +11045,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10793,6 +11073,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10820,6 +11101,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10847,6 +11129,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10916,6 +11199,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10950,6 +11234,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11033,6 +11318,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11060,6 +11346,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11108,6 +11395,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11135,6 +11423,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11183,6 +11472,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11210,6 +11500,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11237,6 +11528,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11299,6 +11591,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11340,6 +11633,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11367,6 +11661,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11394,6 +11689,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11421,6 +11717,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11448,6 +11745,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11517,6 +11815,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11544,6 +11843,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11571,6 +11871,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11633,6 +11934,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11667,6 +11969,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11694,6 +11997,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11721,6 +12025,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11748,6 +12053,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11775,6 +12081,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11802,6 +12109,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11829,6 +12137,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11856,6 +12165,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11883,6 +12193,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11910,6 +12221,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11965,6 +12277,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -11992,6 +12305,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12019,6 +12333,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12046,6 +12361,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12108,6 +12424,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12142,6 +12459,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12169,6 +12487,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12196,6 +12515,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12251,6 +12571,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12306,6 +12627,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12333,6 +12655,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12360,6 +12683,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12387,6 +12711,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12414,6 +12739,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12441,6 +12767,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12496,6 +12823,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12565,6 +12893,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12592,6 +12921,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12619,6 +12949,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12653,6 +12984,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12785,6 +13117,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12882,6 +13215,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12916,6 +13250,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12985,6 +13320,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13012,6 +13348,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13039,6 +13376,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13066,6 +13404,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13093,6 +13432,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13120,6 +13460,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13175,6 +13516,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13202,6 +13544,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13250,6 +13593,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13347,6 +13691,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13416,6 +13761,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13562,6 +13908,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13617,6 +13964,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13644,6 +13992,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13671,6 +14020,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13726,6 +14076,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13753,6 +14104,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13780,6 +14132,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13807,6 +14160,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13834,6 +14188,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13861,6 +14216,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13888,6 +14244,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13915,6 +14272,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13942,6 +14300,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -14032,6 +14391,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14059,6 +14419,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14086,6 +14447,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14113,6 +14475,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14266,6 +14629,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14293,6 +14657,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14320,6 +14685,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14347,6 +14713,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14388,6 +14755,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14415,6 +14783,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14442,6 +14811,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14469,6 +14839,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14524,6 +14895,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14551,6 +14923,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14578,6 +14951,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14675,6 +15049,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14702,6 +15077,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14729,6 +15105,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14784,6 +15161,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14811,6 +15189,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14873,6 +15252,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14900,6 +15280,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14927,6 +15308,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14954,6 +15336,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14981,6 +15364,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15008,6 +15392,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15063,6 +15448,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15132,6 +15518,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15159,6 +15546,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15186,6 +15574,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15213,6 +15602,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15240,6 +15630,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15267,6 +15658,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15294,6 +15686,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15433,6 +15826,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15460,6 +15854,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15487,6 +15882,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15514,6 +15910,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15541,6 +15938,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15582,6 +15980,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15609,6 +16008,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15636,6 +16036,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15663,6 +16064,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15690,6 +16092,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15724,6 +16127,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15751,6 +16155,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15778,6 +16183,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15875,6 +16281,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15902,6 +16309,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15929,6 +16337,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15956,6 +16365,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15983,6 +16393,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16010,6 +16421,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16037,6 +16449,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16064,6 +16477,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16091,6 +16505,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16118,6 +16533,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16145,6 +16561,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16186,6 +16603,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16213,6 +16631,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16240,6 +16659,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16302,6 +16722,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16329,6 +16750,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16356,6 +16778,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16383,6 +16806,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16410,6 +16834,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16465,6 +16890,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16492,6 +16918,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16519,6 +16946,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16546,6 +16974,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16573,6 +17002,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16663,6 +17093,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16690,6 +17121,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16717,6 +17149,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16744,6 +17177,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16771,6 +17205,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16798,6 +17233,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16825,6 +17261,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16971,6 +17408,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16998,6 +17436,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17025,6 +17464,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17052,6 +17492,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17079,6 +17520,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17113,6 +17555,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17168,6 +17611,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17237,6 +17681,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17264,6 +17709,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17291,6 +17737,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17318,6 +17765,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17345,6 +17793,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17372,6 +17821,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17399,6 +17849,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17489,6 +17940,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17516,6 +17968,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17543,6 +17996,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17570,6 +18024,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17597,6 +18052,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17645,6 +18101,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17686,6 +18143,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17713,6 +18171,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17740,6 +18199,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17774,6 +18234,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17801,6 +18262,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17870,6 +18332,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17897,6 +18360,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17931,6 +18395,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17958,6 +18423,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17985,6 +18451,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18040,6 +18507,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18095,6 +18563,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18164,6 +18633,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18191,6 +18661,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18218,6 +18689,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18245,6 +18717,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18300,6 +18773,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18369,6 +18843,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18396,6 +18871,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18465,6 +18941,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18492,6 +18969,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18519,6 +18997,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18546,6 +19025,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18573,6 +19053,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18600,6 +19081,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18627,6 +19109,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18661,6 +19144,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18695,6 +19179,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18722,6 +19207,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18749,6 +19235,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18804,6 +19291,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18831,6 +19319,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18858,6 +19347,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18885,6 +19375,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18919,6 +19410,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18946,6 +19438,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18973,6 +19466,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19000,6 +19494,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19027,6 +19522,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19061,6 +19557,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19088,6 +19585,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19143,6 +19641,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19170,6 +19669,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19253,6 +19753,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19287,6 +19788,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19342,6 +19844,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19369,6 +19872,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19396,6 +19900,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19423,6 +19928,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19457,6 +19963,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19491,6 +19998,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19518,6 +20026,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19545,6 +20054,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19572,6 +20082,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19627,6 +20138,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19654,6 +20166,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19681,6 +20194,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19729,6 +20243,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19756,6 +20271,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19783,6 +20299,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19810,6 +20327,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19837,6 +20355,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19864,6 +20383,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19891,6 +20411,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19918,6 +20439,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19945,6 +20467,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -20014,6 +20537,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20041,6 +20565,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20068,6 +20593,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20095,6 +20621,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20129,6 +20656,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20156,6 +20684,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20183,6 +20712,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20210,6 +20740,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20279,6 +20810,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20306,6 +20838,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20347,6 +20880,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20374,6 +20908,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20443,6 +20978,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20505,6 +21041,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20532,6 +21069,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20601,6 +21139,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20628,6 +21167,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20655,6 +21195,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20682,6 +21223,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20709,6 +21251,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20736,6 +21279,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20763,6 +21307,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20790,6 +21335,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20824,6 +21370,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20914,6 +21461,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20941,6 +21489,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20968,6 +21517,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -21002,6 +21552,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21036,6 +21587,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21077,6 +21629,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21132,6 +21685,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21159,6 +21713,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21186,6 +21741,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21255,6 +21811,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21282,6 +21839,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21323,6 +21881,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21378,6 +21937,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21405,6 +21965,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21432,6 +21993,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21466,6 +22028,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21493,6 +22056,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21520,6 +22084,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21547,6 +22112,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21574,6 +22140,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21601,6 +22168,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21642,6 +22210,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21669,6 +22238,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21696,6 +22266,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21723,6 +22294,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21799,6 +22371,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21826,6 +22399,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21853,6 +22427,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21880,6 +22455,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21907,6 +22483,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21934,6 +22511,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21982,6 +22560,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22016,6 +22595,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22043,6 +22623,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22070,6 +22651,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22097,6 +22679,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22124,6 +22707,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22151,6 +22735,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22178,6 +22763,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22219,6 +22805,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22246,6 +22833,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22273,6 +22861,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22412,6 +23001,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22453,6 +23043,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22480,6 +23071,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22514,6 +23106,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22569,6 +23162,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22596,6 +23190,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22623,6 +23218,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22671,6 +23267,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22712,6 +23309,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22739,6 +23337,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22766,6 +23365,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22835,6 +23435,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22869,6 +23470,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22896,6 +23498,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22930,6 +23533,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22964,6 +23568,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22991,6 +23596,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -23018,6 +23624,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23045,6 +23652,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23072,6 +23680,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23099,6 +23708,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23126,6 +23736,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23181,6 +23792,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23208,6 +23820,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23263,6 +23876,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23325,6 +23939,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23352,6 +23967,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23379,6 +23995,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23420,6 +24037,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23475,6 +24093,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23502,6 +24121,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23529,6 +24149,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23556,6 +24177,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23590,6 +24212,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23617,6 +24240,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23651,6 +24275,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23678,6 +24303,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23726,6 +24352,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23753,6 +24380,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23780,6 +24408,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23807,6 +24436,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23834,6 +24464,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23889,6 +24520,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23916,6 +24548,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23943,6 +24576,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23998,6 +24632,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -24025,6 +24660,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24073,6 +24709,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24121,6 +24758,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24148,6 +24786,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24175,6 +24814,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24202,6 +24842,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24229,6 +24870,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24256,6 +24898,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24283,6 +24926,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24310,6 +24954,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24337,6 +24982,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24364,6 +25010,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24391,6 +25038,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24418,6 +25066,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24445,6 +25094,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24479,6 +25129,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24541,6 +25192,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24568,6 +25220,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24595,6 +25248,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24734,6 +25388,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24803,6 +25458,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24830,6 +25486,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24857,6 +25514,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24926,6 +25584,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24953,6 +25612,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24980,6 +25640,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -25007,6 +25668,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -25041,6 +25703,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25082,6 +25745,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25109,6 +25773,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25136,6 +25801,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25163,6 +25829,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25190,6 +25857,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25217,6 +25885,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25244,6 +25913,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25271,6 +25941,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25340,6 +26011,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25367,6 +26039,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25394,6 +26067,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25428,6 +26102,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25455,6 +26130,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25503,6 +26179,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25537,6 +26214,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25564,6 +26242,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25591,6 +26270,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25618,6 +26298,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25645,6 +26326,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25672,6 +26354,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25699,6 +26382,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25726,6 +26410,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25788,6 +26473,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25815,6 +26501,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25849,6 +26536,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25876,6 +26564,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25903,6 +26592,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25951,6 +26641,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25978,6 +26669,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -26005,6 +26697,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26032,6 +26725,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26066,6 +26760,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26163,6 +26858,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26190,6 +26886,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26252,6 +26949,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26279,6 +26977,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26306,6 +27005,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26333,6 +27033,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26360,6 +27061,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26387,6 +27089,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26414,6 +27117,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26448,6 +27152,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26475,6 +27180,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26544,6 +27250,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26571,6 +27278,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26668,6 +27376,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26695,6 +27404,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26722,6 +27432,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26749,6 +27460,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26776,6 +27488,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26803,6 +27516,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26858,6 +27572,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26885,6 +27600,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27073,6 +27789,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27100,6 +27817,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27127,6 +27845,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27154,6 +27873,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27188,6 +27908,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27215,6 +27936,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27291,6 +28013,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27318,6 +28041,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27359,6 +28083,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27386,6 +28111,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27427,6 +28153,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27517,6 +28244,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27544,6 +28272,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27571,6 +28300,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27598,6 +28328,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27625,6 +28356,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27652,6 +28384,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27679,6 +28412,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27706,6 +28440,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27733,6 +28468,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27760,6 +28496,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27787,6 +28524,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27814,6 +28552,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27841,6 +28580,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27868,6 +28608,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27972,6 +28713,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -28027,6 +28769,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -28054,6 +28797,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -28081,6 +28825,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28108,6 +28853,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28135,6 +28881,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28162,6 +28909,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28217,6 +28965,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28244,6 +28993,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28271,6 +29021,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28305,6 +29056,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28360,6 +29112,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28387,6 +29140,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28414,6 +29168,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28483,6 +29238,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28510,6 +29266,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28537,6 +29294,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28564,6 +29322,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28591,6 +29350,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28618,6 +29378,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28645,6 +29406,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28672,6 +29434,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28727,6 +29490,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28754,6 +29518,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28781,6 +29546,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28815,6 +29581,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28842,6 +29609,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28876,6 +29644,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28903,6 +29672,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28930,6 +29700,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28957,6 +29728,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -29040,6 +29812,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29067,6 +29840,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29136,6 +29910,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29233,6 +30008,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29260,6 +30036,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29287,6 +30064,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29314,6 +30092,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29383,6 +30162,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29410,6 +30190,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29465,6 +30246,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29492,6 +30274,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29519,6 +30302,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29546,6 +30330,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29587,6 +30372,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29614,6 +30400,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29648,6 +30435,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29675,6 +30463,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29702,6 +30491,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29729,6 +30519,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29756,6 +30547,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29790,6 +30582,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29817,6 +30610,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29844,6 +30638,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29871,6 +30666,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29898,6 +30694,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29925,6 +30722,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29952,6 +30750,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -30049,6 +30848,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -30076,6 +30876,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -30103,6 +30904,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30130,6 +30932,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30157,6 +30960,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30184,6 +30988,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30211,6 +31016,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30238,6 +31044,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30279,6 +31086,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30306,6 +31114,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30333,6 +31142,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30388,6 +31198,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30415,6 +31226,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30442,6 +31254,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30469,6 +31282,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30496,6 +31310,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30523,6 +31338,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30550,6 +31366,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30605,6 +31422,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30632,6 +31450,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30666,6 +31485,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30728,6 +31548,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30755,6 +31576,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30782,6 +31604,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30809,6 +31632,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30836,6 +31660,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30863,6 +31688,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30890,6 +31716,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30917,6 +31744,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30944,6 +31772,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30999,6 +31828,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -31026,6 +31856,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -31053,6 +31884,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31080,6 +31912,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -31107,6 +31940,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31134,6 +31968,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31168,6 +32003,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31195,6 +32031,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31250,6 +32087,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31277,6 +32115,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31304,6 +32143,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31331,6 +32171,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31358,6 +32199,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31385,6 +32227,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31412,6 +32255,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31439,6 +32283,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31564,6 +32409,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31591,6 +32437,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31618,6 +32465,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31645,6 +32493,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31700,6 +32549,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31727,6 +32577,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31782,6 +32633,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31809,6 +32661,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31836,6 +32689,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31891,6 +32745,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31925,6 +32780,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32015,6 +32871,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32042,6 +32899,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -32125,6 +32983,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32166,6 +33025,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32193,6 +33053,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32248,6 +33109,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32275,6 +33137,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32302,6 +33165,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32336,6 +33200,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32363,6 +33228,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32390,6 +33256,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32417,6 +33284,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32444,6 +33312,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32471,6 +33340,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32498,6 +33368,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32525,6 +33396,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32552,6 +33424,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32607,6 +33480,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32634,6 +33508,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32661,6 +33536,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32688,6 +33564,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32715,6 +33592,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32742,6 +33620,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32769,6 +33648,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32824,6 +33704,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32872,6 +33753,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32913,6 +33795,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32940,6 +33823,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32967,6 +33851,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32994,6 +33879,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33084,6 +33970,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33111,6 +33998,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33138,6 +34026,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33172,6 +34061,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33199,6 +34089,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33226,6 +34117,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33267,6 +34159,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33322,6 +34215,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33349,6 +34243,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33446,6 +34341,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33522,6 +34418,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33598,6 +34495,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33688,6 +34586,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33729,6 +34628,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33770,6 +34670,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33825,6 +34726,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33852,6 +34754,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33886,6 +34789,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33913,6 +34817,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33996,6 +34901,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -34023,6 +34929,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -34050,6 +34957,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34077,6 +34985,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34104,6 +35013,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -34131,6 +35041,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34172,6 +35083,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34199,6 +35111,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34268,6 +35181,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34295,6 +35209,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34322,6 +35237,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34349,6 +35265,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34376,6 +35293,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34403,6 +35321,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34437,6 +35356,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34471,6 +35391,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34568,6 +35489,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34595,6 +35517,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34622,6 +35545,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34649,6 +35573,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34676,6 +35601,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34703,6 +35629,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34758,6 +35685,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34785,6 +35713,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34875,6 +35804,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34930,6 +35860,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34957,6 +35888,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34984,6 +35916,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35011,6 +35944,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -35059,6 +35993,7 @@
         {
             "id": "0xe02e8ddecbe302ba1a40107c726e3ee889b0ff10",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
@@ -35093,6 +36028,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35120,6 +36056,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35147,6 +36084,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35279,6 +36217,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35306,6 +36245,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35333,6 +36273,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35360,6 +36301,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35387,6 +36329,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35414,6 +36357,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35441,6 +36385,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35468,6 +36413,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35495,6 +36441,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35522,6 +36469,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35584,6 +36532,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35632,6 +36581,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35659,6 +36609,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35686,6 +36637,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35713,6 +36665,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35740,6 +36693,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35774,6 +36728,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35801,6 +36756,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35828,6 +36784,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35855,6 +36812,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35882,6 +36840,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35930,6 +36889,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35985,6 +36945,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -36012,6 +36973,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -36039,6 +37001,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36073,6 +37036,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -36100,6 +37064,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36169,6 +37134,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36217,6 +37183,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36272,6 +37239,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36313,6 +37281,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36340,6 +37309,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36409,6 +37379,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36436,6 +37407,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36463,6 +37435,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36490,6 +37463,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36594,6 +37568,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36621,6 +37596,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36648,6 +37624,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36745,6 +37722,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36772,6 +37750,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36799,6 +37778,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36826,6 +37806,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36853,6 +37834,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36880,6 +37862,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36907,6 +37890,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36934,6 +37918,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36961,6 +37946,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36988,6 +37974,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -37015,6 +38002,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -37049,6 +38037,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -37076,6 +38065,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -37103,6 +38093,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37158,6 +38149,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37185,6 +38177,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37212,6 +38205,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37267,6 +38261,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37294,6 +38289,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37349,6 +38345,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37376,6 +38373,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37403,6 +38401,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37451,6 +38450,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37478,6 +38478,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37505,6 +38506,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37532,6 +38534,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37573,6 +38576,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37600,6 +38604,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37634,6 +38639,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37661,6 +38667,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37695,6 +38702,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37750,6 +38758,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37777,6 +38786,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37804,6 +38814,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37852,6 +38863,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37886,6 +38898,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37948,6 +38961,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37975,6 +38989,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -38002,6 +39017,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38050,6 +39066,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -38077,6 +39094,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38104,6 +39122,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -38152,6 +39171,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38179,6 +39199,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38290,6 +39311,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38345,6 +39367,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38372,6 +39395,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38420,6 +39444,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38447,6 +39472,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38516,6 +39542,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38543,6 +39570,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38598,6 +39626,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38625,6 +39654,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38652,6 +39682,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38679,6 +39710,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38706,6 +39738,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38733,6 +39766,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38795,6 +39829,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38822,6 +39857,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38870,6 +39906,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38897,6 +39934,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38924,6 +39962,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38951,6 +39990,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -39006,6 +40046,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39033,6 +40074,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -39060,6 +40102,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -39087,6 +40130,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -39156,6 +40200,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39183,6 +40228,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39210,6 +40256,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39286,6 +40333,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39313,6 +40361,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39347,6 +40396,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39381,6 +40431,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39415,6 +40466,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39442,6 +40494,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39469,6 +40522,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39496,6 +40550,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39530,6 +40585,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39557,6 +40613,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39584,6 +40641,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39611,6 +40669,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39645,6 +40704,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39679,6 +40739,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39706,6 +40767,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39733,6 +40795,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39844,6 +40907,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39871,6 +40935,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39898,6 +40963,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39925,6 +40991,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39980,6 +41047,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -40007,6 +41075,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40041,6 +41110,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40068,6 +41138,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -40165,6 +41236,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40192,6 +41264,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40219,6 +41292,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40246,6 +41320,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40315,6 +41390,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x93db5e0965435057224eee49563ac616fbc9fe531aab95ccd754e4a91fc658e0.json
+++ b/test/testData/testPools/0x93db5e0965435057224eee49563ac616fbc9fe531aab95ccd754e4a91fc658e0.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -827,6 +832,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1392,6 +1399,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1826,6 +1834,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1921,6 +1930,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1955,6 +1965,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2031,6 +2042,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2133,6 +2145,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2406,6 +2419,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2433,6 +2447,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2494,6 +2509,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2636,6 +2652,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3002,6 +3019,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3362,6 +3380,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4047,6 +4066,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4217,6 +4237,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4319,6 +4340,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4400,6 +4422,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4739,6 +4762,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4957,6 +4981,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5026,6 +5051,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5080,6 +5106,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5249,6 +5276,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5358,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5466,6 +5495,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5635,6 +5665,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5886,6 +5917,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6355,6 +6387,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6900,6 +6933,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6981,6 +7015,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7157,6 +7192,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7320,6 +7356,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7455,6 +7492,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7578,6 +7616,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7658,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7788,6 +7828,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8161,6 +8202,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8474,6 +8516,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8624,6 +8667,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +8933,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9174,6 +9219,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9269,6 +9315,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10362,6 +10409,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10491,6 +10539,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10599,6 +10648,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10680,6 +10730,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10953,6 +11004,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10980,6 +11032,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11641,6 +11694,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11979,6 +12033,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12264,6 +12319,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12508,6 +12564,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12719,6 +12776,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12746,6 +12804,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12794,6 +12853,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12862,6 +12922,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13182,6 +13243,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13353,6 +13415,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13421,6 +13484,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13482,6 +13546,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13523,6 +13588,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13619,6 +13685,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13998,6 +14065,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14195,6 +14263,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14222,6 +14291,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14291,6 +14361,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14548,6 +14619,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14698,6 +14770,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14806,6 +14879,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14887,6 +14961,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15083,6 +15158,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15382,6 +15458,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15451,6 +15528,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15850,6 +15928,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16481,6 +16560,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16671,6 +16751,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16908,6 +16989,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16977,6 +17059,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17180,6 +17263,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17465,6 +17549,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17866,6 +17951,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18049,6 +18135,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18103,6 +18190,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18307,6 +18395,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19149,6 +19238,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19230,6 +19320,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19257,6 +19348,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19345,6 +19437,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19595,6 +19688,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20232,6 +20326,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20845,6 +20940,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21343,6 +21439,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21742,6 +21839,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22291,6 +22389,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22318,6 +22417,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22359,6 +22459,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22529,6 +22630,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23140,6 +23242,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23276,6 +23379,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23432,6 +23536,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23845,6 +23950,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23953,6 +24059,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24604,6 +24711,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24645,6 +24753,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25278,6 +25387,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25739,6 +25849,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26085,6 +26196,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26112,6 +26224,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26616,6 +26729,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26805,6 +26919,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26886,6 +27001,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26948,6 +27064,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27017,6 +27134,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27213,6 +27331,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27424,6 +27543,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27451,6 +27571,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27863,6 +27984,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27890,6 +28012,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27965,6 +28088,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28154,6 +28278,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28296,6 +28421,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28662,6 +28788,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28946,6 +29073,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29166,6 +29294,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29315,6 +29444,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29911,6 +30041,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30291,6 +30422,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30534,6 +30666,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31178,6 +31311,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31435,6 +31569,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31490,6 +31625,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31625,6 +31761,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31932,6 +32069,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32027,6 +32165,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32170,6 +32309,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32528,6 +32668,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32744,6 +32885,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33003,6 +33145,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33240,6 +33383,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33321,6 +33465,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33417,6 +33562,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33492,6 +33638,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33567,6 +33714,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33594,6 +33742,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33737,6 +33886,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33764,6 +33914,7 @@
         {
             "id": "0xd8e72a62e214864cbd9381cc04fa1006a8c8fb10",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23b608675a2b2fb1890d3abbd85c5775c51691d5",
@@ -33948,6 +34099,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33975,6 +34127,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34504,6 +34657,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34824,6 +34978,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34851,6 +35006,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34905,6 +35061,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35142,6 +35299,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35169,6 +35327,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35217,6 +35376,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35922,6 +36082,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36481,6 +36642,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36508,6 +36670,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36637,6 +36800,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37091,6 +37255,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37682,6 +37847,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37872,6 +38038,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38164,6 +38331,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38205,6 +38373,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38273,6 +38442,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38443,6 +38613,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38524,6 +38695,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38720,6 +38892,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38930,6 +39103,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39188,6 +39362,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39724,6 +39899,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39901,6 +40077,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40043,6 +40220,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x958eb7095ad851133bb2d3282a370108832094082e7554e48c9218cf376cd0be.json
+++ b/test/testData/testPools/0x958eb7095ad851133bb2d3282a370108832094082e7554e48c9218cf376cd0be.json
@@ -13,6 +13,7 @@
         {
             "id": "0x6c3f90f043a72fa612cbac8115ee7e52bde6e490",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "600",
             "tokens": [
                 {
@@ -48,6 +49,7 @@
         {
             "id": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "500",
             "tokens": [
                 {
@@ -90,6 +92,7 @@
         {
             "id": "0x845838df265dcd2c412a1dc9e959c7d08537f8a2",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "450",
             "tokens": [
                 {
@@ -118,6 +121,7 @@
         {
             "id": "0xd2967f45c4f384deea880f807be904762a3dea07",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -146,6 +150,7 @@
         {
             "id": "0xb19059ebb43466c323583928285a49f558e572fd",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "300",
             "tokens": [
                 {
@@ -174,6 +179,7 @@
         {
             "id": "0x5b5cfe992adac0c9d48e05854b2d91c73a003858",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -202,6 +208,7 @@
         {
             "id": "0x6d65b498cb23deaba52db31c93da9bffb340fb8f",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "5",
             "tokens": [
                 {
@@ -230,6 +237,7 @@
         {
             "id": "0x1aef73d49dedc4b1778d0706583995958dc862e6",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -258,6 +266,7 @@
         {
             "id": "0xd905e2eaebe188fc92179b6350807d8bd91db0d8",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -300,6 +309,7 @@
         {
             "id": "0x49849c98ae39fff122806c06791fa73784fb3675",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -328,6 +338,7 @@
         {
             "id": "0xc2ee6b0334c261ed60c72f6054450b61b8f18e35",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -356,6 +367,7 @@
         {
             "id": "0x075b1bb99792c9e1041ba13afef80c91a1e70fb3",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -391,6 +403,7 @@
         {
             "id": "0xc25a3a3b969415c80451098fa907ec722572917f",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -433,6 +446,7 @@
         {
             "id": "0x64eda51d3ad40d56b9dfc5554e06f94e1dd786fd",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "150",
             "tokens": [
                 {
@@ -461,6 +475,7 @@
         {
             "id": "0x97e2768e8e73511ca874545dc5ff8067eb19b787",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -489,6 +504,7 @@
         {
             "id": "0x4f3e8f405cf5afc05d68142f3783bdfe13811522",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "50",
             "tokens": [
                 {
@@ -517,6 +533,7 @@
         {
             "id": "0x9fc689ccada600b6df723d9e47d84d76664a1f23",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "2000",
             "tokens": [
                 {
@@ -552,6 +569,7 @@
         {
             "id": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "1000",
             "tokens": [
                 {
@@ -594,6 +612,7 @@
         {
             "id": "0x3a664ab939fd8482048609f652f9a0b0677337b9",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -622,6 +641,7 @@
         {
             "id": "0x410e3e86ef427e30b9235497143881f717d93c2a",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -650,6 +670,7 @@
         {
             "id": "0x2fe94ea3d5d4a175184081439753de15aef9d614",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -678,6 +699,7 @@
         {
             "id": "0xde5331ac4b3630f94853ff322b66407e0d6331e8",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -706,6 +728,7 @@
         {
             "id": "0x94e131324b6054c0d789b190b2dac504e4361b53",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -734,6 +757,7 @@
         {
             "id": "0x194ebd173f6cdace046c53eacce9b953f28411d1",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -762,6 +786,7 @@
         {
             "id": "0xa3d87fffce63b53e0d54faa1cc983b7eb0b74a9c",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -790,6 +815,7 @@
         {
             "id": "0x06325440d014e39736583c165c2963ba99faf14e",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "10",
             "tokens": [
                 {
@@ -818,6 +844,7 @@
         {
             "id": "0xaa17a236f2badc98ddc0cf999abb47d47fc0a6cf",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "10",
             "tokens": [
                 {
@@ -846,6 +873,7 @@
         {
             "id": "0x5282a4ef67d9c33135340fb3289cc1711c13638c",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "600",
             "tokens": [
                 {
@@ -881,6 +909,7 @@
         {
             "id": "0xcee60cfa923170e4f8204ae08b4fa6a3f5656f3a",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -909,6 +938,7 @@
         {
             "id": "0x7eb40e450b9655f4b3cc4259bcc731c63ff55ae6",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {

--- a/test/testData/testPools/0x95e9d514d6c751ce4781be643906ea0b9100f80b82dc52e72d5c76b84b8afc64.json
+++ b/test/testData/testPools/0x95e9d514d6c751ce4781be643906ea0b9100f80b82dc52e72d5c76b84b8afc64.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x995a2d20a846226c7680fff641cee4397f81c6e1f0675d69c7d26d05a60b39f3.json
+++ b/test/testData/testPools/0x995a2d20a846226c7680fff641cee4397f81c6e1f0675d69c7d26d05a60b39f3.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x99cc915640bbb9ef7dd6979062fea2a34eff2b400398a4c00405462840956818.json
+++ b/test/testData/testPools/0x99cc915640bbb9ef7dd6979062fea2a34eff2b400398a4c00405462840956818.json
@@ -97,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -124,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -422,6 +424,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -592,6 +595,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -619,6 +623,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -830,6 +835,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1191,6 +1197,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1395,6 +1402,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1829,6 +1837,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1924,6 +1933,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1958,6 +1968,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2034,6 +2045,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2136,6 +2148,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2409,6 +2422,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2436,6 +2450,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2497,6 +2512,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2639,6 +2655,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3005,6 +3022,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3365,6 +3383,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4050,6 +4069,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4220,6 +4240,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4322,6 +4343,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4403,6 +4425,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4742,6 +4765,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4960,6 +4984,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5029,6 +5054,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5083,6 +5109,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5252,6 +5279,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5333,6 +5361,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5469,6 +5498,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5638,6 +5668,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5889,6 +5920,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6358,6 +6390,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6903,6 +6936,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6984,6 +7018,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7160,6 +7195,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7323,6 +7359,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7458,6 +7495,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7581,6 +7619,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7622,6 +7661,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7791,6 +7831,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8164,6 +8205,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8477,6 +8519,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8627,6 +8670,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8892,6 +8936,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9177,6 +9222,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9272,6 +9318,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10365,6 +10412,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10494,6 +10542,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10602,6 +10651,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10683,6 +10733,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10956,6 +11007,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10983,6 +11035,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11644,6 +11697,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11982,6 +12036,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12267,6 +12322,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12511,6 +12567,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12722,6 +12779,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12749,6 +12807,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12797,6 +12856,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12865,6 +12925,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13185,6 +13246,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13356,6 +13418,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13424,6 +13487,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13485,6 +13549,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13526,6 +13591,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13622,6 +13688,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14001,6 +14068,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14198,6 +14266,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14225,6 +14294,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14294,6 +14364,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14551,6 +14622,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14701,6 +14773,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14809,6 +14882,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14890,6 +14964,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15086,6 +15161,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15385,6 +15461,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15454,6 +15531,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15853,6 +15931,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16484,6 +16563,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16674,6 +16754,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16911,6 +16992,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16980,6 +17062,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17183,6 +17266,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17468,6 +17552,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17869,6 +17954,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18052,6 +18138,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18106,6 +18193,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18310,6 +18398,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19152,6 +19241,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19233,6 +19323,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19260,6 +19351,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19348,6 +19440,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19598,6 +19691,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20235,6 +20329,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20848,6 +20943,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21346,6 +21442,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21745,6 +21842,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22294,6 +22392,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22321,6 +22420,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22362,6 +22462,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22532,6 +22633,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23143,6 +23245,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23279,6 +23382,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23435,6 +23539,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23848,6 +23953,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23956,6 +24062,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24607,6 +24714,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24648,6 +24756,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25281,6 +25390,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25742,6 +25852,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26088,6 +26199,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26115,6 +26227,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26619,6 +26732,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26808,6 +26922,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26889,6 +27004,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26951,6 +27067,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27020,6 +27137,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27216,6 +27334,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27427,6 +27546,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27454,6 +27574,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27866,6 +27987,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27893,6 +28015,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27968,6 +28091,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28157,6 +28281,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28299,6 +28424,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28665,6 +28791,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28949,6 +29076,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29169,6 +29297,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29318,6 +29447,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29914,6 +30044,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30294,6 +30425,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30537,6 +30669,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31181,6 +31314,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31438,6 +31572,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31493,6 +31628,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31628,6 +31764,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31935,6 +32072,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32030,6 +32168,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32173,6 +32312,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32531,6 +32671,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32747,6 +32888,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33006,6 +33148,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33243,6 +33386,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33324,6 +33468,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33420,6 +33565,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33495,6 +33641,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33570,6 +33717,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33597,6 +33745,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33740,6 +33889,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33767,6 +33917,7 @@
         {
             "id": "0xd8e72a62e214864cbd9381cc04fa1006a8c8fb10",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23b608675a2b2fb1890d3abbd85c5775c51691d5",
@@ -33951,6 +34102,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33978,6 +34130,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34507,6 +34660,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34827,6 +34981,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34854,6 +35009,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34908,6 +35064,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35145,6 +35302,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35172,6 +35330,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35220,6 +35379,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35925,6 +36085,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36484,6 +36645,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36511,6 +36673,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36640,6 +36803,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37094,6 +37258,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37685,6 +37850,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37875,6 +38041,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38167,6 +38334,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38208,6 +38376,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38276,6 +38445,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38446,6 +38616,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38527,6 +38698,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38723,6 +38895,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38933,6 +39106,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39191,6 +39365,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39727,6 +39902,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39904,6 +40080,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40046,6 +40223,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x99cc915640bbb9ef7dd6979062fea2a34eff2b400398a4c00405462840956818.json
+++ b/test/testData/testPools/0x99cc915640bbb9ef7dd6979062fea2a34eff2b400398a4c00405462840956818.json
@@ -16,6 +16,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -43,6 +44,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -70,6 +72,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -174,6 +177,7 @@
         {
             "id": "0x01223eb6b9cbe061f2f22e96f74936c0115ec6fb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4de9ab5dd20547b7334a295763dfd0a11b010e0a",
@@ -201,6 +205,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -228,6 +233,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -262,6 +268,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -289,6 +296,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -316,6 +324,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -343,6 +352,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -370,6 +380,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -397,6 +408,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -452,6 +464,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -500,6 +513,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -541,6 +555,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -568,6 +583,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -651,6 +667,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -678,6 +695,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -726,6 +744,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -753,6 +772,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -780,6 +800,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -884,6 +905,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -911,6 +933,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -938,6 +961,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -965,6 +989,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -992,6 +1017,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1033,6 +1059,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1060,6 +1087,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1101,6 +1129,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1128,6 +1157,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1267,6 +1297,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1294,6 +1325,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1321,6 +1353,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1348,6 +1381,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1375,6 +1409,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1430,6 +1465,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1457,6 +1493,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1505,6 +1542,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1532,6 +1570,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1580,6 +1619,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1607,6 +1647,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1634,6 +1675,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1661,6 +1703,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1702,6 +1745,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1729,6 +1773,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1756,6 +1801,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1783,6 +1829,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1810,6 +1857,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1865,6 +1913,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1906,6 +1955,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -2017,6 +2067,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2093,6 +2144,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2211,6 +2263,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2259,6 +2312,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2286,6 +2340,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2313,6 +2368,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2368,6 +2424,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2395,6 +2452,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2485,6 +2543,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2540,6 +2599,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2574,6 +2634,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2601,6 +2662,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2628,6 +2690,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2704,6 +2767,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2731,6 +2795,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2765,6 +2830,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2792,6 +2858,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2819,6 +2886,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2846,6 +2914,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2873,6 +2942,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2907,6 +2977,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2934,6 +3005,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2961,6 +3033,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2988,6 +3061,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3092,6 +3166,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3126,6 +3201,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3153,6 +3229,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3180,6 +3257,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3207,6 +3285,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3248,6 +3327,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3275,6 +3355,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3302,6 +3383,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3329,6 +3411,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3356,6 +3439,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3425,6 +3509,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3473,6 +3558,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3500,6 +3586,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3527,6 +3614,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3554,6 +3642,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3581,6 +3670,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3650,6 +3740,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3677,6 +3768,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3704,6 +3796,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3731,6 +3824,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3758,6 +3852,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3785,6 +3880,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3812,6 +3908,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3839,6 +3936,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3873,6 +3971,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3900,6 +3999,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3927,6 +4027,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3954,6 +4055,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3988,6 +4090,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4015,6 +4118,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4042,6 +4146,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4097,6 +4202,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4138,6 +4244,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4165,6 +4272,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4213,6 +4321,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4289,6 +4398,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4316,6 +4426,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4371,6 +4482,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4398,6 +4510,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4481,6 +4594,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4522,6 +4636,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4549,6 +4664,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4576,6 +4692,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4603,6 +4720,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4630,6 +4748,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4657,6 +4776,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4684,6 +4804,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4711,6 +4832,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4738,6 +4860,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4793,6 +4916,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4862,6 +4986,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4889,6 +5014,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4916,6 +5042,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4943,6 +5070,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5082,6 +5210,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5137,6 +5266,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5171,6 +5301,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5198,6 +5329,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5225,6 +5357,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5252,6 +5385,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5307,6 +5441,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5334,6 +5469,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5389,6 +5525,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5416,6 +5553,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5471,6 +5609,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5533,6 +5672,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5560,6 +5700,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5587,6 +5728,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5614,6 +5756,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5641,6 +5784,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5696,6 +5840,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5730,6 +5875,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5757,6 +5903,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5784,6 +5931,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5839,6 +5987,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5866,6 +6015,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5893,6 +6043,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5948,6 +6099,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5975,6 +6127,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6002,6 +6155,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6029,6 +6183,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6056,6 +6211,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6083,6 +6239,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6131,6 +6288,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6158,6 +6316,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6199,6 +6358,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6247,6 +6407,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6274,6 +6435,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6301,6 +6463,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6356,6 +6519,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6432,6 +6596,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6501,6 +6666,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6528,6 +6694,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6562,6 +6729,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6589,6 +6757,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6616,6 +6785,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6643,6 +6813,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6670,6 +6841,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6697,6 +6869,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6724,6 +6897,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6751,6 +6925,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6813,6 +6988,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6882,6 +7058,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6909,6 +7086,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6964,6 +7142,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6991,6 +7170,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7053,6 +7233,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7080,6 +7261,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7107,6 +7289,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7134,6 +7317,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7168,6 +7352,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7223,6 +7408,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7250,6 +7436,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7305,6 +7492,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7332,6 +7520,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7387,6 +7576,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7414,6 +7604,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7441,6 +7632,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7468,6 +7660,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7523,6 +7716,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7550,6 +7744,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7689,6 +7884,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7716,6 +7912,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7743,6 +7940,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7770,6 +7968,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7797,6 +7996,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7859,6 +8059,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7893,6 +8094,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7920,6 +8122,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7947,6 +8150,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7995,6 +8199,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -8022,6 +8227,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8049,6 +8255,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8076,6 +8283,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8103,6 +8311,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8130,6 +8339,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8157,6 +8367,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8233,6 +8444,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8260,6 +8472,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8294,6 +8507,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8321,6 +8535,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8348,6 +8563,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8389,6 +8605,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8416,6 +8633,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8450,6 +8668,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8547,6 +8766,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8574,6 +8794,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8601,6 +8822,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8698,6 +8920,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8725,6 +8948,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8752,6 +8976,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8786,6 +9011,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8813,6 +9039,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8861,6 +9088,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8909,6 +9137,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8964,6 +9193,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8991,6 +9221,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -9018,6 +9249,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9045,6 +9277,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9072,6 +9305,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9141,6 +9375,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9168,6 +9403,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9195,6 +9431,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9250,6 +9487,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9291,6 +9529,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9388,6 +9627,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9436,6 +9676,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9463,6 +9704,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9532,6 +9774,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9580,6 +9823,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9607,6 +9851,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9634,6 +9879,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9661,6 +9907,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9688,6 +9935,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9715,6 +9963,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9742,6 +9991,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9769,6 +10019,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9796,6 +10047,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9823,6 +10075,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9850,6 +10103,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9877,6 +10131,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9904,6 +10159,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9931,6 +10187,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9958,6 +10215,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9985,6 +10243,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -10012,6 +10271,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10039,6 +10299,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10080,6 +10341,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10107,6 +10369,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10134,6 +10397,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10189,6 +10453,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10216,6 +10481,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10243,6 +10509,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10277,6 +10544,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10304,6 +10572,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10331,6 +10600,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10358,6 +10628,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10385,6 +10656,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10440,6 +10712,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10467,6 +10740,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10515,6 +10789,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10570,6 +10845,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10597,6 +10873,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10624,6 +10901,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10679,6 +10957,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10706,6 +10985,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10796,6 +11076,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10823,6 +11104,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10850,6 +11132,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10877,6 +11160,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10946,6 +11230,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10980,6 +11265,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11063,6 +11349,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11090,6 +11377,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11138,6 +11426,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11165,6 +11454,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11213,6 +11503,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11240,6 +11531,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11267,6 +11559,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11329,6 +11622,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11370,6 +11664,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11397,6 +11692,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11424,6 +11720,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11451,6 +11748,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11478,6 +11776,7 @@
         {
             "id": "0x4b3fa856cef9aa85ed9bbfa8992d6138c5f150e6",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -11547,6 +11846,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11616,6 +11916,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11643,6 +11944,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11670,6 +11972,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11732,6 +12035,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11766,6 +12070,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11793,6 +12098,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11820,6 +12126,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11847,6 +12154,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11874,6 +12182,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11901,6 +12210,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11928,6 +12238,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11955,6 +12266,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11982,6 +12294,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12009,6 +12322,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12064,6 +12378,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12091,6 +12406,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12118,6 +12434,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12145,6 +12462,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12207,6 +12525,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12241,6 +12560,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12268,6 +12588,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12295,6 +12616,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12350,6 +12672,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12405,6 +12728,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12432,6 +12756,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12459,6 +12784,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12486,6 +12812,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12513,6 +12840,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12540,6 +12868,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12595,6 +12924,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12664,6 +12994,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12691,6 +13022,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12718,6 +13050,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12752,6 +13085,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12884,6 +13218,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12981,6 +13316,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -13015,6 +13351,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -13084,6 +13421,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13111,6 +13449,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13138,6 +13477,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13165,6 +13505,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13192,6 +13533,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13219,6 +13561,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13274,6 +13617,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13301,6 +13645,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13349,6 +13694,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13446,6 +13792,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13515,6 +13862,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13661,6 +14009,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13716,6 +14065,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13743,6 +14093,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13770,6 +14121,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13825,6 +14177,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13852,6 +14205,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13879,6 +14233,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13906,6 +14261,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13933,6 +14289,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13960,6 +14317,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13987,6 +14345,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14014,6 +14373,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -14041,6 +14401,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -14131,6 +14492,7 @@
         {
             "id": "0x58ce2e98a050925d99b209799d10f413c729f6fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bead9a1bcc1b84d06e3f2df67e3549fd55ab054",
@@ -14158,6 +14520,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14185,6 +14548,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14212,6 +14576,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14239,6 +14604,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14392,6 +14758,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14419,6 +14786,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14446,6 +14814,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14473,6 +14842,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14514,6 +14884,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14541,6 +14912,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14568,6 +14940,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14595,6 +14968,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14650,6 +15024,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14677,6 +15052,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14704,6 +15080,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14801,6 +15178,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14828,6 +15206,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14855,6 +15234,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14910,6 +15290,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14937,6 +15318,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14999,6 +15381,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -15026,6 +15409,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -15053,6 +15437,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -15080,6 +15465,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15107,6 +15493,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15134,6 +15521,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15189,6 +15577,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15258,6 +15647,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15285,6 +15675,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15312,6 +15703,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15339,6 +15731,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15366,6 +15759,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15393,6 +15787,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15420,6 +15815,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15559,6 +15955,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15586,6 +15983,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15613,6 +16011,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15640,6 +16039,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15667,6 +16067,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15708,6 +16109,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15735,6 +16137,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15762,6 +16165,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15789,6 +16193,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15816,6 +16221,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15850,6 +16256,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15877,6 +16284,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15904,6 +16312,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16001,6 +16410,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16028,6 +16438,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -16055,6 +16466,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -16082,6 +16494,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -16109,6 +16522,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16136,6 +16550,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16163,6 +16578,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16190,6 +16606,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16217,6 +16634,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16244,6 +16662,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16271,6 +16690,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16312,6 +16732,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16339,6 +16760,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16366,6 +16788,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16428,6 +16851,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16455,6 +16879,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16482,6 +16907,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16509,6 +16935,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16536,6 +16963,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16591,6 +17019,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16618,6 +17047,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16645,6 +17075,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16672,6 +17103,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16699,6 +17131,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16789,6 +17222,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16816,6 +17250,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16843,6 +17278,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16870,6 +17306,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16897,6 +17334,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16924,6 +17362,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16951,6 +17390,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -17097,6 +17537,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17124,6 +17565,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17151,6 +17593,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17178,6 +17621,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17205,6 +17649,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17239,6 +17684,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17294,6 +17740,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17363,6 +17810,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17390,6 +17838,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17417,6 +17866,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17444,6 +17894,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17471,6 +17922,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17498,6 +17950,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17525,6 +17978,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17615,6 +18069,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17642,6 +18097,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17669,6 +18125,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17696,6 +18153,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17723,6 +18181,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17771,6 +18230,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17812,6 +18272,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17839,6 +18300,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17866,6 +18328,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17900,6 +18363,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17927,6 +18391,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17996,6 +18461,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -18023,6 +18489,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -18057,6 +18524,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -18084,6 +18552,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -18111,6 +18580,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18166,6 +18636,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18221,6 +18692,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18290,6 +18762,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18317,6 +18790,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18344,6 +18818,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18371,6 +18846,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18426,6 +18902,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18495,6 +18972,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18522,6 +19000,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18591,6 +19070,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18618,6 +19098,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18645,6 +19126,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18672,6 +19154,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18699,6 +19182,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18726,6 +19210,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18753,6 +19238,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18787,6 +19273,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18821,6 +19308,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18848,6 +19336,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18875,6 +19364,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18930,6 +19420,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18957,6 +19448,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18984,6 +19476,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -19011,6 +19504,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -19045,6 +19539,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -19072,6 +19567,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -19099,6 +19595,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19126,6 +19623,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19153,6 +19651,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19187,6 +19686,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19214,6 +19714,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19269,6 +19770,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19296,6 +19798,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19379,6 +19882,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19413,6 +19917,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19468,6 +19973,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19495,6 +20001,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19522,6 +20029,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19549,6 +20057,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19583,6 +20092,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19610,6 +20120,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19637,6 +20148,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19664,6 +20176,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19719,6 +20232,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19746,6 +20260,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19773,6 +20288,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19821,6 +20337,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19848,6 +20365,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19875,6 +20393,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19902,6 +20421,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19929,6 +20449,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19956,6 +20477,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19983,6 +20505,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -20010,6 +20533,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -20037,6 +20561,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -20106,6 +20631,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20133,6 +20659,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20160,6 +20687,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20187,6 +20715,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20221,6 +20750,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20248,6 +20778,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20275,6 +20806,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20302,6 +20834,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20371,6 +20904,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20398,6 +20932,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20439,6 +20974,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20466,6 +21002,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20535,6 +21072,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20597,6 +21135,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20624,6 +21163,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20693,6 +21233,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20720,6 +21261,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20747,6 +21289,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20774,6 +21317,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20801,6 +21345,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20828,6 +21373,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20855,6 +21401,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20882,6 +21429,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20916,6 +21464,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21006,6 +21555,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21033,6 +21583,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -21060,6 +21611,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -21094,6 +21646,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21128,6 +21681,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21169,6 +21723,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21224,6 +21779,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21251,6 +21807,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21278,6 +21835,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21347,6 +21905,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21374,6 +21933,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21415,6 +21975,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21470,6 +22031,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21497,6 +22059,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21524,6 +22087,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21558,6 +22122,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21585,6 +22150,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21612,6 +22178,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21639,6 +22206,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21666,6 +22234,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21693,6 +22262,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21734,6 +22304,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21761,6 +22332,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21788,6 +22360,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21815,6 +22388,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21891,6 +22465,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21918,6 +22493,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21945,6 +22521,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21972,6 +22549,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21999,6 +22577,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22026,6 +22605,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22074,6 +22654,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22108,6 +22689,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22135,6 +22717,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22162,6 +22745,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22189,6 +22773,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22216,6 +22801,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22243,6 +22829,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22270,6 +22857,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22311,6 +22899,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22338,6 +22927,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22365,6 +22955,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22504,6 +23095,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22545,6 +23137,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22572,6 +23165,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22606,6 +23200,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22661,6 +23256,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22688,6 +23284,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22715,6 +23312,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22763,6 +23361,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22804,6 +23403,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22831,6 +23431,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22858,6 +23459,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22927,6 +23529,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22961,6 +23564,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22988,6 +23592,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23022,6 +23627,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23056,6 +23662,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -23083,6 +23690,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -23110,6 +23718,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23137,6 +23746,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23164,6 +23774,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23191,6 +23802,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23218,6 +23830,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23273,6 +23886,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23300,6 +23914,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23355,6 +23970,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23417,6 +24033,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23444,6 +24061,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23471,6 +24089,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23512,6 +24131,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23567,6 +24187,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23594,6 +24215,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23621,6 +24243,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23648,6 +24271,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23682,6 +24306,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23709,6 +24334,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23743,6 +24369,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23770,6 +24397,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23818,6 +24446,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23845,6 +24474,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23872,6 +24502,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23899,6 +24530,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23926,6 +24558,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23981,6 +24614,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -24008,6 +24642,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -24035,6 +24670,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -24090,6 +24726,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -24117,6 +24754,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24165,6 +24803,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24213,6 +24852,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24240,6 +24880,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24267,6 +24908,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24294,6 +24936,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24321,6 +24964,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24348,6 +24992,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24375,6 +25020,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24402,6 +25048,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24429,6 +25076,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24456,6 +25104,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24483,6 +25132,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24510,6 +25160,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24537,6 +25188,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24571,6 +25223,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24633,6 +25286,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24660,6 +25314,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24687,6 +25342,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24826,6 +25482,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24895,6 +25552,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24922,6 +25580,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24949,6 +25608,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -25018,6 +25678,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25045,6 +25706,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25072,6 +25734,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -25099,6 +25762,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -25133,6 +25797,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25174,6 +25839,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25201,6 +25867,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25228,6 +25895,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25255,6 +25923,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25282,6 +25951,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25309,6 +25979,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25336,6 +26007,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25363,6 +26035,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25432,6 +26105,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25459,6 +26133,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25486,6 +26161,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25520,6 +26196,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25547,6 +26224,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25595,6 +26273,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25629,6 +26308,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25656,6 +26336,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25683,6 +26364,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25710,6 +26392,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25737,6 +26420,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25764,6 +26448,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25791,6 +26476,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25818,6 +26504,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25880,6 +26567,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25907,6 +26595,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25941,6 +26630,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25968,6 +26658,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25995,6 +26686,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26043,6 +26735,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26070,6 +26763,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -26097,6 +26791,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26124,6 +26819,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26158,6 +26854,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26255,6 +26952,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26282,6 +26980,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26344,6 +27043,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26371,6 +27071,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26398,6 +27099,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26425,6 +27127,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26452,6 +27155,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26479,6 +27183,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26506,6 +27211,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26540,6 +27246,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26567,6 +27274,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26636,6 +27344,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26663,6 +27372,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26760,6 +27470,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26787,6 +27498,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26814,6 +27526,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26841,6 +27554,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26868,6 +27582,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26895,6 +27610,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26950,6 +27666,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26977,6 +27694,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27165,6 +27883,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27192,6 +27911,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27219,6 +27939,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27246,6 +27967,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27280,6 +28002,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27307,6 +28030,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27383,6 +28107,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27410,6 +28135,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27451,6 +28177,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27478,6 +28205,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27519,6 +28247,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27609,6 +28338,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27636,6 +28366,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27663,6 +28394,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27690,6 +28422,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27717,6 +28450,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27744,6 +28478,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27771,6 +28506,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27798,6 +28534,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27825,6 +28562,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27852,6 +28590,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27879,6 +28618,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27906,6 +28646,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27933,6 +28674,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27960,6 +28702,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -28064,6 +28807,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -28119,6 +28863,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -28146,6 +28891,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -28173,6 +28919,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28200,6 +28947,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28227,6 +28975,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28254,6 +29003,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28309,6 +29059,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28336,6 +29087,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28363,6 +29115,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28397,6 +29150,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28452,6 +29206,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28479,6 +29234,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28506,6 +29262,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28575,6 +29332,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28602,6 +29360,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28629,6 +29388,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28656,6 +29416,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28683,6 +29444,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28710,6 +29472,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28737,6 +29500,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28764,6 +29528,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28819,6 +29584,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28846,6 +29612,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28873,6 +29640,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28907,6 +29675,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28934,6 +29703,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28968,6 +29738,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28995,6 +29766,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -29022,6 +29794,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -29049,6 +29822,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -29132,6 +29906,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29159,6 +29934,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29228,6 +30004,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29325,6 +30102,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29352,6 +30130,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29379,6 +30158,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29406,6 +30186,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29475,6 +30256,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29502,6 +30284,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29557,6 +30340,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29584,6 +30368,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29611,6 +30396,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29638,6 +30424,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29679,6 +30466,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29706,6 +30494,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29740,6 +30529,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29767,6 +30557,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29794,6 +30585,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29821,6 +30613,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29848,6 +30641,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29882,6 +30676,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29909,6 +30704,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29936,6 +30732,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29963,6 +30760,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29990,6 +30788,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30017,6 +30816,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -30114,6 +30914,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -30141,6 +30942,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -30168,6 +30970,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30195,6 +30998,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30222,6 +31026,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30249,6 +31054,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30276,6 +31082,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30303,6 +31110,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30344,6 +31152,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30371,6 +31180,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30398,6 +31208,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30453,6 +31264,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30480,6 +31292,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30507,6 +31320,7 @@
         {
             "id": "0xc34473ccac5e14a4b7bf558d41477a05976e670c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bead9a1bcc1b84d06e3f2df67e3549fd55ab054",
@@ -30534,6 +31348,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30561,6 +31376,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30588,6 +31404,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30615,6 +31432,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30642,6 +31460,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30697,6 +31516,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30724,6 +31544,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30758,6 +31579,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30820,6 +31642,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30847,6 +31670,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30874,6 +31698,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30901,6 +31726,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30928,6 +31754,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30955,6 +31782,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30982,6 +31810,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -31009,6 +31838,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -31036,6 +31866,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31091,6 +31922,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -31118,6 +31950,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -31145,6 +31978,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31172,6 +32006,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -31199,6 +32034,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31226,6 +32062,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31260,6 +32097,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31287,6 +32125,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31342,6 +32181,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31369,6 +32209,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31396,6 +32237,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31423,6 +32265,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31450,6 +32293,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31477,6 +32321,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31504,6 +32349,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31531,6 +32377,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31656,6 +32503,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31683,6 +32531,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31710,6 +32559,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31737,6 +32587,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31792,6 +32643,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31819,6 +32671,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31874,6 +32727,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31901,6 +32755,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31928,6 +32783,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31983,6 +32839,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -32017,6 +32874,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32107,6 +32965,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32134,6 +32993,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -32217,6 +33077,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32258,6 +33119,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32285,6 +33147,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32340,6 +33203,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32367,6 +33231,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32394,6 +33259,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32428,6 +33294,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32455,6 +33322,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32482,6 +33350,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32509,6 +33378,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32536,6 +33406,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32563,6 +33434,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32590,6 +33462,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32617,6 +33490,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32644,6 +33518,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32699,6 +33574,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32726,6 +33602,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32753,6 +33630,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32780,6 +33658,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32807,6 +33686,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32834,6 +33714,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32861,6 +33742,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32916,6 +33798,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32964,6 +33847,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33005,6 +33889,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33032,6 +33917,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -33059,6 +33945,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -33086,6 +33973,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33176,6 +34064,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33203,6 +34092,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33230,6 +34120,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33264,6 +34155,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33291,6 +34183,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33318,6 +34211,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33359,6 +34253,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33414,6 +34309,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33441,6 +34337,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33538,6 +34435,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33614,6 +34512,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33690,6 +34589,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33780,6 +34680,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33821,6 +34722,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33862,6 +34764,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33987,6 +34890,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -34014,6 +34918,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -34048,6 +34953,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34075,6 +34981,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -34158,6 +35065,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -34185,6 +35093,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -34212,6 +35121,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34239,6 +35149,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34266,6 +35177,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -34293,6 +35205,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34334,6 +35247,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34361,6 +35275,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34430,6 +35345,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34457,6 +35373,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34484,6 +35401,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34511,6 +35429,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34538,6 +35457,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34565,6 +35485,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34599,6 +35520,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34633,6 +35555,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34730,6 +35653,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34757,6 +35681,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34784,6 +35709,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34811,6 +35737,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34838,6 +35765,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34865,6 +35793,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34920,6 +35849,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34947,6 +35877,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -35037,6 +35968,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -35092,6 +36024,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -35119,6 +36052,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -35146,6 +36080,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35173,6 +36108,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -35221,6 +36157,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35248,6 +36185,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35275,6 +36213,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35407,6 +36346,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35434,6 +36374,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35461,6 +36402,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35488,6 +36430,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35515,6 +36458,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35542,6 +36486,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35569,6 +36514,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35596,6 +36542,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35623,6 +36570,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35650,6 +36598,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35712,6 +36661,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35760,6 +36710,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35787,6 +36738,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35814,6 +36766,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35841,6 +36794,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35868,6 +36822,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35902,6 +36857,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35929,6 +36885,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35956,6 +36913,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35983,6 +36941,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -36010,6 +36969,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -36058,6 +37018,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -36113,6 +37074,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -36140,6 +37102,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -36167,6 +37130,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36201,6 +37165,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -36228,6 +37193,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36297,6 +37263,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36345,6 +37312,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36400,6 +37368,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36441,6 +37410,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36468,6 +37438,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36537,6 +37508,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36564,6 +37536,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36591,6 +37564,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36618,6 +37592,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36722,6 +37697,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36749,6 +37725,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36776,6 +37753,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36873,6 +37851,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36900,6 +37879,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36927,6 +37907,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36954,6 +37935,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36981,6 +37963,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37008,6 +37991,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37035,6 +38019,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37062,6 +38047,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -37089,6 +38075,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -37116,6 +38103,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -37143,6 +38131,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -37177,6 +38166,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -37204,6 +38194,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -37231,6 +38222,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37286,6 +38278,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37313,6 +38306,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37340,6 +38334,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37395,6 +38390,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37422,6 +38418,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37477,6 +38474,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37504,6 +38502,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37531,6 +38530,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37579,6 +38579,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37606,6 +38607,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37633,6 +38635,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37660,6 +38663,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37701,6 +38705,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37728,6 +38733,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37762,6 +38768,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37789,6 +38796,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37823,6 +38831,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37878,6 +38887,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37905,6 +38915,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37932,6 +38943,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37980,6 +38992,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38014,6 +39027,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -38076,6 +39090,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -38103,6 +39118,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -38130,6 +39146,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38178,6 +39195,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -38205,6 +39223,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38232,6 +39251,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -38280,6 +39300,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38307,6 +39328,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38418,6 +39440,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38473,6 +39496,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38500,6 +39524,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38548,6 +39573,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38575,6 +39601,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38644,6 +39671,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38671,6 +39699,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38726,6 +39755,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38753,6 +39783,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38780,6 +39811,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38807,6 +39839,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38834,6 +39867,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38861,6 +39895,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38923,6 +39958,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38950,6 +39986,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38998,6 +40035,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -39025,6 +40063,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -39052,6 +40091,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39079,6 +40119,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -39134,6 +40175,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39161,6 +40203,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -39188,6 +40231,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -39215,6 +40259,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -39284,6 +40329,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39311,6 +40357,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39338,6 +40385,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39414,6 +40462,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39441,6 +40490,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39475,6 +40525,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39509,6 +40560,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39543,6 +40595,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39570,6 +40623,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39597,6 +40651,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39624,6 +40679,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39658,6 +40714,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39685,6 +40742,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39712,6 +40770,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39739,6 +40798,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39773,6 +40833,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39807,6 +40868,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39834,6 +40896,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39861,6 +40924,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39972,6 +41036,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39999,6 +41064,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -40026,6 +41092,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -40053,6 +41120,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -40108,6 +41176,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -40135,6 +41204,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40169,6 +41239,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40196,6 +41267,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -40293,6 +41365,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40320,6 +41393,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40347,6 +41421,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40374,6 +41449,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40443,6 +41519,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x99dd2c21aa009e98e000a3bd515a8ddcbb52748642fde10f9137f9de3cfae957.json
+++ b/test/testData/testPools/0x99dd2c21aa009e98e000a3bd515a8ddcbb52748642fde10f9137f9de3cfae957.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0x99dd2c21aa009e98e000a3bd515a8ddcbb52748642fde10f9137f9de3cfae957.json
+++ b/test/testData/testPools/0x99dd2c21aa009e98e000a3bd515a8ddcbb52748642fde10f9137f9de3cfae957.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -171,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -198,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -232,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -259,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -286,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -313,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -340,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -367,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -422,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -470,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -511,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -538,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -621,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -648,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -696,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -723,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -750,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -854,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -881,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -908,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -935,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -962,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1003,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1030,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1071,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1098,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1237,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1264,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1291,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1318,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1345,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1400,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1427,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1475,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1502,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1550,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1577,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1604,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1631,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1672,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1699,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1726,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1753,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1780,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1835,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1876,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1987,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2063,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2181,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2229,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2256,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2283,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2338,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2365,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2455,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2510,6 +2568,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2544,6 +2603,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2571,6 +2631,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2598,6 +2659,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2674,6 +2736,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2701,6 +2764,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2735,6 +2799,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2762,6 +2827,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2789,6 +2855,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2816,6 +2883,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2843,6 +2911,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2877,6 +2946,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2904,6 +2974,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2931,6 +3002,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2958,6 +3030,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3062,6 +3135,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3096,6 +3170,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3123,6 +3198,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3150,6 +3226,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3177,6 +3254,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3218,6 +3296,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3245,6 +3324,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3272,6 +3352,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3299,6 +3380,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3326,6 +3408,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3395,6 +3478,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3443,6 +3527,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3470,6 +3555,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3497,6 +3583,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3524,6 +3611,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3551,6 +3639,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3620,6 +3709,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3647,6 +3737,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3674,6 +3765,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3701,6 +3793,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3728,6 +3821,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3755,6 +3849,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3782,6 +3877,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3809,6 +3905,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3843,6 +3940,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3870,6 +3968,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3897,6 +3996,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3924,6 +4024,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3958,6 +4059,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3985,6 +4087,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4012,6 +4115,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4067,6 +4171,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4108,6 +4213,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4135,6 +4241,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4183,6 +4290,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4259,6 +4367,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4286,6 +4395,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4341,6 +4451,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4368,6 +4479,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4451,6 +4563,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4492,6 +4605,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4519,6 +4633,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4546,6 +4661,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4573,6 +4689,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4600,6 +4717,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4627,6 +4745,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4654,6 +4773,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4681,6 +4801,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4708,6 +4829,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4763,6 +4885,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4832,6 +4955,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4859,6 +4983,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4886,6 +5011,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4913,6 +5039,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5052,6 +5179,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5107,6 +5235,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5141,6 +5270,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5168,6 +5298,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5195,6 +5326,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5222,6 +5354,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5277,6 +5410,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5304,6 +5438,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5359,6 +5494,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5386,6 +5522,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5441,6 +5578,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5503,6 +5641,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5530,6 +5669,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5557,6 +5697,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5584,6 +5725,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5611,6 +5753,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5666,6 +5809,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5700,6 +5844,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5727,6 +5872,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5754,6 +5900,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5809,6 +5956,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5836,6 +5984,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5863,6 +6012,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5918,6 +6068,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5945,6 +6096,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5972,6 +6124,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5999,6 +6152,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6026,6 +6180,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6053,6 +6208,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6101,6 +6257,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6128,6 +6285,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6169,6 +6327,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6217,6 +6376,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6244,6 +6404,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6271,6 +6432,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6326,6 +6488,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6402,6 +6565,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6471,6 +6635,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6498,6 +6663,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6532,6 +6698,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6559,6 +6726,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6586,6 +6754,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6613,6 +6782,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6640,6 +6810,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6667,6 +6838,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6694,6 +6866,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6721,6 +6894,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6783,6 +6957,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6852,6 +7027,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6879,6 +7055,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6934,6 +7111,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6961,6 +7139,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7023,6 +7202,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7050,6 +7230,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7077,6 +7258,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7104,6 +7286,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7138,6 +7321,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7193,6 +7377,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7220,6 +7405,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7275,6 +7461,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7302,6 +7489,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7357,6 +7545,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7384,6 +7573,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7411,6 +7601,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7438,6 +7629,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7493,6 +7685,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7520,6 +7713,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7659,6 +7853,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7686,6 +7881,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7713,6 +7909,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7740,6 +7937,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7767,6 +7965,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7829,6 +8028,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7863,6 +8063,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7890,6 +8091,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7917,6 +8119,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7965,6 +8168,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7992,6 +8196,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8019,6 +8224,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8046,6 +8252,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8073,6 +8280,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8100,6 +8308,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8127,6 +8336,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8203,6 +8413,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8230,6 +8441,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8264,6 +8476,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8291,6 +8504,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8318,6 +8532,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8359,6 +8574,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8386,6 +8602,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8420,6 +8637,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8517,6 +8735,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8544,6 +8763,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8571,6 +8791,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8668,6 +8889,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8695,6 +8917,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8722,6 +8945,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8756,6 +8980,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8783,6 +9008,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8831,6 +9057,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8879,6 +9106,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8934,6 +9162,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8961,6 +9190,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8988,6 +9218,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9015,6 +9246,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9042,6 +9274,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9111,6 +9344,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9138,6 +9372,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9165,6 +9400,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9220,6 +9456,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9261,6 +9498,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9358,6 +9596,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9406,6 +9645,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9433,6 +9673,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9502,6 +9743,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9550,6 +9792,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9577,6 +9820,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9604,6 +9848,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9631,6 +9876,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9658,6 +9904,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9685,6 +9932,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9712,6 +9960,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9739,6 +9988,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9766,6 +10016,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9793,6 +10044,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9820,6 +10072,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9847,6 +10100,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9874,6 +10128,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9901,6 +10156,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9928,6 +10184,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9955,6 +10212,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9982,6 +10240,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10009,6 +10268,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10050,6 +10310,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10077,6 +10338,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10104,6 +10366,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10159,6 +10422,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10186,6 +10450,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10213,6 +10478,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10247,6 +10513,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10274,6 +10541,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10301,6 +10569,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10328,6 +10597,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10355,6 +10625,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10410,6 +10681,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10437,6 +10709,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10485,6 +10758,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10540,6 +10814,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10567,6 +10842,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10594,6 +10870,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10649,6 +10926,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10676,6 +10954,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10766,6 +11045,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10793,6 +11073,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10820,6 +11101,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10847,6 +11129,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10916,6 +11199,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10950,6 +11234,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11033,6 +11318,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11060,6 +11346,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11108,6 +11395,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11135,6 +11423,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11183,6 +11472,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11210,6 +11500,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11237,6 +11528,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11299,6 +11591,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11340,6 +11633,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11367,6 +11661,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11394,6 +11689,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11421,6 +11717,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11448,6 +11745,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11517,6 +11815,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11544,6 +11843,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11571,6 +11871,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11633,6 +11934,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11667,6 +11969,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11694,6 +11997,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11721,6 +12025,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11748,6 +12053,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11775,6 +12081,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11802,6 +12109,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11829,6 +12137,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11856,6 +12165,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11883,6 +12193,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11910,6 +12221,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11965,6 +12277,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -11992,6 +12305,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12019,6 +12333,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12046,6 +12361,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12108,6 +12424,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12142,6 +12459,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12169,6 +12487,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12196,6 +12515,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12251,6 +12571,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12306,6 +12627,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12333,6 +12655,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12360,6 +12683,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12387,6 +12711,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12414,6 +12739,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12441,6 +12767,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12496,6 +12823,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12565,6 +12893,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12592,6 +12921,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12619,6 +12949,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12653,6 +12984,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12785,6 +13117,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12882,6 +13215,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12916,6 +13250,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12985,6 +13320,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13012,6 +13348,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13039,6 +13376,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13066,6 +13404,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13093,6 +13432,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13120,6 +13460,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13175,6 +13516,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13202,6 +13544,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13250,6 +13593,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13347,6 +13691,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13416,6 +13761,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13562,6 +13908,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13617,6 +13964,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13644,6 +13992,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13671,6 +14020,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13726,6 +14076,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13753,6 +14104,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13780,6 +14132,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13807,6 +14160,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13834,6 +14188,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13861,6 +14216,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13888,6 +14244,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13915,6 +14272,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13942,6 +14300,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -14032,6 +14391,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14059,6 +14419,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14086,6 +14447,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14113,6 +14475,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14266,6 +14629,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14293,6 +14657,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14320,6 +14685,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14347,6 +14713,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14388,6 +14755,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14415,6 +14783,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14442,6 +14811,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14469,6 +14839,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14524,6 +14895,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14551,6 +14923,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14578,6 +14951,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14675,6 +15049,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14702,6 +15077,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14729,6 +15105,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14784,6 +15161,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14811,6 +15189,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14873,6 +15252,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14900,6 +15280,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14927,6 +15308,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14954,6 +15336,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14981,6 +15364,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15008,6 +15392,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15063,6 +15448,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15132,6 +15518,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15159,6 +15546,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15186,6 +15574,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15213,6 +15602,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15240,6 +15630,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15267,6 +15658,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15294,6 +15686,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15433,6 +15826,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15460,6 +15854,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15487,6 +15882,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15514,6 +15910,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15541,6 +15938,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15582,6 +15980,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15609,6 +16008,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15636,6 +16036,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15663,6 +16064,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15690,6 +16092,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15724,6 +16127,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15751,6 +16155,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15778,6 +16183,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15875,6 +16281,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15902,6 +16309,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15929,6 +16337,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15956,6 +16365,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15983,6 +16393,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16010,6 +16421,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16037,6 +16449,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16064,6 +16477,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16091,6 +16505,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16118,6 +16533,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16145,6 +16561,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16186,6 +16603,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16213,6 +16631,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16240,6 +16659,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16302,6 +16722,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16329,6 +16750,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16356,6 +16778,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16383,6 +16806,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16410,6 +16834,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16465,6 +16890,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16492,6 +16918,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16519,6 +16946,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16546,6 +16974,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16573,6 +17002,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16663,6 +17093,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16690,6 +17121,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16717,6 +17149,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16744,6 +17177,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16771,6 +17205,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16798,6 +17233,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16825,6 +17261,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16971,6 +17408,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16998,6 +17436,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17025,6 +17464,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17052,6 +17492,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17079,6 +17520,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17113,6 +17555,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17168,6 +17611,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17237,6 +17681,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17264,6 +17709,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17291,6 +17737,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17318,6 +17765,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17345,6 +17793,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17372,6 +17821,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17399,6 +17849,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17489,6 +17940,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17516,6 +17968,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17543,6 +17996,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17570,6 +18024,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17597,6 +18052,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17645,6 +18101,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17686,6 +18143,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17713,6 +18171,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17740,6 +18199,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17774,6 +18234,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17801,6 +18262,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17870,6 +18332,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17897,6 +18360,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17931,6 +18395,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17958,6 +18423,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17985,6 +18451,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18040,6 +18507,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18095,6 +18563,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18164,6 +18633,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18191,6 +18661,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18218,6 +18689,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18245,6 +18717,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18300,6 +18773,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18369,6 +18843,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18396,6 +18871,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18465,6 +18941,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18492,6 +18969,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18519,6 +18997,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18546,6 +19025,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18573,6 +19053,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18600,6 +19081,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18627,6 +19109,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18661,6 +19144,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18695,6 +19179,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18722,6 +19207,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18749,6 +19235,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18804,6 +19291,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18831,6 +19319,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18858,6 +19347,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18885,6 +19375,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18919,6 +19410,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18946,6 +19438,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18973,6 +19466,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19000,6 +19494,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19027,6 +19522,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19061,6 +19557,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19088,6 +19585,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19143,6 +19641,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19170,6 +19669,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19253,6 +19753,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19287,6 +19788,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19342,6 +19844,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19369,6 +19872,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19396,6 +19900,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19423,6 +19928,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19457,6 +19963,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19491,6 +19998,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19518,6 +20026,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19545,6 +20054,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19572,6 +20082,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19627,6 +20138,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19654,6 +20166,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19681,6 +20194,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19729,6 +20243,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19756,6 +20271,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19783,6 +20299,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19810,6 +20327,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19837,6 +20355,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19864,6 +20383,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19891,6 +20411,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19918,6 +20439,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19945,6 +20467,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -20014,6 +20537,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20041,6 +20565,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20068,6 +20593,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20095,6 +20621,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20129,6 +20656,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20156,6 +20684,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20183,6 +20712,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20210,6 +20740,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20279,6 +20810,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20306,6 +20838,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20347,6 +20880,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20374,6 +20908,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20443,6 +20978,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20505,6 +21041,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20532,6 +21069,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20601,6 +21139,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20628,6 +21167,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20655,6 +21195,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20682,6 +21223,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20709,6 +21251,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20736,6 +21279,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20763,6 +21307,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20790,6 +21335,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20824,6 +21370,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20914,6 +21461,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20941,6 +21489,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20968,6 +21517,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -21002,6 +21552,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21036,6 +21587,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21077,6 +21629,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21132,6 +21685,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21159,6 +21713,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21186,6 +21741,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21255,6 +21811,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21282,6 +21839,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21323,6 +21881,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21378,6 +21937,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21405,6 +21965,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21432,6 +21993,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21466,6 +22028,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21493,6 +22056,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21520,6 +22084,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21547,6 +22112,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21574,6 +22140,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21601,6 +22168,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21642,6 +22210,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21669,6 +22238,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21696,6 +22266,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21723,6 +22294,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21799,6 +22371,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21826,6 +22399,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21853,6 +22427,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21880,6 +22455,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21907,6 +22483,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21934,6 +22511,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21982,6 +22560,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22016,6 +22595,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22043,6 +22623,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22070,6 +22651,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22097,6 +22679,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22124,6 +22707,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22151,6 +22735,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22178,6 +22763,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22219,6 +22805,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22246,6 +22833,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22273,6 +22861,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22412,6 +23001,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22453,6 +23043,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22480,6 +23071,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22514,6 +23106,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22569,6 +23162,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22596,6 +23190,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22623,6 +23218,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22671,6 +23267,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22712,6 +23309,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22739,6 +23337,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22766,6 +23365,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22835,6 +23435,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22869,6 +23470,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22896,6 +23498,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22930,6 +23533,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22964,6 +23568,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22991,6 +23596,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -23018,6 +23624,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23045,6 +23652,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23072,6 +23680,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23099,6 +23708,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23126,6 +23736,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23181,6 +23792,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23208,6 +23820,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23263,6 +23876,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23325,6 +23939,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23352,6 +23967,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23379,6 +23995,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23420,6 +24037,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23475,6 +24093,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23502,6 +24121,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23529,6 +24149,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23556,6 +24177,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23590,6 +24212,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23617,6 +24240,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23651,6 +24275,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23678,6 +24303,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23726,6 +24352,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23753,6 +24380,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23780,6 +24408,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23807,6 +24436,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23834,6 +24464,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23889,6 +24520,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23916,6 +24548,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23943,6 +24576,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23998,6 +24632,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -24025,6 +24660,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24073,6 +24709,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24121,6 +24758,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24148,6 +24786,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24175,6 +24814,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24202,6 +24842,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24229,6 +24870,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24256,6 +24898,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24283,6 +24926,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24310,6 +24954,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24337,6 +24982,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24364,6 +25010,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24391,6 +25038,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24418,6 +25066,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24445,6 +25094,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24479,6 +25129,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24541,6 +25192,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24568,6 +25220,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24595,6 +25248,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24734,6 +25388,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24803,6 +25458,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24830,6 +25486,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24857,6 +25514,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24926,6 +25584,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24953,6 +25612,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24980,6 +25640,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -25007,6 +25668,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -25041,6 +25703,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25082,6 +25745,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25109,6 +25773,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25136,6 +25801,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25163,6 +25829,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25190,6 +25857,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25217,6 +25885,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25244,6 +25913,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25271,6 +25941,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25340,6 +26011,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25367,6 +26039,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25394,6 +26067,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25428,6 +26102,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25455,6 +26130,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25503,6 +26179,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25537,6 +26214,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25564,6 +26242,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25591,6 +26270,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25618,6 +26298,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25645,6 +26326,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25672,6 +26354,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25699,6 +26382,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25726,6 +26410,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25788,6 +26473,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25815,6 +26501,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25849,6 +26536,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25876,6 +26564,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25903,6 +26592,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25951,6 +26641,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25978,6 +26669,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -26005,6 +26697,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26032,6 +26725,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26066,6 +26760,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26163,6 +26858,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26190,6 +26886,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26252,6 +26949,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26279,6 +26977,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26306,6 +27005,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26333,6 +27033,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26360,6 +27061,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26387,6 +27089,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26414,6 +27117,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26448,6 +27152,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26475,6 +27180,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26544,6 +27250,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26571,6 +27278,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26668,6 +27376,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26695,6 +27404,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26722,6 +27432,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26749,6 +27460,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26776,6 +27488,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26803,6 +27516,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26858,6 +27572,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26885,6 +27600,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27073,6 +27789,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27100,6 +27817,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27127,6 +27845,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27154,6 +27873,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27188,6 +27908,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27215,6 +27936,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27291,6 +28013,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27318,6 +28041,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27359,6 +28083,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27386,6 +28111,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27427,6 +28153,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27517,6 +28244,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27544,6 +28272,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27571,6 +28300,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27598,6 +28328,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27625,6 +28356,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27652,6 +28384,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27679,6 +28412,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27706,6 +28440,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27733,6 +28468,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27760,6 +28496,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27787,6 +28524,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27814,6 +28552,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27841,6 +28580,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27868,6 +28608,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27972,6 +28713,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -28027,6 +28769,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -28054,6 +28797,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -28081,6 +28825,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28108,6 +28853,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28135,6 +28881,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28162,6 +28909,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28217,6 +28965,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28244,6 +28993,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28271,6 +29021,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28305,6 +29056,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28360,6 +29112,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28387,6 +29140,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28414,6 +29168,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28483,6 +29238,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28510,6 +29266,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28537,6 +29294,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28564,6 +29322,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28591,6 +29350,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28618,6 +29378,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28645,6 +29406,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28672,6 +29434,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28727,6 +29490,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28754,6 +29518,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28781,6 +29546,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28815,6 +29581,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28842,6 +29609,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28876,6 +29644,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28903,6 +29672,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28930,6 +29700,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28957,6 +29728,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -29040,6 +29812,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29067,6 +29840,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29136,6 +29910,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29233,6 +30008,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29260,6 +30036,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29287,6 +30064,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29314,6 +30092,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29383,6 +30162,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29410,6 +30190,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29465,6 +30246,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29492,6 +30274,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29519,6 +30302,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29546,6 +30330,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29587,6 +30372,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29614,6 +30400,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29648,6 +30435,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29675,6 +30463,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29702,6 +30491,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29729,6 +30519,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29756,6 +30547,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29790,6 +30582,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29817,6 +30610,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29844,6 +30638,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29871,6 +30666,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29898,6 +30694,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29925,6 +30722,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29952,6 +30750,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -30049,6 +30848,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -30076,6 +30876,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -30103,6 +30904,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30130,6 +30932,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30157,6 +30960,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30184,6 +30988,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30211,6 +31016,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30238,6 +31044,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30279,6 +31086,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30306,6 +31114,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30333,6 +31142,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30388,6 +31198,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30415,6 +31226,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30442,6 +31254,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30469,6 +31282,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30496,6 +31310,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30523,6 +31338,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30550,6 +31366,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30605,6 +31422,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30632,6 +31450,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30666,6 +31485,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30728,6 +31548,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30755,6 +31576,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30782,6 +31604,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30809,6 +31632,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30836,6 +31660,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30863,6 +31688,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30890,6 +31716,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30917,6 +31744,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30944,6 +31772,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30999,6 +31828,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -31026,6 +31856,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -31053,6 +31884,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31080,6 +31912,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -31107,6 +31940,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31134,6 +31968,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31168,6 +32003,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31195,6 +32031,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31250,6 +32087,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31277,6 +32115,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31304,6 +32143,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31331,6 +32171,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31358,6 +32199,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31385,6 +32227,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31412,6 +32255,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31439,6 +32283,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31564,6 +32409,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31591,6 +32437,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31618,6 +32465,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31645,6 +32493,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31700,6 +32549,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31727,6 +32577,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31782,6 +32633,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31809,6 +32661,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31836,6 +32689,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31891,6 +32745,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31925,6 +32780,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32015,6 +32871,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32042,6 +32899,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -32125,6 +32983,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32166,6 +33025,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32193,6 +33053,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32248,6 +33109,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32275,6 +33137,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32302,6 +33165,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32336,6 +33200,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32363,6 +33228,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32390,6 +33256,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32417,6 +33284,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32444,6 +33312,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32471,6 +33340,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32498,6 +33368,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32525,6 +33396,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32552,6 +33424,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32607,6 +33480,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32634,6 +33508,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32661,6 +33536,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32688,6 +33564,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32715,6 +33592,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32742,6 +33620,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32769,6 +33648,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32824,6 +33704,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32872,6 +33753,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32913,6 +33795,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32940,6 +33823,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32967,6 +33851,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32994,6 +33879,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33084,6 +33970,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33111,6 +33998,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33138,6 +34026,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33172,6 +34061,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33199,6 +34089,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33226,6 +34117,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33267,6 +34159,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33322,6 +34215,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33349,6 +34243,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33446,6 +34341,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33522,6 +34418,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33598,6 +34495,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33688,6 +34586,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33729,6 +34628,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33770,6 +34670,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33825,6 +34726,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33852,6 +34754,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33886,6 +34789,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33913,6 +34817,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33996,6 +34901,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -34023,6 +34929,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -34050,6 +34957,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34077,6 +34985,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34104,6 +35013,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -34131,6 +35041,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34172,6 +35083,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34199,6 +35111,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34268,6 +35181,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34295,6 +35209,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34322,6 +35237,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34349,6 +35265,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34376,6 +35293,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34403,6 +35321,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34437,6 +35356,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34471,6 +35391,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34568,6 +35489,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34595,6 +35517,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34622,6 +35545,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34649,6 +35573,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34676,6 +35601,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34703,6 +35629,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34758,6 +35685,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34785,6 +35713,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34875,6 +35804,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34930,6 +35860,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34957,6 +35888,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34984,6 +35916,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35011,6 +35944,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -35059,6 +35993,7 @@
         {
             "id": "0xe02e8ddecbe302ba1a40107c726e3ee889b0ff10",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
@@ -35093,6 +36028,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35120,6 +36056,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35147,6 +36084,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35279,6 +36217,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35306,6 +36245,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35333,6 +36273,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35360,6 +36301,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35387,6 +36329,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35414,6 +36357,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35441,6 +36385,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35468,6 +36413,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35495,6 +36441,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35522,6 +36469,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35584,6 +36532,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35632,6 +36581,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35659,6 +36609,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35686,6 +36637,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35713,6 +36665,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35740,6 +36693,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35774,6 +36728,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35801,6 +36756,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35828,6 +36784,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35855,6 +36812,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35882,6 +36840,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35930,6 +36889,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35985,6 +36945,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -36012,6 +36973,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -36039,6 +37001,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36073,6 +37036,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -36100,6 +37064,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36169,6 +37134,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36217,6 +37183,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36272,6 +37239,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36313,6 +37281,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36340,6 +37309,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36409,6 +37379,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36436,6 +37407,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36463,6 +37435,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36490,6 +37463,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36594,6 +37568,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36621,6 +37596,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36648,6 +37624,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36745,6 +37722,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36772,6 +37750,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36799,6 +37778,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36826,6 +37806,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36853,6 +37834,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36880,6 +37862,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36907,6 +37890,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36934,6 +37918,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36961,6 +37946,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36988,6 +37974,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -37015,6 +38002,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -37049,6 +38037,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -37076,6 +38065,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -37103,6 +38093,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37158,6 +38149,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37185,6 +38177,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37212,6 +38205,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37267,6 +38261,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37294,6 +38289,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37349,6 +38345,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37376,6 +38373,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37403,6 +38401,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37451,6 +38450,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37478,6 +38478,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37505,6 +38506,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37532,6 +38534,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37573,6 +38576,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37600,6 +38604,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37634,6 +38639,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37661,6 +38667,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37695,6 +38702,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37750,6 +38758,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37777,6 +38786,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37804,6 +38814,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37852,6 +38863,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37886,6 +38898,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37948,6 +38961,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37975,6 +38989,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -38002,6 +39017,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38050,6 +39066,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -38077,6 +39094,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38104,6 +39122,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -38152,6 +39171,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38179,6 +39199,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38290,6 +39311,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38345,6 +39367,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38372,6 +39395,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38420,6 +39444,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38447,6 +39472,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38516,6 +39542,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38543,6 +39570,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38598,6 +39626,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38625,6 +39654,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38652,6 +39682,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38679,6 +39710,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38706,6 +39738,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38733,6 +39766,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38795,6 +39829,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38822,6 +39857,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38870,6 +39906,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38897,6 +39934,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38924,6 +39962,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38951,6 +39990,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -39006,6 +40046,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39033,6 +40074,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -39060,6 +40102,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -39087,6 +40130,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -39156,6 +40200,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39183,6 +40228,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39210,6 +40256,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39286,6 +40333,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39313,6 +40361,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39347,6 +40396,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39381,6 +40431,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39415,6 +40466,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39442,6 +40494,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39469,6 +40522,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39496,6 +40550,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39530,6 +40585,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39557,6 +40613,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39584,6 +40641,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39611,6 +40669,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39645,6 +40704,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39679,6 +40739,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39706,6 +40767,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39733,6 +40795,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39844,6 +40907,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39871,6 +40935,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39898,6 +40963,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39925,6 +40991,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39980,6 +41047,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -40007,6 +41075,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40041,6 +41110,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40068,6 +41138,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -40165,6 +41236,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40192,6 +41264,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40219,6 +41292,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40246,6 +41320,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40315,6 +41390,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0x9f0559dbf2512e4cb5754f74b917941fd0098d2ac9963cd7113b167e8b91ae54.json
+++ b/test/testData/testPools/0x9f0559dbf2512e4cb5754f74b917941fd0098d2ac9963cd7113b167e8b91ae54.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -827,6 +832,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1392,6 +1399,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1826,6 +1834,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1921,6 +1930,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1955,6 +1965,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2031,6 +2042,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2133,6 +2145,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2406,6 +2419,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2433,6 +2447,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2494,6 +2509,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2636,6 +2652,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3002,6 +3019,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3362,6 +3380,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4047,6 +4066,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4217,6 +4237,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4319,6 +4340,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4400,6 +4422,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4739,6 +4762,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4957,6 +4981,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5026,6 +5051,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5080,6 +5106,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5249,6 +5276,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5358,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5466,6 +5495,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5635,6 +5665,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5886,6 +5917,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6355,6 +6387,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6900,6 +6933,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6981,6 +7015,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7157,6 +7192,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7320,6 +7356,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7455,6 +7492,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7578,6 +7616,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7658,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7788,6 +7828,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8161,6 +8202,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8474,6 +8516,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8624,6 +8667,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +8933,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9174,6 +9219,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9269,6 +9315,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10362,6 +10409,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10491,6 +10539,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10599,6 +10648,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10680,6 +10730,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10953,6 +11004,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10980,6 +11032,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11641,6 +11694,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11979,6 +12033,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12264,6 +12319,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12508,6 +12564,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12719,6 +12776,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12746,6 +12804,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12794,6 +12853,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12862,6 +12922,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13182,6 +13243,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13353,6 +13415,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13421,6 +13484,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13482,6 +13546,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13523,6 +13588,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13619,6 +13685,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13998,6 +14065,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14195,6 +14263,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14222,6 +14291,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14291,6 +14361,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14548,6 +14619,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14698,6 +14770,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14806,6 +14879,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14887,6 +14961,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15083,6 +15158,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15382,6 +15458,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15451,6 +15528,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15850,6 +15928,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16481,6 +16560,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16671,6 +16751,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16908,6 +16989,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16977,6 +17059,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17180,6 +17263,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17465,6 +17549,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17866,6 +17951,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18049,6 +18135,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18103,6 +18190,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18307,6 +18395,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19149,6 +19238,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19230,6 +19320,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19257,6 +19348,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19345,6 +19437,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19595,6 +19688,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20232,6 +20326,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20845,6 +20940,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21343,6 +21439,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21742,6 +21839,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22291,6 +22389,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22318,6 +22417,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22359,6 +22459,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22529,6 +22630,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23140,6 +23242,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23276,6 +23379,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23432,6 +23536,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23845,6 +23950,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23953,6 +24059,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24604,6 +24711,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24645,6 +24753,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25278,6 +25387,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25739,6 +25849,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26085,6 +26196,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26112,6 +26224,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26616,6 +26729,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26805,6 +26919,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26886,6 +27001,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26948,6 +27064,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27017,6 +27134,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27213,6 +27331,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27424,6 +27543,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27451,6 +27571,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27863,6 +27984,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27890,6 +28012,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27965,6 +28088,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28154,6 +28278,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28296,6 +28421,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28662,6 +28788,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28946,6 +29073,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29166,6 +29294,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29315,6 +29444,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29911,6 +30041,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30291,6 +30422,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30534,6 +30666,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31178,6 +31311,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31435,6 +31569,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31490,6 +31625,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31625,6 +31761,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31932,6 +32069,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32027,6 +32165,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32170,6 +32309,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32528,6 +32668,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32744,6 +32885,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33003,6 +33145,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33240,6 +33383,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33321,6 +33465,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33417,6 +33562,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33492,6 +33638,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33567,6 +33714,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33594,6 +33742,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33737,6 +33886,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33764,6 +33914,7 @@
         {
             "id": "0xd8e72a62e214864cbd9381cc04fa1006a8c8fb10",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23b608675a2b2fb1890d3abbd85c5775c51691d5",
@@ -33948,6 +34099,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33975,6 +34127,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34504,6 +34657,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34824,6 +34978,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34851,6 +35006,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34905,6 +35061,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35142,6 +35299,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35169,6 +35327,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35217,6 +35376,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35922,6 +36082,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36481,6 +36642,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36508,6 +36670,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36637,6 +36800,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37091,6 +37255,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37682,6 +37847,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37872,6 +38038,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38164,6 +38331,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38205,6 +38373,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38273,6 +38442,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38443,6 +38613,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38524,6 +38695,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38720,6 +38892,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38930,6 +39103,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39188,6 +39362,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39724,6 +39899,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39901,6 +40077,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40043,6 +40220,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xa04bc9066116b13e832a9e57667ed6485e087e84fa1fc500987e7ecdc5b98fe0.json
+++ b/test/testData/testPools/0xa04bc9066116b13e832a9e57667ed6485e087e84fa1fc500987e7ecdc5b98fe0.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xa7a3cf76686c6d6aa6e976724b4463c6f7b0e98453ad3a8488b6e9daa2fecc42.json
+++ b/test/testData/testPools/0xa7a3cf76686c6d6aa6e976724b4463c6f7b0e98453ad3a8488b6e9daa2fecc42.json
@@ -100,6 +100,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -129,6 +130,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -451,6 +453,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -636,6 +639,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -665,6 +669,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -895,6 +900,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1289,6 +1295,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1511,6 +1518,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1981,6 +1989,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2084,6 +2093,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2121,6 +2131,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2204,6 +2215,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2317,6 +2329,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2616,6 +2629,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2645,6 +2659,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2711,6 +2726,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2864,6 +2880,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3260,6 +3277,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3651,6 +3669,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4393,6 +4412,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4578,6 +4598,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4689,6 +4710,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4776,6 +4798,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5143,6 +5166,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5381,6 +5405,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5458,6 +5483,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5516,6 +5542,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5698,6 +5725,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5785,6 +5813,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5933,6 +5962,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6115,6 +6145,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6387,6 +6418,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6897,6 +6929,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7492,6 +7525,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7579,6 +7613,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7769,6 +7804,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7946,6 +7982,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8091,6 +8128,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8226,6 +8264,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8271,6 +8310,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8453,6 +8493,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8857,6 +8898,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9198,6 +9240,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9362,6 +9405,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9650,6 +9694,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9959,6 +10004,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10062,6 +10108,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11248,6 +11295,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11388,6 +11436,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11504,6 +11553,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11591,6 +11641,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11890,6 +11941,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11919,6 +11971,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12641,6 +12694,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13005,6 +13059,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13314,6 +13369,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13578,6 +13634,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13808,6 +13865,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13837,6 +13895,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13890,6 +13949,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13964,6 +14024,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14313,6 +14374,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14501,6 +14563,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14575,6 +14638,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14641,6 +14705,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14686,6 +14751,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14792,6 +14858,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -15201,6 +15268,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15415,6 +15483,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15444,6 +15513,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15521,6 +15591,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15798,6 +15869,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15962,6 +16034,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -16078,6 +16151,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -16165,6 +16239,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16376,6 +16451,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16701,6 +16777,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16778,6 +16855,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -17208,6 +17286,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17892,6 +17971,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18098,6 +18178,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -18354,6 +18435,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -18431,6 +18513,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18650,6 +18733,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18959,6 +19043,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -19395,6 +19480,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19593,6 +19679,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -19651,6 +19738,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19873,6 +19961,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -20787,6 +20876,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20874,6 +20964,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20903,6 +20994,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20998,6 +21090,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -21267,6 +21360,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21956,6 +22050,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -22625,6 +22720,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23170,6 +23266,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23600,6 +23697,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24194,6 +24292,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -24223,6 +24322,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -24268,6 +24368,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -24453,6 +24554,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -25116,6 +25218,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25264,6 +25367,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -25433,6 +25537,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25879,6 +25984,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -25995,6 +26101,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -26700,6 +26807,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26745,6 +26853,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -27435,6 +27544,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -27934,6 +28044,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -28309,6 +28420,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -28338,6 +28450,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28888,6 +29001,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -29091,6 +29205,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29178,6 +29293,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29247,6 +29363,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -29324,6 +29441,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -29535,6 +29653,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -29765,6 +29884,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -29794,6 +29914,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -30237,6 +30358,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30266,6 +30388,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30348,6 +30471,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30551,6 +30675,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -30704,6 +30829,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31100,6 +31226,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31406,6 +31533,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31650,6 +31778,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31811,6 +31940,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -32455,6 +32585,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32867,6 +32998,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -33128,6 +33260,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -33825,6 +33958,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -34102,6 +34236,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -34163,6 +34298,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34308,6 +34444,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -34644,6 +34781,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34747,6 +34885,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34903,6 +35042,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -35288,6 +35428,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -35520,6 +35661,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35803,6 +35945,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -36059,6 +36202,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36146,6 +36290,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36252,6 +36397,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -36334,6 +36480,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36416,6 +36563,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -36445,6 +36593,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -36601,6 +36750,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36630,6 +36780,7 @@
         {
             "id": "0xd8e72a62e214864cbd9381cc04fa1006a8c8fb10",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23b608675a2b2fb1890d3abbd85c5775c51691d5",
@@ -36831,6 +36982,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -36860,6 +37012,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -37433,6 +37586,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37782,6 +37936,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -37811,6 +37966,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -37869,6 +38025,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -38125,6 +38282,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38154,6 +38312,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38207,6 +38366,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -38970,6 +39130,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -39581,6 +39742,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39610,6 +39772,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39750,6 +39913,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40241,6 +40405,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -40883,6 +41048,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -41089,6 +41255,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -41406,6 +41573,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -41451,6 +41619,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -41525,6 +41694,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -41710,6 +41880,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -41797,6 +41968,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -42008,6 +42180,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -42235,6 +42408,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -42515,6 +42689,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -43096,6 +43271,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -43289,6 +43465,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -43442,6 +43619,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xa7a3cf76686c6d6aa6e976724b4463c6f7b0e98453ad3a8488b6e9daa2fecc42.json
+++ b/test/testData/testPools/0xa7a3cf76686c6d6aa6e976724b4463c6f7b0e98453ad3a8488b6e9daa2fecc42.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -42,6 +43,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -71,6 +73,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -184,6 +187,7 @@
         {
             "id": "0x01223eb6b9cbe061f2f22e96f74936c0115ec6fb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4de9ab5dd20547b7334a295763dfd0a11b010e0a",
@@ -213,6 +217,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -242,6 +247,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -279,6 +285,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -308,6 +315,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -337,6 +345,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -366,6 +375,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -395,6 +405,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -424,6 +435,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -483,6 +495,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -536,6 +549,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -581,6 +595,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -610,6 +625,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -699,6 +715,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -728,6 +745,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -781,6 +799,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -810,6 +829,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -839,6 +859,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -954,6 +975,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -983,6 +1005,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -1012,6 +1035,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -1041,6 +1065,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -1070,6 +1095,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1115,6 +1141,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1144,6 +1171,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1189,6 +1217,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1218,6 +1247,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1373,6 +1403,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1402,6 +1433,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1431,6 +1463,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1460,6 +1493,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1489,6 +1523,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1548,6 +1583,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1577,6 +1613,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1630,6 +1667,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1659,6 +1697,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1712,6 +1751,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1741,6 +1781,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1770,6 +1811,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1799,6 +1841,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1844,6 +1887,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1873,6 +1917,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1902,6 +1947,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1931,6 +1977,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1960,6 +2007,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -2019,6 +2067,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -2064,6 +2113,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -2185,6 +2235,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2268,6 +2319,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2399,6 +2451,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2452,6 +2505,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2481,6 +2535,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2510,6 +2565,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2571,6 +2627,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2600,6 +2657,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2697,6 +2755,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2756,6 +2815,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2793,6 +2853,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2822,6 +2883,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2851,6 +2913,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2934,6 +2997,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2963,6 +3027,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -3000,6 +3065,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3029,6 +3095,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -3058,6 +3125,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3087,6 +3155,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -3116,6 +3185,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3153,6 +3223,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -3182,6 +3253,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -3211,6 +3283,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -3240,6 +3313,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3355,6 +3429,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3392,6 +3467,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3421,6 +3497,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3450,6 +3527,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3479,6 +3557,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3524,6 +3603,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3553,6 +3633,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3582,6 +3663,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3611,6 +3693,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3640,6 +3723,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3715,6 +3799,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3768,6 +3853,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3797,6 +3883,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3826,6 +3913,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3855,6 +3943,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3884,6 +3973,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3961,6 +4051,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3990,6 +4081,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4019,6 +4111,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4048,6 +4141,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -4077,6 +4171,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -4106,6 +4201,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -4135,6 +4231,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -4164,6 +4261,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -4201,6 +4299,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -4230,6 +4329,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4259,6 +4359,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -4288,6 +4389,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4325,6 +4427,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4354,6 +4457,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4383,6 +4487,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4442,6 +4547,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4487,6 +4593,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4516,6 +4623,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4569,6 +4677,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4652,6 +4761,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4681,6 +4791,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4740,6 +4851,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4769,6 +4881,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4860,6 +4973,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4905,6 +5019,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4934,6 +5049,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4963,6 +5079,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4992,6 +5109,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5021,6 +5139,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -5050,6 +5169,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5079,6 +5199,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5108,6 +5229,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -5137,6 +5259,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5196,6 +5319,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -5273,6 +5397,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -5302,6 +5427,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5331,6 +5457,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5360,6 +5487,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5513,6 +5641,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5572,6 +5701,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5609,6 +5739,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5638,6 +5769,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5667,6 +5799,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5696,6 +5829,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5755,6 +5889,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5784,6 +5919,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5843,6 +5979,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5872,6 +6009,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5933,6 +6071,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -6000,6 +6139,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6029,6 +6169,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -6058,6 +6199,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -6087,6 +6229,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -6116,6 +6259,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -6175,6 +6319,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -6212,6 +6357,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6241,6 +6387,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -6270,6 +6417,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -6331,6 +6479,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -6360,6 +6509,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -6389,6 +6539,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -6448,6 +6599,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -6477,6 +6629,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6506,6 +6659,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6535,6 +6689,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6564,6 +6719,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6593,6 +6749,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6646,6 +6803,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6675,6 +6833,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6720,6 +6879,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6773,6 +6933,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6802,6 +6963,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6831,6 +6993,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6892,6 +7055,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6975,6 +7139,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -7052,6 +7217,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7081,6 +7247,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -7118,6 +7285,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -7147,6 +7315,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -7176,6 +7345,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7205,6 +7375,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7234,6 +7405,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -7263,6 +7435,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -7292,6 +7465,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7321,6 +7495,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -7390,6 +7565,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -7467,6 +7643,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -7496,6 +7673,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7555,6 +7733,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7584,6 +7763,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7651,6 +7831,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7680,6 +7861,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7709,6 +7891,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7738,6 +7921,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7775,6 +7959,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7834,6 +8019,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7863,6 +8049,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7924,6 +8111,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7953,6 +8141,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -8012,6 +8201,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8041,6 +8231,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -8070,6 +8261,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -8099,6 +8291,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -8158,6 +8351,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -8187,6 +8381,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -8340,6 +8535,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -8369,6 +8565,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -8398,6 +8595,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -8427,6 +8625,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8456,6 +8655,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -8523,6 +8723,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -8560,6 +8761,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8589,6 +8791,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -8618,6 +8821,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -8671,6 +8875,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -8700,6 +8905,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8729,6 +8935,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8758,6 +8965,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8787,6 +8995,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8816,6 +9025,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8845,6 +9055,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8928,6 +9139,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8957,6 +9169,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8994,6 +9207,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9023,6 +9237,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9052,6 +9267,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9097,6 +9313,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9126,6 +9343,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9163,6 +9381,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -9270,6 +9489,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9299,6 +9519,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9328,6 +9549,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -9435,6 +9657,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -9464,6 +9687,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -9493,6 +9717,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -9530,6 +9755,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9559,6 +9785,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -9612,6 +9839,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -9665,6 +9893,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9724,6 +9953,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9753,6 +9983,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -9782,6 +10013,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9811,6 +10043,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9840,6 +10073,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9917,6 +10151,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9946,6 +10181,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9975,6 +10211,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -10034,6 +10271,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -10079,6 +10317,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -10186,6 +10425,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -10239,6 +10479,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -10268,6 +10509,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -10345,6 +10587,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -10398,6 +10641,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -10427,6 +10671,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -10456,6 +10701,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -10485,6 +10731,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -10514,6 +10761,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -10543,6 +10791,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10572,6 +10821,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -10601,6 +10851,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -10630,6 +10881,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -10659,6 +10911,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10688,6 +10941,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -10717,6 +10971,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10746,6 +11001,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -10775,6 +11031,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10804,6 +11061,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -10833,6 +11091,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -10862,6 +11121,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10891,6 +11151,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10936,6 +11197,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10965,6 +11227,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10994,6 +11257,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11055,6 +11319,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -11084,6 +11349,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -11113,6 +11379,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -11150,6 +11417,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -11179,6 +11447,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11208,6 +11477,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11237,6 +11507,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -11266,6 +11537,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -11325,6 +11597,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11354,6 +11627,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11407,6 +11681,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11466,6 +11741,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11495,6 +11771,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -11524,6 +11801,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -11583,6 +11861,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -11612,6 +11891,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -11711,6 +11991,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -11740,6 +12021,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -11769,6 +12051,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -11798,6 +12081,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -11875,6 +12159,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -11912,6 +12197,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -12001,6 +12287,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -12030,6 +12317,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -12083,6 +12371,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -12112,6 +12401,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12165,6 +12455,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12194,6 +12485,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12223,6 +12515,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12292,6 +12585,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -12337,6 +12631,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -12366,6 +12661,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -12395,6 +12691,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -12424,6 +12721,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12453,6 +12751,7 @@
         {
             "id": "0x4b3fa856cef9aa85ed9bbfa8992d6138c5f150e6",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -12530,6 +12829,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12607,6 +12907,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12636,6 +12937,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12665,6 +12967,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -12732,6 +13035,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -12769,6 +13073,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -12798,6 +13103,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12827,6 +13133,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12856,6 +13163,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -12885,6 +13193,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -12914,6 +13223,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -12943,6 +13253,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12972,6 +13283,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -13001,6 +13313,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13030,6 +13343,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13089,6 +13403,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -13118,6 +13433,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -13147,6 +13463,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -13176,6 +13493,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13245,6 +13563,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13282,6 +13601,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -13311,6 +13631,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13340,6 +13661,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13399,6 +13721,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13460,6 +13783,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13489,6 +13813,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -13518,6 +13843,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13547,6 +13873,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13576,6 +13903,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13605,6 +13933,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13664,6 +13993,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13741,6 +14071,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -13770,6 +14101,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -13799,6 +14131,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -13836,6 +14169,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -13979,6 +14313,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14086,6 +14421,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -14123,6 +14459,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -14200,6 +14537,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -14229,6 +14567,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -14258,6 +14597,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14287,6 +14627,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -14316,6 +14657,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14345,6 +14687,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14404,6 +14747,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -14433,6 +14777,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -14486,6 +14831,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14593,6 +14939,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14668,6 +15015,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -14829,6 +15177,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -14888,6 +15237,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14917,6 +15267,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -14946,6 +15297,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -15007,6 +15359,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15036,6 +15389,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -15065,6 +15419,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -15094,6 +15449,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15123,6 +15479,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -15152,6 +15509,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -15181,6 +15539,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15210,6 +15569,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -15239,6 +15599,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -15338,6 +15699,7 @@
         {
             "id": "0x58ce2e98a050925d99b209799d10f413c729f6fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bead9a1bcc1b84d06e3f2df67e3549fd55ab054",
@@ -15367,6 +15729,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -15396,6 +15759,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -15425,6 +15789,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15454,6 +15819,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -15621,6 +15987,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -15650,6 +16017,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -15679,6 +16047,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -15708,6 +16077,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15753,6 +16123,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -15782,6 +16153,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -15811,6 +16183,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -15840,6 +16213,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -15899,6 +16273,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15928,6 +16303,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15957,6 +16333,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -16064,6 +16441,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16093,6 +16471,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16122,6 +16501,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16181,6 +16561,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -16210,6 +16591,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16277,6 +16659,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -16306,6 +16689,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -16335,6 +16719,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -16364,6 +16749,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16393,6 +16779,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -16422,6 +16809,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -16481,6 +16869,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -16558,6 +16947,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -16587,6 +16977,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -16616,6 +17007,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16645,6 +17037,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -16674,6 +17067,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -16703,6 +17097,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16732,6 +17127,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -16885,6 +17281,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -16914,6 +17311,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16943,6 +17341,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -16972,6 +17371,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17001,6 +17401,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -17046,6 +17447,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17075,6 +17477,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -17104,6 +17507,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -17133,6 +17537,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -17162,6 +17567,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17199,6 +17605,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -17228,6 +17635,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17257,6 +17665,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -17364,6 +17773,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17393,6 +17803,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -17422,6 +17833,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -17451,6 +17863,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -17480,6 +17893,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -17509,6 +17923,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17538,6 +17953,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -17567,6 +17983,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17596,6 +18013,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -17625,6 +18043,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -17654,6 +18073,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17699,6 +18119,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17728,6 +18149,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17757,6 +18179,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -17826,6 +18249,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17855,6 +18279,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17884,6 +18309,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17913,6 +18339,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -17942,6 +18369,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -18001,6 +18429,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -18030,6 +18459,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18059,6 +18489,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -18088,6 +18519,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -18117,6 +18549,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18216,6 +18649,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -18245,6 +18679,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18274,6 +18709,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18303,6 +18739,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18332,6 +18769,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -18361,6 +18799,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -18390,6 +18829,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -18551,6 +18991,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -18580,6 +19021,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -18609,6 +19051,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -18638,6 +19081,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -18667,6 +19111,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -18704,6 +19149,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18763,6 +19209,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18840,6 +19287,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -18869,6 +19317,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -18898,6 +19347,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18927,6 +19377,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18956,6 +19407,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -18985,6 +19437,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19014,6 +19467,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19113,6 +19567,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -19142,6 +19597,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -19171,6 +19627,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -19200,6 +19657,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -19229,6 +19687,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -19282,6 +19741,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19327,6 +19787,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -19356,6 +19817,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19385,6 +19847,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -19422,6 +19885,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -19451,6 +19915,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19526,6 +19991,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -19555,6 +20021,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -19592,6 +20059,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -19621,6 +20089,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -19650,6 +20119,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19709,6 +20179,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -19768,6 +20239,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -19845,6 +20317,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19874,6 +20347,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -19903,6 +20377,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19932,6 +20407,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19991,6 +20467,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -20068,6 +20545,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -20097,6 +20575,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -20174,6 +20653,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -20203,6 +20683,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -20232,6 +20713,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20261,6 +20743,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -20290,6 +20773,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20319,6 +20803,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -20348,6 +20833,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -20385,6 +20871,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -20422,6 +20909,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20451,6 +20939,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -20480,6 +20969,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20541,6 +21031,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20570,6 +21061,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20599,6 +21091,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -20628,6 +21121,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -20665,6 +21159,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -20694,6 +21189,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -20723,6 +21219,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20752,6 +21249,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -20781,6 +21279,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -20818,6 +21317,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20847,6 +21347,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -20906,6 +21407,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -20935,6 +21437,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -21024,6 +21527,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21061,6 +21565,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21120,6 +21625,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -21149,6 +21655,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21178,6 +21685,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21207,6 +21715,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -21244,6 +21753,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -21273,6 +21783,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -21302,6 +21813,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -21331,6 +21843,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21390,6 +21903,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21419,6 +21933,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -21448,6 +21963,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21501,6 +22017,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21530,6 +22047,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -21559,6 +22077,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -21588,6 +22107,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -21617,6 +22137,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -21646,6 +22167,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -21675,6 +22197,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -21704,6 +22227,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -21733,6 +22257,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -21810,6 +22335,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21839,6 +22365,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21868,6 +22395,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21897,6 +22425,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -21934,6 +22463,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21963,6 +22493,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -21992,6 +22523,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -22021,6 +22553,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22096,6 +22629,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22125,6 +22659,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -22170,6 +22705,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22199,6 +22735,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -22276,6 +22813,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -22345,6 +22883,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -22374,6 +22913,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22451,6 +22991,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22480,6 +23021,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22509,6 +23051,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -22538,6 +23081,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -22567,6 +23111,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22596,6 +23141,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -22625,6 +23171,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -22654,6 +23201,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -22691,6 +23239,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22790,6 +23339,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22819,6 +23369,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -22848,6 +23399,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -22885,6 +23437,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22922,6 +23475,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -22967,6 +23521,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -23028,6 +23583,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23057,6 +23613,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -23086,6 +23643,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -23163,6 +23721,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -23192,6 +23751,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -23237,6 +23797,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23296,6 +23857,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23325,6 +23887,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23354,6 +23917,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -23391,6 +23955,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23420,6 +23985,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23449,6 +24015,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -23478,6 +24045,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -23507,6 +24075,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -23536,6 +24105,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -23581,6 +24151,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -23610,6 +24181,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23639,6 +24211,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -23668,6 +24241,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -23751,6 +24325,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23780,6 +24355,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23809,6 +24385,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -23838,6 +24415,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23867,6 +24445,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -23896,6 +24475,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -23949,6 +24529,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23986,6 +24567,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -24015,6 +24597,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -24044,6 +24627,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24073,6 +24657,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24102,6 +24687,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -24131,6 +24717,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24160,6 +24747,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -24205,6 +24793,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -24234,6 +24823,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -24263,6 +24853,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -24414,6 +25005,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -24459,6 +25051,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24488,6 +25081,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -24525,6 +25119,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -24584,6 +25179,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24613,6 +25209,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -24642,6 +25239,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -24695,6 +25293,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -24740,6 +25339,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24769,6 +25369,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24798,6 +25399,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24875,6 +25477,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -24912,6 +25515,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -24941,6 +25545,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24978,6 +25583,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -25015,6 +25621,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -25044,6 +25651,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -25073,6 +25681,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -25102,6 +25711,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -25131,6 +25741,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25160,6 +25771,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -25189,6 +25801,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25248,6 +25861,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -25277,6 +25891,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -25338,6 +25953,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -25405,6 +26021,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25434,6 +26051,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25463,6 +26081,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -25508,6 +26127,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -25567,6 +26187,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25596,6 +26217,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25625,6 +26247,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -25654,6 +26277,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -25691,6 +26315,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25720,6 +26345,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -25757,6 +26383,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25786,6 +26413,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25839,6 +26467,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -25868,6 +26497,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -25897,6 +26527,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -25926,6 +26557,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -25955,6 +26587,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -26014,6 +26647,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -26043,6 +26677,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -26072,6 +26707,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -26131,6 +26767,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -26160,6 +26797,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -26213,6 +26851,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -26266,6 +26905,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -26295,6 +26935,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -26324,6 +26965,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -26353,6 +26995,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26382,6 +27025,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -26411,6 +27055,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26440,6 +27085,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -26469,6 +27115,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -26498,6 +27145,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -26527,6 +27175,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -26556,6 +27205,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -26585,6 +27235,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -26614,6 +27265,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26651,6 +27303,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -26720,6 +27373,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26749,6 +27403,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -26778,6 +27433,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26931,6 +27587,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -27008,6 +27665,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -27037,6 +27695,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -27066,6 +27725,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27143,6 +27803,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27172,6 +27833,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -27201,6 +27863,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -27230,6 +27893,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27267,6 +27931,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27312,6 +27977,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27341,6 +28007,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -27370,6 +28037,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -27399,6 +28067,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -27428,6 +28097,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27457,6 +28127,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -27486,6 +28157,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27515,6 +28187,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27590,6 +28263,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -27619,6 +28293,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -27648,6 +28323,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -27685,6 +28361,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27714,6 +28391,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -27767,6 +28445,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27804,6 +28483,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -27833,6 +28513,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27862,6 +28543,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -27891,6 +28573,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -27920,6 +28603,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -27949,6 +28633,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -27978,6 +28663,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -28007,6 +28693,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -28074,6 +28761,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28103,6 +28791,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28140,6 +28829,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -28169,6 +28859,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -28198,6 +28889,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28251,6 +28943,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28280,6 +28973,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -28309,6 +29003,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28338,6 +29033,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28375,6 +29071,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28480,6 +29177,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28509,6 +29207,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -28578,6 +29277,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -28607,6 +29307,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -28636,6 +29337,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28665,6 +29367,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -28694,6 +29397,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28723,6 +29427,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -28752,6 +29457,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -28789,6 +29495,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -28818,6 +29525,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -28895,6 +29603,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -28924,6 +29633,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -29031,6 +29741,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -29060,6 +29771,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -29089,6 +29801,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -29118,6 +29831,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29147,6 +29861,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -29176,6 +29891,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -29235,6 +29951,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -29264,6 +29981,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -29471,6 +30189,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -29500,6 +30219,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -29529,6 +30249,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -29558,6 +30279,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29595,6 +30317,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -29624,6 +30347,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -29707,6 +30431,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29736,6 +30461,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -29781,6 +30507,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -29810,6 +30537,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -29855,6 +30583,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -29952,6 +30681,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29981,6 +30711,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -30010,6 +30741,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30039,6 +30771,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30068,6 +30801,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -30097,6 +30831,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -30126,6 +30861,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -30155,6 +30891,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30184,6 +30921,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -30213,6 +30951,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -30242,6 +30981,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -30271,6 +31011,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30300,6 +31041,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30329,6 +31071,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -30442,6 +31185,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -30501,6 +31245,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -30530,6 +31275,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -30559,6 +31305,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30588,6 +31335,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -30617,6 +31365,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -30646,6 +31395,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -30705,6 +31455,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -30734,6 +31485,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -30763,6 +31515,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -30800,6 +31553,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -30859,6 +31613,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -30888,6 +31643,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -30917,6 +31673,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -30994,6 +31751,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31023,6 +31781,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -31052,6 +31811,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31081,6 +31841,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31110,6 +31871,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31139,6 +31901,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -31168,6 +31931,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31197,6 +31961,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -31256,6 +32021,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31285,6 +32051,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31314,6 +32081,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -31351,6 +32119,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -31380,6 +32149,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31417,6 +32187,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -31446,6 +32217,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -31475,6 +32247,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -31504,6 +32277,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -31595,6 +32369,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31624,6 +32399,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31701,6 +32477,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -31808,6 +32585,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31837,6 +32615,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31866,6 +32645,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31895,6 +32675,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -31970,6 +32751,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -31999,6 +32781,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -32060,6 +32843,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -32089,6 +32873,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -32118,6 +32903,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32147,6 +32933,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -32192,6 +32979,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -32221,6 +33009,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -32258,6 +33047,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -32287,6 +33077,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -32316,6 +33107,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -32345,6 +33137,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -32374,6 +33167,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -32411,6 +33205,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32440,6 +33235,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -32469,6 +33265,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -32498,6 +33295,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -32527,6 +33325,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -32556,6 +33355,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -32663,6 +33463,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -32692,6 +33493,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -32721,6 +33523,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -32750,6 +33553,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -32779,6 +33583,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32808,6 +33613,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -32837,6 +33643,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -32866,6 +33673,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32911,6 +33719,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -32940,6 +33749,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -32969,6 +33779,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -33028,6 +33839,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -33057,6 +33869,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33086,6 +33899,7 @@
         {
             "id": "0xc34473ccac5e14a4b7bf558d41477a05976e670c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bead9a1bcc1b84d06e3f2df67e3549fd55ab054",
@@ -33115,6 +33929,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -33144,6 +33959,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -33173,6 +33989,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -33202,6 +34019,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -33231,6 +34049,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -33290,6 +34109,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -33319,6 +34139,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33356,6 +34177,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -33425,6 +34247,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -33454,6 +34277,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -33483,6 +34307,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -33512,6 +34337,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -33541,6 +34367,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -33570,6 +34397,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -33599,6 +34427,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -33628,6 +34457,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -33657,6 +34487,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -33718,6 +34549,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -33747,6 +34579,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -33776,6 +34609,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -33805,6 +34639,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -33834,6 +34669,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33863,6 +34699,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33900,6 +34737,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -33929,6 +34767,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -33988,6 +34827,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -34017,6 +34857,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -34046,6 +34887,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -34075,6 +34917,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34104,6 +34947,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -34133,6 +34977,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34162,6 +35007,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -34191,6 +35037,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -34328,6 +35175,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34357,6 +35205,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34386,6 +35235,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34415,6 +35265,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -34474,6 +35325,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -34503,6 +35355,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -34564,6 +35417,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -34593,6 +35447,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34622,6 +35477,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34683,6 +35539,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -34720,6 +35577,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34819,6 +35677,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34848,6 +35707,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -34939,6 +35799,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -34984,6 +35845,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -35013,6 +35875,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35072,6 +35935,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -35101,6 +35965,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -35130,6 +35995,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35167,6 +36033,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -35196,6 +36063,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -35225,6 +36093,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -35254,6 +36123,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -35283,6 +36153,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35312,6 +36183,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35341,6 +36213,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35370,6 +36243,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -35399,6 +36273,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -35458,6 +36333,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35487,6 +36363,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -35516,6 +36393,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35545,6 +36423,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -35574,6 +36453,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -35603,6 +36483,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35632,6 +36513,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -35691,6 +36573,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -35744,6 +36627,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35789,6 +36673,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35818,6 +36703,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -35847,6 +36733,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -35876,6 +36763,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35975,6 +36863,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -36004,6 +36893,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36033,6 +36923,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -36070,6 +36961,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -36099,6 +36991,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -36128,6 +37021,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -36173,6 +37067,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -36232,6 +37127,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -36261,6 +37157,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -36368,6 +37265,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -36451,6 +37349,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -36534,6 +37433,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36631,6 +37531,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -36676,6 +37577,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36721,6 +37623,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -36858,6 +37761,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -36887,6 +37791,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -36924,6 +37829,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -36953,6 +37859,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -37042,6 +37949,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -37071,6 +37979,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -37100,6 +38009,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37129,6 +38039,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37158,6 +38069,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -37187,6 +38099,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -37232,6 +38145,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37261,6 +38175,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37338,6 +38253,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -37367,6 +38283,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37396,6 +38313,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37425,6 +38343,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37454,6 +38373,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -37483,6 +38403,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -37520,6 +38441,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37557,6 +38479,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -37664,6 +38587,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37693,6 +38617,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -37722,6 +38647,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -37751,6 +38677,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37780,6 +38707,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37809,6 +38737,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -37870,6 +38799,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -37899,6 +38829,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -37996,6 +38927,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -38055,6 +38987,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -38084,6 +39017,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -38113,6 +39047,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38142,6 +39077,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -38195,6 +39131,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38224,6 +39161,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38253,6 +39191,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38396,6 +39335,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -38425,6 +39365,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -38454,6 +39395,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38483,6 +39425,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38512,6 +39455,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38541,6 +39485,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -38570,6 +39515,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38599,6 +39545,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38628,6 +39575,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38657,6 +39605,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38726,6 +39675,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38779,6 +39729,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38808,6 +39759,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38837,6 +39789,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38866,6 +39819,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -38895,6 +39849,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -38932,6 +39887,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -38961,6 +39917,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38990,6 +39947,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -39019,6 +39977,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -39048,6 +40007,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -39101,6 +40061,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -39160,6 +40121,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -39189,6 +40151,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -39218,6 +40181,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39255,6 +40219,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -39284,6 +40249,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -39361,6 +40327,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39414,6 +40381,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39475,6 +40443,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39520,6 +40489,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39549,6 +40519,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -39626,6 +40597,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -39655,6 +40627,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39684,6 +40657,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -39713,6 +40687,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -39826,6 +40801,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -39855,6 +40831,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -39884,6 +40861,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39991,6 +40969,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -40020,6 +40999,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -40049,6 +41029,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -40078,6 +41059,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -40107,6 +41089,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -40136,6 +41119,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -40165,6 +41149,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40194,6 +41179,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -40223,6 +41209,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -40252,6 +41239,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -40281,6 +41269,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -40318,6 +41307,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -40347,6 +41337,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -40376,6 +41367,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40435,6 +41427,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -40464,6 +41457,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -40493,6 +41487,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -40554,6 +41549,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -40583,6 +41579,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -40644,6 +41641,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -40673,6 +41671,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -40702,6 +41701,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40755,6 +41755,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -40784,6 +41785,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -40813,6 +41815,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40842,6 +41845,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -40887,6 +41891,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40916,6 +41921,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40953,6 +41959,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -40982,6 +41989,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -41019,6 +42027,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41078,6 +42087,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41107,6 +42117,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -41136,6 +42147,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -41189,6 +42201,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -41226,6 +42239,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -41293,6 +42307,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -41322,6 +42337,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -41351,6 +42367,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -41404,6 +42421,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -41433,6 +42451,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -41462,6 +42481,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -41515,6 +42535,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -41544,6 +42565,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41665,6 +42687,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -41724,6 +42747,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -41753,6 +42777,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41806,6 +42831,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -41835,6 +42861,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -41910,6 +42937,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -41939,6 +42967,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41998,6 +43027,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -42027,6 +43057,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -42056,6 +43087,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -42085,6 +43117,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -42114,6 +43147,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -42143,6 +43177,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -42210,6 +43245,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -42239,6 +43275,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -42292,6 +43329,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -42321,6 +43359,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -42350,6 +43389,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -42379,6 +43419,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -42438,6 +43479,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -42467,6 +43509,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -42496,6 +43539,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -42525,6 +43569,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -42602,6 +43647,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -42631,6 +43677,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -42660,6 +43707,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -42743,6 +43791,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -42772,6 +43821,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -42809,6 +43859,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -42846,6 +43897,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -42883,6 +43935,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -42912,6 +43965,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -42941,6 +43995,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -42970,6 +44025,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -43007,6 +44063,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -43036,6 +44093,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -43065,6 +44123,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -43094,6 +44153,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -43131,6 +44191,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -43168,6 +44229,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -43197,6 +44259,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -43226,6 +44289,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -43349,6 +44413,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -43378,6 +44443,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -43407,6 +44473,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -43436,6 +44503,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -43495,6 +44563,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -43524,6 +44593,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -43561,6 +44631,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -43590,6 +44661,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -43697,6 +44769,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -43726,6 +44799,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -43755,6 +44829,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -43784,6 +44859,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -43861,6 +44937,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0xa92d76d916fe5fdbb5283a36daaad226089fc3c94e0f7fe41a2173eafe524390.json
+++ b/test/testData/testPools/0xa92d76d916fe5fdbb5283a36daaad226089fc3c94e0f7fe41a2173eafe524390.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -827,6 +832,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1392,6 +1399,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1826,6 +1834,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1921,6 +1930,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1955,6 +1965,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2031,6 +2042,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2133,6 +2145,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2406,6 +2419,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2433,6 +2447,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2494,6 +2509,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2636,6 +2652,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3002,6 +3019,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3362,6 +3380,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4047,6 +4066,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4217,6 +4237,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4319,6 +4340,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4400,6 +4422,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4739,6 +4762,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4957,6 +4981,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5026,6 +5051,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5080,6 +5106,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5249,6 +5276,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5358,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5466,6 +5495,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5635,6 +5665,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5886,6 +5917,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6355,6 +6387,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6900,6 +6933,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6981,6 +7015,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7157,6 +7192,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7320,6 +7356,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7455,6 +7492,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7578,6 +7616,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7658,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7788,6 +7828,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8161,6 +8202,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8474,6 +8516,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8624,6 +8667,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +8933,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9174,6 +9219,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9269,6 +9315,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10362,6 +10409,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10491,6 +10539,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10599,6 +10648,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10680,6 +10730,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10953,6 +11004,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10980,6 +11032,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11641,6 +11694,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11979,6 +12033,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12264,6 +12319,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12508,6 +12564,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12719,6 +12776,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12746,6 +12804,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12794,6 +12853,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12862,6 +12922,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13182,6 +13243,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13353,6 +13415,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13421,6 +13484,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13482,6 +13546,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13523,6 +13588,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13619,6 +13685,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13998,6 +14065,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14195,6 +14263,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14222,6 +14291,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14291,6 +14361,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14548,6 +14619,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14698,6 +14770,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14806,6 +14879,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14887,6 +14961,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15083,6 +15158,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15382,6 +15458,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15451,6 +15528,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15850,6 +15928,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16481,6 +16560,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16671,6 +16751,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16908,6 +16989,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16977,6 +17059,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17180,6 +17263,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17465,6 +17549,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17866,6 +17951,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18049,6 +18135,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18103,6 +18190,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18307,6 +18395,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19149,6 +19238,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19230,6 +19320,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19257,6 +19348,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19345,6 +19437,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19595,6 +19688,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20232,6 +20326,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20845,6 +20940,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21343,6 +21439,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21742,6 +21839,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22291,6 +22389,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22318,6 +22417,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22359,6 +22459,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22529,6 +22630,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23140,6 +23242,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23276,6 +23379,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23432,6 +23536,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23845,6 +23950,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23953,6 +24059,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24604,6 +24711,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24645,6 +24753,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25278,6 +25387,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25739,6 +25849,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26085,6 +26196,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26112,6 +26224,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26616,6 +26729,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26805,6 +26919,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26886,6 +27001,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26948,6 +27064,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27017,6 +27134,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27213,6 +27331,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27424,6 +27543,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27451,6 +27571,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27863,6 +27984,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27890,6 +28012,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27965,6 +28088,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28154,6 +28278,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28296,6 +28421,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28662,6 +28788,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28946,6 +29073,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29166,6 +29294,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29315,6 +29444,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29911,6 +30041,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30291,6 +30422,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30534,6 +30666,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31178,6 +31311,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31435,6 +31569,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31490,6 +31625,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31625,6 +31761,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31932,6 +32069,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32027,6 +32165,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32170,6 +32309,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32528,6 +32668,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32744,6 +32885,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33003,6 +33145,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33240,6 +33383,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33321,6 +33465,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33417,6 +33562,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33492,6 +33638,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33567,6 +33714,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33594,6 +33742,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33737,6 +33886,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33764,6 +33914,7 @@
         {
             "id": "0xd8e72a62e214864cbd9381cc04fa1006a8c8fb10",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23b608675a2b2fb1890d3abbd85c5775c51691d5",
@@ -33948,6 +34099,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33975,6 +34127,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34504,6 +34657,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34824,6 +34978,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34851,6 +35006,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34905,6 +35061,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35142,6 +35299,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35169,6 +35327,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35217,6 +35376,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35922,6 +36082,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36481,6 +36642,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36508,6 +36670,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36637,6 +36800,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37091,6 +37255,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37682,6 +37847,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37872,6 +38038,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38164,6 +38331,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38205,6 +38373,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38273,6 +38442,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38443,6 +38613,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38524,6 +38695,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38720,6 +38892,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38930,6 +39103,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39188,6 +39362,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39724,6 +39899,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39901,6 +40077,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40043,6 +40220,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xab11cdebd9d96f2f4d9d29f0df62de0640c457882d92435aff2a7c1049a0be6a.json
+++ b/test/testData/testPools/0xab11cdebd9d96f2f4d9d29f0df62de0640c457882d92435aff2a7c1049a0be6a.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -827,6 +832,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1392,6 +1399,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1826,6 +1834,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1921,6 +1930,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1955,6 +1965,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2031,6 +2042,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2133,6 +2145,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2406,6 +2419,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2433,6 +2447,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2494,6 +2509,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2636,6 +2652,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3002,6 +3019,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3362,6 +3380,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4047,6 +4066,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4217,6 +4237,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4319,6 +4340,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4400,6 +4422,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4739,6 +4762,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4957,6 +4981,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5026,6 +5051,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5080,6 +5106,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5249,6 +5276,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5358,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5466,6 +5495,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5635,6 +5665,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5886,6 +5917,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6355,6 +6387,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6900,6 +6933,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6981,6 +7015,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7157,6 +7192,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7320,6 +7356,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7455,6 +7492,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7578,6 +7616,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7658,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7788,6 +7828,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8161,6 +8202,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8474,6 +8516,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8624,6 +8667,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +8933,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9174,6 +9219,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9269,6 +9315,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10362,6 +10409,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10491,6 +10539,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10599,6 +10648,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10680,6 +10730,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10953,6 +11004,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10980,6 +11032,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11641,6 +11694,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11979,6 +12033,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12264,6 +12319,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12508,6 +12564,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12719,6 +12776,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12746,6 +12804,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12794,6 +12853,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12862,6 +12922,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13182,6 +13243,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13353,6 +13415,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13421,6 +13484,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13482,6 +13546,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13523,6 +13588,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13619,6 +13685,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13998,6 +14065,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14195,6 +14263,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14222,6 +14291,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14291,6 +14361,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14548,6 +14619,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14698,6 +14770,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14806,6 +14879,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14887,6 +14961,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15083,6 +15158,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15382,6 +15458,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15451,6 +15528,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15850,6 +15928,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16481,6 +16560,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16671,6 +16751,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16908,6 +16989,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16977,6 +17059,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17180,6 +17263,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17465,6 +17549,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17866,6 +17951,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18049,6 +18135,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18103,6 +18190,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18307,6 +18395,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19149,6 +19238,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19230,6 +19320,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19257,6 +19348,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19345,6 +19437,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19595,6 +19688,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20232,6 +20326,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20845,6 +20940,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21343,6 +21439,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21742,6 +21839,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22291,6 +22389,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22318,6 +22417,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22359,6 +22459,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22529,6 +22630,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23140,6 +23242,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23276,6 +23379,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23432,6 +23536,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23845,6 +23950,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23953,6 +24059,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24604,6 +24711,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24645,6 +24753,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25278,6 +25387,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25739,6 +25849,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26085,6 +26196,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26112,6 +26224,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26616,6 +26729,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26805,6 +26919,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26886,6 +27001,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26948,6 +27064,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27017,6 +27134,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27213,6 +27331,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27424,6 +27543,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27451,6 +27571,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27863,6 +27984,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27890,6 +28012,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27965,6 +28088,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28154,6 +28278,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28296,6 +28421,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28662,6 +28788,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28946,6 +29073,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29166,6 +29294,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29315,6 +29444,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29911,6 +30041,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30291,6 +30422,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30534,6 +30666,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31178,6 +31311,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31435,6 +31569,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31490,6 +31625,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31625,6 +31761,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31932,6 +32069,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32027,6 +32165,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32170,6 +32309,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32528,6 +32668,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32744,6 +32885,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33003,6 +33145,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33240,6 +33383,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33321,6 +33465,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33417,6 +33562,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33492,6 +33638,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33567,6 +33714,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33594,6 +33742,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33737,6 +33886,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33764,6 +33914,7 @@
         {
             "id": "0xd8e72a62e214864cbd9381cc04fa1006a8c8fb10",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23b608675a2b2fb1890d3abbd85c5775c51691d5",
@@ -33948,6 +34099,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33975,6 +34127,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34504,6 +34657,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34824,6 +34978,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34851,6 +35006,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34905,6 +35061,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35142,6 +35299,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35169,6 +35327,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35217,6 +35376,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35922,6 +36082,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36481,6 +36642,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36508,6 +36670,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36637,6 +36800,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37091,6 +37255,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37682,6 +37847,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37872,6 +38038,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38164,6 +38331,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38205,6 +38373,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38273,6 +38442,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38443,6 +38613,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38524,6 +38695,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38720,6 +38892,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38930,6 +39103,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39188,6 +39362,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39724,6 +39899,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39901,6 +40077,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40043,6 +40220,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xab88111bd9e2e8c59fd59b84f2d2545b40d42491ad16b720c1344e1c93388523.json
+++ b/test/testData/testPools/0xab88111bd9e2e8c59fd59b84f2d2545b40d42491ad16b720c1344e1c93388523.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xabfeac41f0b0798e67e24557004eea1b1f18f973ea40689425267794ce88f35c.json
+++ b/test/testData/testPools/0xabfeac41f0b0798e67e24557004eea1b1f18f973ea40689425267794ce88f35c.json
@@ -990,6 +990,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1017,6 +1018,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1288,6 +1290,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -1458,6 +1461,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -1485,6 +1489,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -1696,6 +1701,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2057,6 +2063,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2261,6 +2268,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2695,6 +2703,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2790,6 +2799,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2824,6 +2834,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2900,6 +2911,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3002,6 +3014,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3275,6 +3288,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -3302,6 +3316,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3363,6 +3378,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3505,6 +3521,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3871,6 +3888,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -4231,6 +4249,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4916,6 +4935,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -5086,6 +5106,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5188,6 +5209,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5269,6 +5291,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5608,6 +5631,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5826,6 +5850,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5895,6 +5920,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5949,6 +5975,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6118,6 +6145,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6199,6 +6227,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6335,6 +6364,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6504,6 +6534,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6755,6 +6786,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -7224,6 +7256,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7769,6 +7802,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7850,6 +7884,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8026,6 +8061,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8189,6 +8225,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8324,6 +8361,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8447,6 +8485,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8488,6 +8527,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8657,6 +8697,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -9030,6 +9071,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9343,6 +9385,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9493,6 +9536,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9758,6 +9802,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10043,6 +10088,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10138,6 +10184,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11231,6 +11278,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11360,6 +11408,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11468,6 +11517,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11549,6 +11599,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11822,6 +11873,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11849,6 +11901,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12510,6 +12563,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12848,6 +12902,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13133,6 +13188,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13377,6 +13433,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13588,6 +13645,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13615,6 +13673,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13663,6 +13722,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13731,6 +13791,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14051,6 +14112,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14222,6 +14284,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14290,6 +14353,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14351,6 +14415,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14392,6 +14457,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14488,6 +14554,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14867,6 +14934,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15037,6 +15105,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15064,6 +15133,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15133,6 +15203,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15390,6 +15461,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15540,6 +15612,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15648,6 +15721,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15729,6 +15803,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15925,6 +16000,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16224,6 +16300,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16293,6 +16370,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16692,6 +16770,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17323,6 +17402,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17513,6 +17593,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17750,6 +17831,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17819,6 +17901,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18022,6 +18105,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18307,6 +18391,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18708,6 +18793,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18891,6 +18977,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18945,6 +19032,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19149,6 +19237,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19991,6 +20080,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20072,6 +20162,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20099,6 +20190,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20187,6 +20279,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20437,6 +20530,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21074,6 +21168,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21687,6 +21782,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22185,6 +22281,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22584,6 +22681,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23133,6 +23231,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -23160,6 +23259,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -23201,6 +23301,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -23371,6 +23472,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23982,6 +24084,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24118,6 +24221,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -24274,6 +24378,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24687,6 +24792,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24795,6 +24901,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25446,6 +25553,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25487,6 +25595,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26120,6 +26229,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26581,6 +26691,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26927,6 +27038,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26954,6 +27066,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +27571,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27647,6 +27761,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27728,6 +27843,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27790,6 +27906,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27859,6 +27976,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -28055,6 +28173,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28266,6 +28385,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -28293,6 +28413,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28705,6 +28826,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28732,6 +28854,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28807,6 +28930,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28996,6 +29120,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -29138,6 +29263,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29504,6 +29630,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29788,6 +29915,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30008,6 +30136,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30157,6 +30286,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30753,6 +30883,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31133,6 +31264,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31349,6 +31481,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31993,6 +32126,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32250,6 +32384,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32305,6 +32440,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32440,6 +32576,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32747,6 +32884,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32842,6 +32980,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32985,6 +33124,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33343,6 +33483,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33559,6 +33700,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33818,6 +33960,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -34055,6 +34198,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34136,6 +34280,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34232,6 +34377,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34307,6 +34453,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34382,6 +34529,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34409,6 +34557,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34552,6 +34701,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34694,6 +34844,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34721,6 +34872,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35250,6 +35402,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35570,6 +35723,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35597,6 +35751,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35651,6 +35806,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35888,6 +36044,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35915,6 +36072,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35963,6 +36121,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36668,6 +36827,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37227,6 +37387,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37254,6 +37415,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37383,6 +37545,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37837,6 +38000,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38428,6 +38592,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38618,6 +38783,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38910,6 +39076,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38951,6 +39118,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39019,6 +39187,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39189,6 +39358,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39270,6 +39440,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39466,6 +39637,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39676,6 +39848,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39934,6 +40107,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40470,6 +40644,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40647,6 +40822,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40789,6 +40965,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xac60bc1f5ff0fb9a1c981991c9b355c38c65e53f79e3d8d15ee66830910c4ba1.json
+++ b/test/testData/testPools/0xac60bc1f5ff0fb9a1c981991c9b355c38c65e53f79e3d8d15ee66830910c4ba1.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xaf03fbdfd91af3130114164107078f46cdd606c51dc1b8e1fe044648990b4b6e.json
+++ b/test/testData/testPools/0xaf03fbdfd91af3130114164107078f46cdd606c51dc1b8e1fe044648990b4b6e.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xb0fc4e5d34ceaa323482df5bc0954799799cd88fe90d780aa0c1e759005e84b8.json
+++ b/test/testData/testPools/0xb0fc4e5d34ceaa323482df5bc0954799799cd88fe90d780aa0c1e759005e84b8.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -94,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -169,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -196,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -230,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -257,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -284,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -311,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -338,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -365,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -392,6 +405,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -419,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -467,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -508,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -535,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -562,6 +580,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +608,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -616,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -643,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -691,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -718,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -745,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -800,6 +825,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -848,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -875,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -902,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -929,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -956,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -997,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1024,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1065,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1092,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1161,6 +1196,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1230,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1257,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1284,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1311,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1338,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1365,6 +1406,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1392,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1419,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1467,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1494,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1542,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1569,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1596,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1623,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1664,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1691,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1718,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1745,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1772,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1799,6 +1854,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1826,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1867,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1894,6 +1952,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1987,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -1976,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2004,6 +2065,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2051,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2169,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2168,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2216,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2243,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2270,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2325,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2352,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2379,6 +2449,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2477,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2440,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2467,6 +2540,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2494,6 +2569,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2528,6 +2604,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2555,6 +2632,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2582,6 +2660,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2609,6 +2688,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2657,6 +2737,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2684,6 +2765,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2718,6 +2800,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2745,6 +2828,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2772,6 +2856,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2799,6 +2884,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2826,6 +2912,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2860,6 +2947,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2887,6 +2975,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2914,6 +3003,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2941,6 +3031,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -2975,6 +3066,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3044,6 +3136,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3078,6 +3171,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3105,6 +3199,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3132,6 +3227,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3159,6 +3255,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3200,6 +3297,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3227,6 +3325,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3254,6 +3353,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3281,6 +3381,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3308,6 +3409,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3335,6 +3437,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3376,6 +3479,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3424,6 +3528,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3451,6 +3556,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3478,6 +3584,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3505,6 +3612,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3532,6 +3640,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3601,6 +3710,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3628,6 +3738,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3655,6 +3766,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3682,6 +3794,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3709,6 +3822,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3736,6 +3850,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3763,6 +3878,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3790,6 +3906,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3824,6 +3941,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3851,6 +3969,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3878,6 +3997,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3905,6 +4025,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3939,6 +4060,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3966,6 +4088,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -3993,6 +4116,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4020,6 +4144,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4047,6 +4172,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4088,6 +4214,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4115,6 +4242,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4163,6 +4291,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4190,6 +4319,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4238,6 +4368,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4265,6 +4396,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4292,6 +4424,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4319,6 +4452,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4346,6 +4480,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4373,6 +4508,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4428,6 +4564,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4469,6 +4606,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4496,6 +4634,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4523,6 +4662,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4550,6 +4690,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4577,6 +4718,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4604,6 +4746,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4774,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4658,6 +4802,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4685,6 +4830,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4712,6 +4858,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4739,6 +4886,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4808,6 +4956,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4835,6 +4984,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4862,6 +5012,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4889,6 +5040,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -4930,6 +5082,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5152,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5026,6 +5180,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5053,6 +5208,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5080,6 +5236,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5114,6 +5271,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5141,6 +5299,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5168,6 +5327,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5195,6 +5355,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5222,6 +5383,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5249,6 +5411,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5276,6 +5439,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5303,6 +5467,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5495,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5357,6 +5523,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5412,6 +5579,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5439,6 +5607,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5473,6 +5642,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5500,6 +5670,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5527,6 +5698,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5554,6 +5726,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5581,6 +5754,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5608,6 +5782,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5635,6 +5810,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5669,6 +5845,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5696,6 +5873,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5723,6 +5901,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5778,6 +5957,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5805,6 +5985,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5832,6 +6013,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5859,6 +6041,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -5886,6 +6070,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5913,6 +6098,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5940,6 +6126,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5967,6 +6154,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5994,6 +6182,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6021,6 +6210,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6069,6 +6259,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6096,6 +6287,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6137,6 +6329,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6185,6 +6378,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6212,6 +6406,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6239,6 +6434,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6294,6 +6490,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6328,6 +6525,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6369,6 +6567,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6438,6 +6637,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6465,6 +6665,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6499,6 +6700,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6526,6 +6728,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6553,6 +6756,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6580,6 +6784,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6607,6 +6812,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6634,6 +6840,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6661,6 +6868,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6688,6 +6896,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6750,6 +6959,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6819,6 +7029,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6846,6 +7057,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6873,6 +7085,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6900,6 +7113,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6927,6 +7141,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6954,6 +7169,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -6988,6 +7204,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7015,6 +7232,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7042,6 +7260,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7069,6 +7288,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7103,6 +7323,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7130,6 +7351,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7157,6 +7379,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7184,6 +7407,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7239,6 +7463,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7266,6 +7491,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7293,6 +7519,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7320,6 +7547,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7347,6 +7575,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7374,6 +7603,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7401,6 +7631,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7428,6 +7659,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7455,6 +7687,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7482,6 +7715,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7551,6 +7785,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7827,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7855,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7646,6 +7883,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7673,6 +7911,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7700,6 +7939,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7727,6 +7967,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7761,6 +8002,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7788,6 +8030,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7822,6 +8065,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7849,6 +8093,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7876,6 +8121,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7924,6 +8170,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7951,6 +8198,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -7978,6 +8226,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8005,6 +8254,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8032,6 +8282,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8059,6 +8310,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8086,6 +8338,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8134,6 +8387,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8161,6 +8416,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8188,6 +8444,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8222,6 +8479,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8249,6 +8507,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8276,6 +8535,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8317,6 +8577,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8344,6 +8605,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8378,6 +8640,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8447,6 +8710,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8474,6 +8738,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8501,6 +8766,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8528,6 +8794,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8597,6 +8864,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8624,6 +8892,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8651,6 +8920,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8678,6 +8948,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8712,6 +8983,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8739,6 +9011,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8787,6 +9060,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8835,6 +9109,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8862,6 +9137,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +9165,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8916,6 +9193,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8943,6 +9221,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -8970,6 +9249,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8997,6 +9277,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9066,6 +9347,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9093,6 +9375,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9120,6 +9403,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9147,6 +9431,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9174,6 +9459,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9215,6 +9501,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9242,6 +9529,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -9311,6 +9599,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9359,6 +9648,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9386,6 +9676,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9455,6 +9746,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9503,6 +9795,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9530,6 +9823,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9557,6 +9851,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9584,6 +9879,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9611,6 +9907,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9638,6 +9935,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9665,6 +9963,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9692,6 +9991,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9719,6 +10019,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9746,6 +10047,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9773,6 +10075,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9800,6 +10103,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9827,6 +10131,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9854,6 +10159,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9881,6 +10187,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9908,6 +10215,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9935,6 +10243,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -9962,6 +10271,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10003,6 +10313,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10030,6 +10341,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10057,6 +10369,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10112,6 +10425,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10139,6 +10453,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10166,6 +10481,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10200,6 +10516,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10227,6 +10544,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10254,6 +10572,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10281,6 +10600,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10308,6 +10628,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10335,6 +10656,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10362,6 +10684,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10389,6 +10712,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10437,6 +10761,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10464,6 +10789,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10491,6 +10817,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10518,6 +10845,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10545,6 +10873,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10572,6 +10901,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10599,6 +10929,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10626,6 +10957,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10653,6 +10985,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10715,6 +11048,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10742,6 +11076,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10769,6 +11104,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10796,6 +11132,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10865,6 +11202,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10899,6 +11237,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -10926,6 +11265,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11293,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -10980,6 +11321,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11007,6 +11349,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11055,6 +11398,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11082,6 +11426,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11130,6 +11475,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11157,6 +11503,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11184,6 +11531,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11246,6 +11594,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11287,6 +11636,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11314,6 +11664,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11341,6 +11692,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11368,6 +11720,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11395,6 +11748,7 @@
         {
             "id": "0x4b3fa856cef9aa85ed9bbfa8992d6138c5f150e6",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -11464,6 +11818,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11533,6 +11888,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11560,6 +11916,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11587,6 +11944,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11614,6 +11972,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11648,6 +12007,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11682,6 +12042,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11709,6 +12070,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11736,6 +12098,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11763,6 +12126,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11790,6 +12154,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11817,6 +12182,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11844,6 +12210,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11871,6 +12238,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11898,6 +12266,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11925,6 +12294,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11952,6 +12322,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -11979,6 +12350,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12006,6 +12378,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12033,6 +12406,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12060,6 +12434,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12122,6 +12497,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12156,6 +12532,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12183,6 +12560,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12210,6 +12588,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12237,6 +12616,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12264,6 +12644,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12319,6 +12700,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12346,6 +12728,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12373,6 +12756,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12400,6 +12784,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12427,6 +12812,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12454,6 +12840,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12481,6 +12868,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12508,6 +12896,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12577,6 +12966,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12604,6 +12994,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12631,6 +13022,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12665,6 +13057,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12692,6 +13085,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +13113,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +13162,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12794,6 +13190,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +13232,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12890,6 +13288,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12924,6 +13323,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12993,6 +13393,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13020,6 +13421,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13047,6 +13449,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13074,6 +13477,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13101,6 +13505,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13128,6 +13533,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13155,6 +13561,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13182,6 +13589,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13209,6 +13617,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13257,6 +13666,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13326,6 +13736,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13353,6 +13764,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13394,6 +13806,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13421,6 +13834,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13455,6 +13869,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13911,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13565,6 +13981,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13592,6 +14009,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13619,6 +14037,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13646,6 +14065,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13673,6 +14093,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13728,6 +14149,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13755,6 +14177,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13782,6 +14205,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13809,6 +14233,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13836,6 +14261,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13863,6 +14289,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13890,6 +14317,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13917,6 +14345,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13944,6 +14373,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -13971,6 +14401,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14033,6 +14464,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14060,6 +14492,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14087,6 +14520,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14114,6 +14548,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14141,6 +14576,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14604,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14674,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14264,6 +14702,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14291,6 +14730,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14318,6 +14758,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14345,6 +14786,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14386,6 +14828,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14413,6 +14856,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14440,6 +14884,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14467,6 +14912,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14494,6 +14940,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14521,6 +14968,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14548,6 +14996,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14575,6 +15024,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14644,6 +15094,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14671,6 +15122,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14698,6 +15150,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14725,6 +15178,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14752,6 +15206,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14779,6 +15234,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14806,6 +15262,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14833,6 +15290,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14867,6 +15325,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14894,6 +15353,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14921,6 +15381,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14948,6 +15409,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14975,6 +15437,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15002,6 +15465,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15029,6 +15493,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15056,6 +15521,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15125,6 +15591,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15152,6 +15619,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15179,6 +15647,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15206,6 +15675,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15233,6 +15703,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15260,6 +15731,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15287,6 +15759,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15328,6 +15801,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15871,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15424,6 +15899,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15451,6 +15927,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15478,6 +15955,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15505,6 +15983,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15532,6 +16011,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15573,6 +16053,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15600,6 +16081,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15627,6 +16109,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15654,6 +16137,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15681,6 +16165,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15715,6 +16200,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15742,6 +16228,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15769,6 +16256,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15796,6 +16284,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -15865,6 +16354,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15892,6 +16382,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15919,6 +16410,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15946,6 +16438,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15973,6 +16466,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16000,6 +16494,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16027,6 +16522,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16054,6 +16550,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16081,6 +16578,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16108,6 +16606,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16135,6 +16634,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16176,6 +16676,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16203,6 +16704,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16230,6 +16732,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16292,6 +16795,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16319,6 +16823,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16346,6 +16851,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16373,6 +16879,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16400,6 +16907,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16427,6 +16935,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16454,6 +16963,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16481,6 +16991,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16508,6 +17019,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16535,6 +17047,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16562,6 +17075,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16617,6 +17131,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16651,6 +17166,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16678,6 +17194,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16705,6 +17222,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16732,6 +17250,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16759,6 +17278,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16786,6 +17306,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16813,6 +17334,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16854,6 +17376,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17446,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -16957,6 +17481,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16984,6 +17509,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17011,6 +17537,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17038,6 +17565,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17065,6 +17593,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17099,6 +17628,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17126,6 +17656,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17153,6 +17684,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17222,6 +17754,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17249,6 +17782,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17276,6 +17810,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17303,6 +17838,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17330,6 +17866,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17357,6 +17894,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17384,6 +17922,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17411,6 +17950,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17473,6 +18013,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17500,6 +18041,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17527,6 +18069,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17554,6 +18097,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17581,6 +18125,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17629,6 +18174,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17670,6 +18216,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17697,6 +18244,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17724,6 +18272,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17758,6 +18307,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17785,6 +18335,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17812,6 +18363,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17853,6 +18405,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17880,6 +18433,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17914,6 +18468,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17941,6 +18496,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17968,6 +18524,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17995,6 +18552,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18022,6 +18580,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18049,6 +18608,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18076,6 +18636,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18145,6 +18706,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18172,6 +18734,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18199,6 +18762,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18226,6 +18790,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18253,6 +18818,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -18280,6 +18846,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18349,6 +18916,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18376,6 +18944,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18445,6 +19014,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18472,6 +19042,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18499,6 +19070,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18526,6 +19098,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18553,6 +19126,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18580,6 +19154,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18607,6 +19182,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18641,6 +19217,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18675,6 +19252,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18702,6 +19280,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18729,6 +19308,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18784,6 +19364,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18811,6 +19392,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18838,6 +19420,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18865,6 +19448,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18899,6 +19483,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18926,6 +19511,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18953,6 +19539,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18980,6 +19567,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19007,6 +19595,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19041,6 +19630,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19068,6 +19658,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19095,6 +19686,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19122,6 +19714,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19149,6 +19742,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19176,6 +19770,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19798,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19230,6 +19826,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19264,6 +19861,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19291,6 +19889,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19318,6 +19917,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19345,6 +19945,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19372,6 +19973,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19399,6 +20001,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19433,6 +20036,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19460,6 +20064,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19487,6 +20092,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19514,6 +20120,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19541,6 +20148,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -19568,6 +20176,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19595,6 +20204,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19622,6 +20232,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19670,6 +20281,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19697,6 +20309,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19724,6 +20337,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19751,6 +20365,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19778,6 +20393,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19805,6 +20421,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19832,6 +20449,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19859,6 +20477,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19886,6 +20505,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -19955,6 +20575,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19982,6 +20603,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20009,6 +20631,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20036,6 +20659,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20070,6 +20694,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20097,6 +20722,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20124,6 +20750,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20151,6 +20778,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20178,6 +20806,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20219,6 +20848,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20246,6 +20876,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20287,6 +20918,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20314,6 +20946,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20383,6 +21016,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20445,6 +21079,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20472,6 +21107,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20541,6 +21177,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20568,6 +21205,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20595,6 +21233,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20622,6 +21261,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20649,6 +21289,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20676,6 +21317,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20703,6 +21345,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20730,6 +21373,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20764,6 +21408,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20791,6 +21436,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -20853,6 +21499,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20880,6 +21527,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20907,6 +21555,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -20941,6 +21590,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20975,6 +21625,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21016,6 +21667,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21071,6 +21723,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21098,6 +21751,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21125,6 +21779,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21194,6 +21849,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21221,6 +21877,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21262,6 +21919,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21289,6 +21947,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21316,6 +21975,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21343,6 +22003,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21370,6 +22031,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21404,6 +22066,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21431,6 +22094,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21458,6 +22122,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21485,6 +22150,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21512,6 +22178,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21539,6 +22206,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21580,6 +22248,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21607,6 +22276,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21634,6 +22304,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21661,6 +22332,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21688,6 +22360,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -21736,6 +22409,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21763,6 +22437,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21790,6 +22465,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21817,6 +22493,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21844,6 +22521,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21871,6 +22549,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21919,6 +22598,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -21953,6 +22633,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21980,6 +22661,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22007,6 +22689,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22034,6 +22717,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22061,6 +22745,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22088,6 +22773,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22115,6 +22801,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22156,6 +22843,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22183,6 +22871,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22210,6 +22899,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22237,6 +22927,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22955,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22997,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22346,6 +23039,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22387,6 +23081,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22414,6 +23109,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22448,6 +23144,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22475,6 +23172,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -22502,6 +23200,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22529,6 +23228,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22556,6 +23256,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22604,6 +23305,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22645,6 +23347,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22672,6 +23375,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22699,6 +23403,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22768,6 +23473,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22802,6 +23508,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22829,6 +23536,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22863,6 +23571,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22897,6 +23606,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22924,6 +23634,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22951,6 +23662,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -22978,6 +23690,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23005,6 +23718,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23032,6 +23746,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23059,6 +23774,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23086,6 +23802,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23113,6 +23830,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23140,6 +23858,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23195,6 +23914,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23222,6 +23942,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23256,6 +23977,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23283,6 +24005,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23310,6 +24033,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23351,6 +24075,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23378,6 +24103,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23405,6 +24131,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23432,6 +24159,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23459,6 +24187,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23486,6 +24215,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23520,6 +24250,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23547,6 +24278,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23581,6 +24313,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23608,6 +24341,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23656,6 +24390,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23683,6 +24418,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23710,6 +24446,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23737,6 +24474,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23764,6 +24502,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23791,6 +24530,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23818,6 +24558,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23845,6 +24586,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23872,6 +24614,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23899,6 +24642,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -23926,6 +24670,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -23953,6 +24698,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24001,6 +24747,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24049,6 +24796,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24076,6 +24824,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24103,6 +24852,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24130,6 +24880,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24157,6 +24908,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24184,6 +24936,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24211,6 +24964,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24238,6 +24992,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24265,6 +25020,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24292,6 +25048,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24319,6 +25076,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24346,6 +25104,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24373,6 +25132,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24407,6 +25167,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24469,6 +25230,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24496,6 +25258,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24523,6 +25286,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24550,6 +25314,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +25356,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -24660,6 +25426,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24729,6 +25496,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24756,6 +25524,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24783,6 +25552,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24852,6 +25622,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24879,6 +25650,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24906,6 +25678,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24933,6 +25706,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -24967,6 +25741,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25008,6 +25783,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25035,6 +25811,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25062,6 +25839,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25089,6 +25867,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25116,6 +25895,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25143,6 +25923,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25170,6 +25951,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25197,6 +25979,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25224,6 +26007,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25265,6 +26049,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25292,6 +26077,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25319,6 +26105,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25353,6 +26140,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25380,6 +26168,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25428,6 +26217,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25462,6 +26252,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25489,6 +26280,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25516,6 +26308,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25543,6 +26336,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25570,6 +26364,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25597,6 +26392,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25624,6 +26420,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25651,6 +26448,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25685,6 +26483,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25712,6 +26511,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25739,6 +26539,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25773,6 +26574,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25800,6 +26602,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25827,6 +26630,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25875,6 +26679,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25902,6 +26707,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -25929,6 +26735,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25956,6 +26763,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25990,6 +26798,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26031,6 +26840,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26868,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26085,6 +26896,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26112,6 +26924,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26174,6 +26987,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26201,6 +27015,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26228,6 +27043,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26255,6 +27071,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26282,6 +27099,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26309,6 +27127,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26336,6 +27155,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26370,6 +27190,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26397,6 +27218,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26466,6 +27288,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26493,6 +27316,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26562,6 +27386,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26589,6 +27414,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26616,6 +27442,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26643,6 +27470,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26670,6 +27498,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26697,6 +27526,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26724,6 +27554,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26751,6 +27582,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26778,6 +27610,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26805,6 +27638,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26832,6 +27666,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27729,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27799,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -26990,6 +27827,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27017,6 +27855,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27044,6 +27883,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27071,6 +27911,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27105,6 +27946,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27132,6 +27974,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27159,6 +28002,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27207,6 +28051,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27234,6 +28079,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27275,6 +28121,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27302,6 +28149,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27343,6 +28191,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27370,6 +28219,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +28247,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27431,6 +28282,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +28310,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27485,6 +28338,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27512,6 +28366,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27539,6 +28394,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27566,6 +28422,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27593,6 +28450,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27620,6 +28478,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27647,6 +28506,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27674,6 +28534,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27701,6 +28562,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27728,6 +28590,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27755,6 +28618,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27782,6 +28646,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27809,6 +28674,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +28702,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27884,6 +28751,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -27911,6 +28779,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27938,6 +28807,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -27965,6 +28835,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -27992,6 +28863,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28019,6 +28891,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28046,6 +28919,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28073,6 +28947,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28100,6 +28975,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28127,6 +29003,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28154,6 +29031,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28181,6 +29059,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28215,6 +29094,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28242,6 +29122,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28269,6 +29150,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28296,6 +29178,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28323,6 +29206,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28392,6 +29276,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28419,6 +29304,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28446,6 +29332,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28473,6 +29360,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28500,6 +29388,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28527,6 +29416,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28554,6 +29444,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28581,6 +29472,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28608,6 +29500,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28635,6 +29528,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28662,6 +29556,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28689,6 +29584,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28723,6 +29619,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28750,6 +29647,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28784,6 +29682,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28811,6 +29710,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28838,6 +29738,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28865,6 +29766,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -28892,6 +29794,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28947,6 +29850,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28974,6 +29878,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29043,6 +29948,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29112,6 +30018,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29139,6 +30046,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29166,6 +30074,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29193,6 +30102,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29220,6 +30130,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29261,6 +30172,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29288,6 +30200,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29315,6 +30228,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29370,6 +30284,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29397,6 +30312,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29424,6 +30340,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29451,6 +30368,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29492,6 +30410,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29519,6 +30438,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29553,6 +30473,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29580,6 +30501,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29607,6 +30529,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29634,6 +30557,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29661,6 +30585,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29695,6 +30620,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29722,6 +30648,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29749,6 +30676,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29776,6 +30704,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29803,6 +30732,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29830,6 +30760,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29857,6 +30788,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29926,6 +30858,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -29953,6 +30886,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -29980,6 +30914,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30007,6 +30942,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30034,6 +30970,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30061,6 +30998,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30088,6 +31026,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30115,6 +31054,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30156,6 +31096,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30183,6 +31124,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30210,6 +31152,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30237,6 +31180,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30264,6 +31208,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30291,6 +31236,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30318,6 +31264,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30345,6 +31292,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30372,6 +31320,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30399,6 +31348,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30426,6 +31376,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30453,6 +31404,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -30480,6 +31432,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30507,6 +31460,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30541,6 +31495,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30603,6 +31558,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30630,6 +31586,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30657,6 +31614,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30684,6 +31642,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30711,6 +31670,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30738,6 +31698,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30765,6 +31726,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30792,6 +31754,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30819,6 +31782,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30874,6 +31838,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -30901,6 +31866,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30928,6 +31894,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30955,6 +31922,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -30982,6 +31950,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31009,6 +31978,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31043,6 +32013,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31070,6 +32041,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31097,6 +32069,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31124,6 +32097,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31151,6 +32125,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31178,6 +32153,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31205,6 +32181,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31232,6 +32209,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31259,6 +32237,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31286,6 +32265,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31313,6 +32293,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31354,6 +32335,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +32391,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31436,6 +32419,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31463,6 +32447,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31490,6 +32475,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31517,6 +32503,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31544,6 +32531,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31571,6 +32559,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31598,6 +32587,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31653,6 +32643,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31680,6 +32671,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31707,6 +32699,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31762,6 +32755,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31796,6 +32790,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31851,6 +32846,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31885,6 +32881,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31912,6 +32909,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -31946,6 +32944,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31994,6 +32993,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32035,6 +33035,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32062,6 +33063,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32089,6 +33091,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32116,6 +33119,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32143,6 +33147,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32170,6 +33175,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32204,6 +33210,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32231,6 +33238,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32258,6 +33266,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32285,6 +33294,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32312,6 +33322,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32339,6 +33350,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32366,6 +33378,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32393,6 +33406,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32420,6 +33434,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32447,6 +33462,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32474,6 +33490,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32501,6 +33518,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32528,6 +33546,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32555,6 +33574,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32582,6 +33602,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32609,6 +33630,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32636,6 +33658,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32663,6 +33686,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32690,6 +33714,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32738,6 +33763,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32779,6 +33805,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32806,6 +33833,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32833,6 +33861,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32860,6 +33889,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32922,6 +33952,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -32949,6 +33980,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -32976,6 +34008,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33003,6 +34036,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33037,6 +34071,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33064,6 +34099,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33091,6 +34127,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33132,6 +34169,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33159,6 +34197,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33186,6 +34225,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33213,6 +34253,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33240,6 +34281,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33309,6 +34351,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33336,6 +34379,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33384,6 +34428,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33411,6 +34456,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33459,6 +34505,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +34533,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +34562,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33547,6 +34597,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33588,6 +34639,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33629,6 +34681,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33656,6 +34709,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33683,6 +34737,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33710,6 +34765,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33744,6 +34800,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33771,6 +34828,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33798,6 +34856,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +34884,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -33852,6 +34912,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -33879,6 +34940,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -33906,6 +34968,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33933,6 +34996,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33960,6 +35024,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -33987,6 +35052,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34028,6 +35094,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34055,6 +35122,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34124,6 +35192,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34151,6 +35220,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34178,6 +35248,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34205,6 +35276,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34232,6 +35304,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34259,6 +35332,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34293,6 +35367,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34327,6 +35402,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34354,6 +35430,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34423,6 +35500,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34450,6 +35528,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34477,6 +35556,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34504,6 +35584,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +35612,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34558,6 +35640,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34613,6 +35696,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34640,6 +35724,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34674,6 +35759,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +35787,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34728,6 +35815,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34755,6 +35843,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34782,6 +35871,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34809,6 +35899,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34836,6 +35927,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -34863,6 +35955,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -34911,6 +36004,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34938,6 +36032,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34965,6 +36060,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34992,6 +36088,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +36116,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +36165,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35094,6 +36193,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35121,6 +36221,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35148,6 +36249,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35175,6 +36277,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35202,6 +36305,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35229,6 +36333,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35256,6 +36361,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35283,6 +36389,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35310,6 +36417,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35337,6 +36445,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35399,6 +36508,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35447,6 +36557,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35474,6 +36585,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35501,6 +36613,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35528,6 +36641,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35555,6 +36669,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35589,6 +36704,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35616,6 +36732,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35643,6 +36760,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35670,6 +36788,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35697,6 +36816,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35745,6 +36865,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35772,6 +36893,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -35799,6 +36921,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35826,6 +36949,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -35853,6 +36977,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35887,6 +37012,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -35914,6 +37040,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -35983,6 +37110,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36031,6 +37159,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36086,6 +37215,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36127,6 +37257,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36154,6 +37285,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36223,6 +37355,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36250,6 +37383,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36277,6 +37411,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36304,6 +37439,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36331,6 +37467,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +37495,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36406,6 +37544,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36433,6 +37572,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36460,6 +37600,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36487,6 +37628,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36556,6 +37698,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36583,6 +37726,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36610,6 +37754,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36637,6 +37782,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36664,6 +37810,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36691,6 +37838,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36718,6 +37866,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36745,6 +37894,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36772,6 +37922,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36799,6 +37950,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36826,6 +37978,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -36860,6 +38013,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -36887,6 +38041,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -36914,6 +38069,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36941,6 +38097,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -36968,6 +38125,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -36995,6 +38153,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37022,6 +38181,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37077,6 +38237,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37104,6 +38265,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37159,6 +38321,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37186,6 +38349,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37213,6 +38377,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37261,6 +38426,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37288,6 +38454,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37315,6 +38482,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37342,6 +38510,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37383,6 +38552,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37410,6 +38580,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37444,6 +38615,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37471,6 +38643,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37505,6 +38678,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37532,6 +38706,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37559,6 +38734,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37586,6 +38762,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37613,6 +38790,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37661,6 +38839,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37695,6 +38874,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37722,6 +38902,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -37756,6 +38937,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37783,6 +38965,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37810,6 +38993,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -37858,6 +39042,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37885,6 +39070,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37912,6 +39098,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -37960,6 +39147,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -37987,6 +39175,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38014,6 +39203,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +39245,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38096,6 +39287,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38123,6 +39315,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38150,6 +39343,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38177,6 +39371,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38225,6 +39420,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38252,6 +39448,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38293,6 +39490,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38320,6 +39518,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38347,6 +39546,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38374,6 +39574,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38401,6 +39602,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38428,6 +39630,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38455,6 +39658,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38482,6 +39686,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38509,6 +39714,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38536,6 +39742,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38570,6 +39777,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38597,6 +39805,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38624,6 +39833,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38672,6 +39882,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38699,6 +39910,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38726,6 +39938,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38753,6 +39966,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38780,6 +39994,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -38807,6 +40022,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -38834,6 +40050,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -38861,6 +40078,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -38888,6 +40106,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38957,6 +40176,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38984,6 +40204,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39011,6 +40232,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39038,6 +40260,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39086,6 +40309,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39113,6 +40337,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39147,6 +40372,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39181,6 +40407,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39215,6 +40442,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39242,6 +40470,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39269,6 +40498,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39296,6 +40526,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39330,6 +40561,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39357,6 +40589,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39384,6 +40617,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39411,6 +40645,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39445,6 +40680,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39479,6 +40715,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39506,6 +40743,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39533,6 +40771,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39574,6 +40813,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39643,6 +40883,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39670,6 +40911,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39697,6 +40939,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39724,6 +40967,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39751,6 +40995,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39778,6 +41023,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39805,6 +41051,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39839,6 +41086,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39866,6 +41114,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -39893,6 +41142,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39962,6 +41212,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -39989,6 +41240,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40016,6 +41268,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40043,6 +41296,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40112,6 +41366,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0xb0fc4e5d34ceaa323482df5bc0954799799cd88fe90d780aa0c1e759005e84b8.json
+++ b/test/testData/testPools/0xb0fc4e5d34ceaa323482df5bc0954799799cd88fe90d780aa0c1e759005e84b8.json
@@ -2541,7 +2541,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6042,7 +6041,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8387,7 +8385,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -34533,7 +34530,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0xb48d49d52b1925f06c9a3b59c026fa8c9d1951ce583592ecc749c35cd6d83172.json
+++ b/test/testData/testPools/0xb48d49d52b1925f06c9a3b59c026fa8c9d1951ce583592ecc749c35cd6d83172.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -94,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -169,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -196,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -230,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -257,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -284,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -311,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -338,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -365,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -392,6 +405,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -419,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -467,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -508,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -535,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -562,6 +580,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +608,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -616,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -643,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -691,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -718,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -745,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -800,6 +825,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -848,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -875,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -902,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -929,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -956,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -997,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1024,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1065,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1092,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1161,6 +1196,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1230,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1257,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1284,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1311,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1338,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1365,6 +1406,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1392,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1419,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1467,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1494,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1542,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1569,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1596,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1623,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1664,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1691,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1718,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1745,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1772,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1799,6 +1854,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1826,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1867,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1894,6 +1952,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1987,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -1976,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2004,6 +2065,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2051,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2169,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2168,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2216,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2243,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2270,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2325,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2352,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2379,6 +2449,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2477,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2440,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2467,6 +2540,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2494,6 +2569,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2528,6 +2604,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2555,6 +2632,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2582,6 +2660,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2609,6 +2688,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2657,6 +2737,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2684,6 +2765,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2718,6 +2800,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2745,6 +2828,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2772,6 +2856,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2799,6 +2884,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2826,6 +2912,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2860,6 +2947,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2887,6 +2975,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2914,6 +3003,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2941,6 +3031,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -2975,6 +3066,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3044,6 +3136,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3078,6 +3171,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3105,6 +3199,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3132,6 +3227,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3159,6 +3255,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3200,6 +3297,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3227,6 +3325,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3254,6 +3353,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3281,6 +3381,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3308,6 +3409,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3335,6 +3437,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3376,6 +3479,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3424,6 +3528,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3451,6 +3556,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3478,6 +3584,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3505,6 +3612,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3532,6 +3640,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3601,6 +3710,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3628,6 +3738,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3655,6 +3766,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3682,6 +3794,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3709,6 +3822,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3736,6 +3850,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3763,6 +3878,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3790,6 +3906,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3824,6 +3941,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3851,6 +3969,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3878,6 +3997,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3905,6 +4025,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3939,6 +4060,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3966,6 +4088,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -3993,6 +4116,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4020,6 +4144,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4047,6 +4172,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4088,6 +4214,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4115,6 +4242,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4163,6 +4291,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4190,6 +4319,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4238,6 +4368,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4265,6 +4396,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4292,6 +4424,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4319,6 +4452,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4346,6 +4480,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4373,6 +4508,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4428,6 +4564,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4469,6 +4606,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4496,6 +4634,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4523,6 +4662,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4550,6 +4690,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4577,6 +4718,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4604,6 +4746,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4774,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4658,6 +4802,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4685,6 +4830,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4712,6 +4858,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4739,6 +4886,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4808,6 +4956,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4835,6 +4984,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4862,6 +5012,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4889,6 +5040,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -4930,6 +5082,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5152,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5026,6 +5180,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5053,6 +5208,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5080,6 +5236,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5114,6 +5271,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5141,6 +5299,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5168,6 +5327,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5195,6 +5355,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5222,6 +5383,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5249,6 +5411,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5276,6 +5439,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5303,6 +5467,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5495,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5357,6 +5523,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5412,6 +5579,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5439,6 +5607,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5473,6 +5642,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5500,6 +5670,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5527,6 +5698,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5554,6 +5726,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5581,6 +5754,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5608,6 +5782,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5635,6 +5810,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5669,6 +5845,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5696,6 +5873,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5723,6 +5901,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5778,6 +5957,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5805,6 +5985,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5832,6 +6013,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5859,6 +6041,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -5886,6 +6070,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5913,6 +6098,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5940,6 +6126,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5967,6 +6154,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5994,6 +6182,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6021,6 +6210,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6069,6 +6259,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6096,6 +6287,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6137,6 +6329,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6185,6 +6378,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6212,6 +6406,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6239,6 +6434,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6294,6 +6490,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6328,6 +6525,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6369,6 +6567,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6438,6 +6637,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6465,6 +6665,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6499,6 +6700,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6526,6 +6728,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6553,6 +6756,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6580,6 +6784,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6607,6 +6812,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6634,6 +6840,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6661,6 +6868,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6688,6 +6896,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6750,6 +6959,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6819,6 +7029,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6846,6 +7057,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6873,6 +7085,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6900,6 +7113,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6927,6 +7141,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6954,6 +7169,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -6988,6 +7204,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7015,6 +7232,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7042,6 +7260,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7069,6 +7288,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7103,6 +7323,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7130,6 +7351,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7157,6 +7379,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7184,6 +7407,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7239,6 +7463,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7266,6 +7491,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7293,6 +7519,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7320,6 +7547,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7347,6 +7575,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7374,6 +7603,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7401,6 +7631,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7428,6 +7659,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7455,6 +7687,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7482,6 +7715,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7551,6 +7785,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7827,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7855,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7646,6 +7883,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7673,6 +7911,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7700,6 +7939,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7727,6 +7967,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7761,6 +8002,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7788,6 +8030,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7822,6 +8065,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7849,6 +8093,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7876,6 +8121,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7924,6 +8170,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7951,6 +8198,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -7978,6 +8226,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8005,6 +8254,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8032,6 +8282,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8059,6 +8310,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8086,6 +8338,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8134,6 +8387,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8161,6 +8416,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8188,6 +8444,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8222,6 +8479,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8249,6 +8507,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8276,6 +8535,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8317,6 +8577,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8344,6 +8605,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8378,6 +8640,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8447,6 +8710,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8474,6 +8738,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8501,6 +8766,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8528,6 +8794,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8597,6 +8864,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8624,6 +8892,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8651,6 +8920,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8678,6 +8948,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8712,6 +8983,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8739,6 +9011,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8787,6 +9060,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8835,6 +9109,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8862,6 +9137,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +9165,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8916,6 +9193,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8943,6 +9221,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -8970,6 +9249,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8997,6 +9277,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9066,6 +9347,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9093,6 +9375,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9120,6 +9403,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9147,6 +9431,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9174,6 +9459,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9215,6 +9501,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9242,6 +9529,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -9311,6 +9599,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9359,6 +9648,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9386,6 +9676,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9455,6 +9746,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9503,6 +9795,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9530,6 +9823,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9557,6 +9851,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9584,6 +9879,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9611,6 +9907,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9638,6 +9935,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9665,6 +9963,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9692,6 +9991,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9719,6 +10019,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9746,6 +10047,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9773,6 +10075,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9800,6 +10103,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9827,6 +10131,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9854,6 +10159,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9881,6 +10187,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9908,6 +10215,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9935,6 +10243,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -9962,6 +10271,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10003,6 +10313,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10030,6 +10341,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10057,6 +10369,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10112,6 +10425,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10139,6 +10453,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10166,6 +10481,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10200,6 +10516,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10227,6 +10544,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10254,6 +10572,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10281,6 +10600,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10308,6 +10628,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10335,6 +10656,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10362,6 +10684,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10389,6 +10712,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10437,6 +10761,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10464,6 +10789,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10491,6 +10817,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10518,6 +10845,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10545,6 +10873,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10572,6 +10901,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10599,6 +10929,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10626,6 +10957,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10653,6 +10985,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10715,6 +11048,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10742,6 +11076,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10769,6 +11104,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10796,6 +11132,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10865,6 +11202,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10899,6 +11237,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -10926,6 +11265,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11293,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -10980,6 +11321,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11007,6 +11349,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11055,6 +11398,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11082,6 +11426,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11130,6 +11475,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11157,6 +11503,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11184,6 +11531,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11246,6 +11594,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11287,6 +11636,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11314,6 +11664,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11341,6 +11692,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11368,6 +11720,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11395,6 +11748,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11464,6 +11818,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11491,6 +11846,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11518,6 +11874,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11545,6 +11902,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11579,6 +11937,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11613,6 +11972,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11640,6 +12000,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11667,6 +12028,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11694,6 +12056,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11721,6 +12084,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11748,6 +12112,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11775,6 +12140,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11802,6 +12168,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11829,6 +12196,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11856,6 +12224,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11883,6 +12252,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -11910,6 +12280,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -11937,6 +12308,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -11964,6 +12336,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -11991,6 +12364,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12053,6 +12427,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12087,6 +12462,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12114,6 +12490,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12141,6 +12518,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12168,6 +12546,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12195,6 +12574,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12250,6 +12630,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12277,6 +12658,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12304,6 +12686,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12331,6 +12714,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12358,6 +12742,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12385,6 +12770,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12412,6 +12798,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12439,6 +12826,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12508,6 +12896,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12535,6 +12924,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12562,6 +12952,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12596,6 +12987,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12623,6 +13015,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +13043,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +13092,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12725,6 +13120,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +13162,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12821,6 +13218,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12855,6 +13253,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12924,6 +13323,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -12951,6 +13351,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -12978,6 +13379,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13005,6 +13407,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13032,6 +13435,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13059,6 +13463,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13086,6 +13491,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13113,6 +13519,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13140,6 +13547,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13188,6 +13596,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13257,6 +13666,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13284,6 +13694,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13325,6 +13736,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13352,6 +13764,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13386,6 +13799,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13841,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13496,6 +13911,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13523,6 +13939,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13550,6 +13967,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13577,6 +13995,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13604,6 +14023,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13659,6 +14079,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13686,6 +14107,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13713,6 +14135,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13740,6 +14163,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13767,6 +14191,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13794,6 +14219,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13821,6 +14247,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13848,6 +14275,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13875,6 +14303,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -13902,6 +14331,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13964,6 +14394,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -13991,6 +14422,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14018,6 +14450,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14045,6 +14478,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14072,6 +14506,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14534,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14604,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14195,6 +14632,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14222,6 +14660,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14249,6 +14688,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14276,6 +14716,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14317,6 +14758,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14344,6 +14786,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14371,6 +14814,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14398,6 +14842,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14425,6 +14870,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14452,6 +14898,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14479,6 +14926,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14506,6 +14954,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14575,6 +15024,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14602,6 +15052,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14629,6 +15080,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14656,6 +15108,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14683,6 +15136,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14710,6 +15164,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14737,6 +15192,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14764,6 +15220,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14798,6 +15255,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14825,6 +15283,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14852,6 +15311,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14879,6 +15339,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14906,6 +15367,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -14933,6 +15395,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -14960,6 +15423,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -14987,6 +15451,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15056,6 +15521,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15083,6 +15549,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15110,6 +15577,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15137,6 +15605,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15164,6 +15633,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15191,6 +15661,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15218,6 +15689,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15259,6 +15731,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15801,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15355,6 +15829,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15382,6 +15857,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15409,6 +15885,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15436,6 +15913,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15463,6 +15941,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15504,6 +15983,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15531,6 +16011,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15558,6 +16039,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15585,6 +16067,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15612,6 +16095,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15646,6 +16130,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15673,6 +16158,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15700,6 +16186,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15727,6 +16214,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -15796,6 +16284,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15823,6 +16312,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15850,6 +16340,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15877,6 +16368,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15904,6 +16396,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -15931,6 +16424,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15958,6 +16452,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -15985,6 +16480,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16012,6 +16508,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16039,6 +16536,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16066,6 +16564,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16107,6 +16606,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16134,6 +16634,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16161,6 +16662,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16223,6 +16725,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16250,6 +16753,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16277,6 +16781,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16304,6 +16809,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16331,6 +16837,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16358,6 +16865,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16385,6 +16893,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16412,6 +16921,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16439,6 +16949,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16466,6 +16977,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16493,6 +17005,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16548,6 +17061,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16582,6 +17096,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16609,6 +17124,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16636,6 +17152,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16663,6 +17180,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16690,6 +17208,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16717,6 +17236,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16744,6 +17264,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16785,6 +17306,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +17376,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -16888,6 +17411,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16915,6 +17439,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -16942,6 +17467,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16969,6 +17495,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -16996,6 +17523,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17030,6 +17558,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17057,6 +17586,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17084,6 +17614,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17153,6 +17684,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17180,6 +17712,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17207,6 +17740,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17234,6 +17768,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17261,6 +17796,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17288,6 +17824,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17315,6 +17852,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17342,6 +17880,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17404,6 +17943,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17431,6 +17971,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17458,6 +17999,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17485,6 +18027,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17512,6 +18055,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17560,6 +18104,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17601,6 +18146,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17628,6 +18174,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17655,6 +18202,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17689,6 +18237,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17716,6 +18265,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17743,6 +18293,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17784,6 +18335,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17811,6 +18363,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17845,6 +18398,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17872,6 +18426,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17899,6 +18454,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17926,6 +18482,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17953,6 +18510,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -17980,6 +18538,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18007,6 +18566,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18076,6 +18636,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18103,6 +18664,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18130,6 +18692,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18157,6 +18720,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18184,6 +18748,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -18211,6 +18776,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18280,6 +18846,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18307,6 +18874,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18376,6 +18944,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18403,6 +18972,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18430,6 +19000,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18457,6 +19028,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18484,6 +19056,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18511,6 +19084,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18538,6 +19112,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18572,6 +19147,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18606,6 +19182,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18633,6 +19210,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18660,6 +19238,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18715,6 +19294,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18742,6 +19322,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18769,6 +19350,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18796,6 +19378,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18830,6 +19413,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18857,6 +19441,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18884,6 +19469,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18911,6 +19497,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18938,6 +19525,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -18972,6 +19560,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18999,6 +19588,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19026,6 +19616,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19053,6 +19644,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19080,6 +19672,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19107,6 +19700,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19728,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19161,6 +19756,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19195,6 +19791,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19222,6 +19819,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19249,6 +19847,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19276,6 +19875,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19303,6 +19903,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19330,6 +19931,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19364,6 +19966,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19398,6 +20001,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19425,6 +20029,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19452,6 +20057,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19479,6 +20085,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19506,6 +20113,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -19533,6 +20141,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19560,6 +20169,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19587,6 +20197,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19635,6 +20246,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19662,6 +20274,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19689,6 +20302,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19716,6 +20330,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19743,6 +20358,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19770,6 +20386,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19797,6 +20414,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19824,6 +20442,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19851,6 +20470,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -19920,6 +20540,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19947,6 +20568,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19974,6 +20596,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20001,6 +20624,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20035,6 +20659,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20062,6 +20687,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20089,6 +20715,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20116,6 +20743,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20143,6 +20771,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20184,6 +20813,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20211,6 +20841,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20252,6 +20883,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20279,6 +20911,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20348,6 +20981,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20410,6 +21044,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20437,6 +21072,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20506,6 +21142,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20533,6 +21170,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20560,6 +21198,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20587,6 +21226,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20614,6 +21254,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20641,6 +21282,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20668,6 +21310,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20695,6 +21338,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20729,6 +21373,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20756,6 +21401,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -20818,6 +21464,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20845,6 +21492,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20872,6 +21520,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -20906,6 +21555,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20940,6 +21590,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -20981,6 +21632,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21036,6 +21688,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21063,6 +21716,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21090,6 +21744,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21159,6 +21814,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21186,6 +21842,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21227,6 +21884,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21254,6 +21912,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21281,6 +21940,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21308,6 +21968,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21335,6 +21996,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21369,6 +22031,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21396,6 +22059,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21423,6 +22087,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21450,6 +22115,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21477,6 +22143,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21504,6 +22171,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21545,6 +22213,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21572,6 +22241,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21599,6 +22269,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21626,6 +22297,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21653,6 +22325,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -21701,6 +22374,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21728,6 +22402,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21755,6 +22430,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21782,6 +22458,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21809,6 +22486,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21836,6 +22514,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21884,6 +22563,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -21918,6 +22598,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21945,6 +22626,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -21972,6 +22654,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21999,6 +22682,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22026,6 +22710,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22053,6 +22738,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22080,6 +22766,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22121,6 +22808,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22148,6 +22836,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22175,6 +22864,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22202,6 +22892,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22920,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22962,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22311,6 +23004,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22352,6 +23046,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22379,6 +23074,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22413,6 +23109,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22440,6 +23137,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -22467,6 +23165,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22494,6 +23193,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22521,6 +23221,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22569,6 +23270,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22610,6 +23312,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22637,6 +23340,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22664,6 +23368,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22733,6 +23438,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22767,6 +23473,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22794,6 +23501,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22828,6 +23536,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22862,6 +23571,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22889,6 +23599,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22916,6 +23627,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -22943,6 +23655,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22970,6 +23683,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22997,6 +23711,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23024,6 +23739,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23051,6 +23767,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23078,6 +23795,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23105,6 +23823,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23160,6 +23879,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23187,6 +23907,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23221,6 +23942,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23248,6 +23970,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23275,6 +23998,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23316,6 +24040,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23343,6 +24068,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23370,6 +24096,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23397,6 +24124,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23424,6 +24152,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23451,6 +24180,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23485,6 +24215,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23512,6 +24243,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23546,6 +24278,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23573,6 +24306,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23621,6 +24355,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23648,6 +24383,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23675,6 +24411,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23702,6 +24439,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23729,6 +24467,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23756,6 +24495,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23783,6 +24523,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23810,6 +24551,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23837,6 +24579,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23864,6 +24607,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -23891,6 +24635,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -23918,6 +24663,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -23966,6 +24712,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24014,6 +24761,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24041,6 +24789,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24068,6 +24817,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24095,6 +24845,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24122,6 +24873,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24149,6 +24901,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24176,6 +24929,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24203,6 +24957,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24230,6 +24985,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24257,6 +25013,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24284,6 +25041,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24311,6 +25069,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24338,6 +25097,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24372,6 +25132,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24434,6 +25195,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24461,6 +25223,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24488,6 +25251,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24515,6 +25279,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +25321,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -24625,6 +25391,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24694,6 +25461,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24721,6 +25489,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24748,6 +25517,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24817,6 +25587,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24844,6 +25615,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24871,6 +25643,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24898,6 +25671,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -24932,6 +25706,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24973,6 +25748,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25000,6 +25776,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25027,6 +25804,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25054,6 +25832,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25081,6 +25860,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25108,6 +25888,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25135,6 +25916,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25162,6 +25944,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25189,6 +25972,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25230,6 +26014,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25257,6 +26042,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25284,6 +26070,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25318,6 +26105,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25345,6 +26133,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25393,6 +26182,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25427,6 +26217,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25454,6 +26245,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25481,6 +26273,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25508,6 +26301,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25535,6 +26329,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25562,6 +26357,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25589,6 +26385,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25616,6 +26413,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25650,6 +26448,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25677,6 +26476,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25704,6 +26504,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25738,6 +26539,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25765,6 +26567,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25792,6 +26595,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25840,6 +26644,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25867,6 +26672,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -25894,6 +26700,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25921,6 +26728,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25955,6 +26763,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25996,6 +26805,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26833,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26050,6 +26861,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26077,6 +26889,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26139,6 +26952,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26166,6 +26980,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26193,6 +27008,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26220,6 +27036,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26247,6 +27064,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26274,6 +27092,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26301,6 +27120,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26335,6 +27155,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26362,6 +27183,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26431,6 +27253,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26458,6 +27281,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26527,6 +27351,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26554,6 +27379,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26581,6 +27407,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26608,6 +27435,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26635,6 +27463,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26662,6 +27491,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26689,6 +27519,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26716,6 +27547,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26743,6 +27575,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26770,6 +27603,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26797,6 +27631,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +27694,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27764,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -26955,6 +27792,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -26982,6 +27820,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27009,6 +27848,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27036,6 +27876,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27070,6 +27911,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27097,6 +27939,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27124,6 +27967,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27172,6 +28016,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27199,6 +28044,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27240,6 +28086,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27267,6 +28114,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27308,6 +28156,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27335,6 +28184,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +28212,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27396,6 +28247,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27423,6 +28275,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27450,6 +28303,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27477,6 +28331,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27504,6 +28359,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27531,6 +28387,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27558,6 +28415,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27585,6 +28443,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27612,6 +28471,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27639,6 +28499,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27666,6 +28527,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27693,6 +28555,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27720,6 +28583,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27747,6 +28611,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27774,6 +28639,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +28667,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27849,6 +28716,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -27876,6 +28744,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27903,6 +28772,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -27930,6 +28800,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -27957,6 +28828,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27984,6 +28856,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28011,6 +28884,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28038,6 +28912,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28065,6 +28940,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28092,6 +28968,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28119,6 +28996,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28146,6 +29024,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28180,6 +29059,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28207,6 +29087,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28234,6 +29115,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28261,6 +29143,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28288,6 +29171,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28357,6 +29241,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28384,6 +29269,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28411,6 +29297,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28438,6 +29325,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28465,6 +29353,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28492,6 +29381,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28519,6 +29409,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28546,6 +29437,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28573,6 +29465,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28600,6 +29493,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28627,6 +29521,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28654,6 +29549,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28688,6 +29584,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28715,6 +29612,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28749,6 +29647,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28776,6 +29675,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28803,6 +29703,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28830,6 +29731,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -28857,6 +29759,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28912,6 +29815,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28939,6 +29843,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29008,6 +29913,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29077,6 +29983,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29104,6 +30011,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29131,6 +30039,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29158,6 +30067,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29185,6 +30095,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29226,6 +30137,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29253,6 +30165,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29280,6 +30193,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29335,6 +30249,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29362,6 +30277,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29389,6 +30305,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29416,6 +30333,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29457,6 +30375,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29484,6 +30403,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29518,6 +30438,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29545,6 +30466,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29572,6 +30494,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29599,6 +30522,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29626,6 +30550,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29660,6 +30585,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29687,6 +30613,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29714,6 +30641,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29741,6 +30669,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29768,6 +30697,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29795,6 +30725,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29822,6 +30753,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -29849,6 +30781,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29918,6 +30851,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -29945,6 +30879,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -29972,6 +30907,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -29999,6 +30935,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30026,6 +30963,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30053,6 +30991,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30080,6 +31019,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30107,6 +31047,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30148,6 +31089,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30175,6 +31117,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30202,6 +31145,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30229,6 +31173,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30256,6 +31201,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30283,6 +31229,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30310,6 +31257,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30337,6 +31285,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30364,6 +31313,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30391,6 +31341,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30418,6 +31369,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30445,6 +31397,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -30472,6 +31425,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30499,6 +31453,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30533,6 +31488,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30595,6 +31551,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30622,6 +31579,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30649,6 +31607,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30676,6 +31635,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30703,6 +31663,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30730,6 +31691,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30757,6 +31719,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30784,6 +31747,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30811,6 +31775,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30866,6 +31831,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -30893,6 +31859,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30920,6 +31887,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30947,6 +31915,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -30974,6 +31943,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31001,6 +31971,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31035,6 +32006,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31062,6 +32034,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31089,6 +32062,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31116,6 +32090,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31143,6 +32118,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31170,6 +32146,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31197,6 +32174,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31224,6 +32202,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31251,6 +32230,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31278,6 +32258,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31305,6 +32286,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31346,6 +32328,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +32384,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31428,6 +32412,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31455,6 +32440,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31482,6 +32468,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31509,6 +32496,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31536,6 +32524,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31563,6 +32552,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31590,6 +32580,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31645,6 +32636,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31672,6 +32664,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31699,6 +32692,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31754,6 +32748,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31788,6 +32783,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31843,6 +32839,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31877,6 +32874,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31904,6 +32902,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -31938,6 +32937,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31986,6 +32986,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32027,6 +33028,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32054,6 +33056,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32081,6 +33084,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32108,6 +33112,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32135,6 +33140,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32162,6 +33168,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32196,6 +33203,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32223,6 +33231,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32250,6 +33259,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32277,6 +33287,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32304,6 +33315,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32331,6 +33343,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32358,6 +33371,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32385,6 +33399,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32412,6 +33427,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32439,6 +33455,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32466,6 +33483,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32493,6 +33511,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32520,6 +33539,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32547,6 +33567,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32574,6 +33595,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32601,6 +33623,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32628,6 +33651,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32655,6 +33679,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32682,6 +33707,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32730,6 +33756,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32771,6 +33798,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32798,6 +33826,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32825,6 +33854,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32852,6 +33882,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32914,6 +33945,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -32941,6 +33973,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -32968,6 +34001,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32995,6 +34029,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33029,6 +34064,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33056,6 +34092,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33083,6 +34120,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33124,6 +34162,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33151,6 +34190,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33178,6 +34218,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33205,6 +34246,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33232,6 +34274,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33301,6 +34344,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33328,6 +34372,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33376,6 +34421,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33403,6 +34449,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33451,6 +34498,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +34526,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +34555,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33539,6 +34590,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33580,6 +34632,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33621,6 +34674,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33648,6 +34702,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33675,6 +34730,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33702,6 +34758,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33736,6 +34793,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33763,6 +34821,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33790,6 +34849,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +34877,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -33844,6 +34905,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -33871,6 +34933,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -33898,6 +34961,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33925,6 +34989,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +35017,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -33979,6 +35045,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34020,6 +35087,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34047,6 +35115,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34116,6 +35185,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34143,6 +35213,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34170,6 +35241,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34197,6 +35269,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34224,6 +35297,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34251,6 +35325,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34285,6 +35360,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34319,6 +35395,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34346,6 +35423,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34415,6 +35493,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34442,6 +35521,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34469,6 +35549,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34496,6 +35577,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34523,6 +35605,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34550,6 +35633,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34605,6 +35689,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34632,6 +35717,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34666,6 +35752,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +35780,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34720,6 +35808,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34747,6 +35836,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34774,6 +35864,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34801,6 +35892,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34828,6 +35920,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -34855,6 +35948,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -34903,6 +35997,7 @@
         {
             "id": "0xe02e8ddecbe302ba1a40107c726e3ee889b0ff10",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
@@ -34937,6 +36032,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34964,6 +36060,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34991,6 +36088,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35018,6 +36116,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +36144,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +36193,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35120,6 +36221,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35147,6 +36249,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35174,6 +36277,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35201,6 +36305,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35228,6 +36333,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35255,6 +36361,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35282,6 +36389,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35309,6 +36417,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35336,6 +36445,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35363,6 +36473,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35425,6 +36536,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35473,6 +36585,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35500,6 +36613,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35527,6 +36641,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35554,6 +36669,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35581,6 +36697,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35615,6 +36732,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35642,6 +36760,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35669,6 +36788,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35696,6 +36816,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35723,6 +36844,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35771,6 +36893,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35798,6 +36921,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -35825,6 +36949,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35852,6 +36977,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -35879,6 +37005,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35913,6 +37040,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -35940,6 +37068,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36009,6 +37138,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36057,6 +37187,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36112,6 +37243,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36153,6 +37285,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36180,6 +37313,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36249,6 +37383,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36276,6 +37411,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36303,6 +37439,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36330,6 +37467,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36357,6 +37495,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +37523,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36432,6 +37572,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36459,6 +37600,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36486,6 +37628,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36513,6 +37656,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36582,6 +37726,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36609,6 +37754,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36636,6 +37782,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36663,6 +37810,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36690,6 +37838,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36717,6 +37866,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36744,6 +37894,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36771,6 +37922,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36798,6 +37950,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36825,6 +37978,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36852,6 +38006,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -36886,6 +38041,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -36913,6 +38069,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -36940,6 +38097,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36967,6 +38125,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -36994,6 +38153,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37021,6 +38181,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37048,6 +38209,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37103,6 +38265,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37130,6 +38293,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37185,6 +38349,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37212,6 +38377,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37239,6 +38405,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37287,6 +38454,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37314,6 +38482,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37341,6 +38510,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37368,6 +38538,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37409,6 +38580,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37436,6 +38608,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37470,6 +38643,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37497,6 +38671,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37531,6 +38706,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37558,6 +38734,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37585,6 +38762,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37612,6 +38790,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37639,6 +38818,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37687,6 +38867,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37721,6 +38902,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37748,6 +38930,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -37782,6 +38965,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37809,6 +38993,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37836,6 +39021,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -37884,6 +39070,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37911,6 +39098,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37938,6 +39126,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -37986,6 +39175,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38013,6 +39203,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38040,6 +39231,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +39273,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38122,6 +39315,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38149,6 +39343,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38176,6 +39371,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38203,6 +39399,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38251,6 +39448,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38278,6 +39476,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38319,6 +39518,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38346,6 +39546,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38373,6 +39574,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38400,6 +39602,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38427,6 +39630,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38454,6 +39658,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38481,6 +39686,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38508,6 +39714,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38535,6 +39742,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38562,6 +39770,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38596,6 +39805,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38623,6 +39833,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38650,6 +39861,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38698,6 +39910,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38725,6 +39938,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38752,6 +39966,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38779,6 +39994,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38806,6 +40022,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -38833,6 +40050,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -38860,6 +40078,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -38887,6 +40106,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -38914,6 +40134,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38983,6 +40204,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39010,6 +40232,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39037,6 +40260,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39064,6 +40288,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39112,6 +40337,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39139,6 +40365,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39173,6 +40400,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39207,6 +40435,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39241,6 +40470,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39268,6 +40498,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39295,6 +40526,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39322,6 +40554,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39356,6 +40589,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39383,6 +40617,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39410,6 +40645,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39437,6 +40673,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39471,6 +40708,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39505,6 +40743,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39532,6 +40771,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39559,6 +40799,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39600,6 +40841,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39669,6 +40911,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39696,6 +40939,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39723,6 +40967,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39750,6 +40995,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39777,6 +41023,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39804,6 +41051,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39831,6 +41079,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39865,6 +41114,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39892,6 +41142,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -39919,6 +41170,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39988,6 +41240,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40015,6 +41268,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40042,6 +41296,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40069,6 +41324,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40138,6 +41394,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0xb48d49d52b1925f06c9a3b59c026fa8c9d1951ce583592ecc749c35cd6d83172.json
+++ b/test/testData/testPools/0xb48d49d52b1925f06c9a3b59c026fa8c9d1951ce583592ecc749c35cd6d83172.json
@@ -2541,7 +2541,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6042,7 +6041,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8387,7 +8385,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -34526,7 +34523,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0xb69fdcc676e206124c50fa607924e4fb49a40761dd4a21cb4acf20f88fcd7970.json
+++ b/test/testData/testPools/0xb69fdcc676e206124c50fa607924e4fb49a40761dd4a21cb4acf20f88fcd7970.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xb8d4677d37d143abf30f3a4ad720a0a9487cad83e053cccb32a5fad1c775ae64.json
+++ b/test/testData/testPools/0xb8d4677d37d143abf30f3a4ad720a0a9487cad83e053cccb32a5fad1c775ae64.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xbdce4f52f4a863e9d137e44475cc913eb82154e9998819ce55846530dbd3025d.json
+++ b/test/testData/testPools/0xbdce4f52f4a863e9d137e44475cc913eb82154e9998819ce55846530dbd3025d.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xbf58764ea30623769a3520a141f5beb2de61f571c5d82aa0048290c417ddba61.json
+++ b/test/testData/testPools/0xbf58764ea30623769a3520a141f5beb2de61f571c5d82aa0048290c417ddba61.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xbf7f8dc5c7cc9fe1cc7654395610fe2625d06a67d80b079c238647631a048da8.json
+++ b/test/testData/testPools/0xbf7f8dc5c7cc9fe1cc7654395610fe2625d06a67d80b079c238647631a048da8.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xc0ff267f73ee9accb8a0b434966f95ac83dff238396e7d0f937644b8c853c588.json
+++ b/test/testData/testPools/0xc0ff267f73ee9accb8a0b434966f95ac83dff238396e7d0f937644b8c853c588.json
@@ -1161,6 +1161,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2468,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5859,6 +5861,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8134,6 +8137,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8451,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14575,6 +14580,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -20143,6 +20149,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -33478,6 +33485,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",

--- a/test/testData/testPools/0xc2ce998972eafe5bf0f6fb85935587f725546482e757c917fc650d3b55d3f694.json
+++ b/test/testData/testPools/0xc2ce998972eafe5bf0f6fb85935587f725546482e757c917fc650d3b55d3f694.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -94,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -169,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -196,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -230,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -257,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -284,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -311,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -338,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -365,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -392,6 +405,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -419,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -467,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -508,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -535,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -562,6 +580,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +608,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -616,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -643,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -691,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -718,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -745,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -800,6 +825,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -848,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -875,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -902,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -929,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -956,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -997,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1024,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1065,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1092,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1161,6 +1196,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1230,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1257,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1284,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1311,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1338,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1365,6 +1406,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1392,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1419,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1467,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1494,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1542,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1569,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1596,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1623,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1664,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1691,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1718,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1745,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1772,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1799,6 +1854,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1826,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1867,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1894,6 +1952,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1987,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -1976,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2004,6 +2065,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2051,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2169,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2168,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2216,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2243,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2270,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2325,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2352,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2379,6 +2449,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2477,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2440,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2467,6 +2540,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2494,6 +2569,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2528,6 +2604,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2555,6 +2632,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2582,6 +2660,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2609,6 +2688,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2657,6 +2737,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2684,6 +2765,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2718,6 +2800,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2745,6 +2828,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2772,6 +2856,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2799,6 +2884,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2826,6 +2912,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2860,6 +2947,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2887,6 +2975,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2914,6 +3003,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2941,6 +3031,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -2975,6 +3066,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3044,6 +3136,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3078,6 +3171,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3105,6 +3199,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3132,6 +3227,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3159,6 +3255,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3200,6 +3297,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3227,6 +3325,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3254,6 +3353,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3281,6 +3381,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3308,6 +3409,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3335,6 +3437,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3376,6 +3479,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3424,6 +3528,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3451,6 +3556,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3478,6 +3584,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3505,6 +3612,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3532,6 +3640,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3601,6 +3710,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3628,6 +3738,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3655,6 +3766,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3682,6 +3794,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3709,6 +3822,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3736,6 +3850,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3763,6 +3878,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3790,6 +3906,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3824,6 +3941,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3851,6 +3969,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3878,6 +3997,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3905,6 +4025,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3939,6 +4060,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3966,6 +4088,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -3993,6 +4116,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4020,6 +4144,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4047,6 +4172,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4088,6 +4214,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4115,6 +4242,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4163,6 +4291,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4190,6 +4319,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4238,6 +4368,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4265,6 +4396,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4292,6 +4424,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4319,6 +4452,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4346,6 +4480,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4373,6 +4508,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4428,6 +4564,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4469,6 +4606,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4496,6 +4634,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4523,6 +4662,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4550,6 +4690,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4577,6 +4718,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4604,6 +4746,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4774,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4658,6 +4802,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4685,6 +4830,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4712,6 +4858,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4739,6 +4886,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4808,6 +4956,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4835,6 +4984,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4862,6 +5012,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4889,6 +5040,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -4930,6 +5082,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5152,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5026,6 +5180,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5053,6 +5208,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5080,6 +5236,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5114,6 +5271,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5141,6 +5299,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5168,6 +5327,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5195,6 +5355,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5222,6 +5383,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5249,6 +5411,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5276,6 +5439,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5303,6 +5467,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5495,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5357,6 +5523,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5412,6 +5579,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5439,6 +5607,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5473,6 +5642,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5500,6 +5670,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5527,6 +5698,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5554,6 +5726,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5581,6 +5754,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5608,6 +5782,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5635,6 +5810,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5669,6 +5845,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5696,6 +5873,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5723,6 +5901,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5778,6 +5957,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5805,6 +5985,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5832,6 +6013,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5859,6 +6041,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -5886,6 +6070,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5913,6 +6098,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5940,6 +6126,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5967,6 +6154,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5994,6 +6182,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6021,6 +6210,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6069,6 +6259,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6096,6 +6287,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6137,6 +6329,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6185,6 +6378,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6212,6 +6406,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6239,6 +6434,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6294,6 +6490,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6328,6 +6525,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6369,6 +6567,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6438,6 +6637,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6465,6 +6665,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6499,6 +6700,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6526,6 +6728,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6553,6 +6756,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6580,6 +6784,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6607,6 +6812,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6634,6 +6840,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6661,6 +6868,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6688,6 +6896,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6750,6 +6959,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6819,6 +7029,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6846,6 +7057,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6873,6 +7085,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6900,6 +7113,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6927,6 +7141,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6954,6 +7169,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -6988,6 +7204,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7015,6 +7232,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7042,6 +7260,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7069,6 +7288,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7103,6 +7323,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7130,6 +7351,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7157,6 +7379,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7184,6 +7407,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7239,6 +7463,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7266,6 +7491,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7293,6 +7519,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7320,6 +7547,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7347,6 +7575,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7374,6 +7603,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7401,6 +7631,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7428,6 +7659,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7455,6 +7687,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7482,6 +7715,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7551,6 +7785,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7827,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7855,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7646,6 +7883,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7673,6 +7911,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7700,6 +7939,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7727,6 +7967,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7761,6 +8002,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7788,6 +8030,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7822,6 +8065,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7849,6 +8093,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7876,6 +8121,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7924,6 +8170,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7951,6 +8198,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -7978,6 +8226,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8005,6 +8254,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8032,6 +8282,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8059,6 +8310,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8086,6 +8338,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8134,6 +8387,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8161,6 +8416,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8188,6 +8444,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8222,6 +8479,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8249,6 +8507,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8276,6 +8535,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8317,6 +8577,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8344,6 +8605,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8378,6 +8640,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8447,6 +8710,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8474,6 +8738,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8501,6 +8766,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8528,6 +8794,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8597,6 +8864,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8624,6 +8892,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8651,6 +8920,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8678,6 +8948,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8712,6 +8983,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8739,6 +9011,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8787,6 +9060,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8835,6 +9109,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8862,6 +9137,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +9165,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8916,6 +9193,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8943,6 +9221,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -8970,6 +9249,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8997,6 +9277,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9066,6 +9347,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9093,6 +9375,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9120,6 +9403,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9147,6 +9431,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9174,6 +9459,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9215,6 +9501,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9242,6 +9529,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -9311,6 +9599,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9359,6 +9648,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9386,6 +9676,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9455,6 +9746,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9503,6 +9795,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9530,6 +9823,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9557,6 +9851,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9584,6 +9879,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9611,6 +9907,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9638,6 +9935,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9665,6 +9963,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9692,6 +9991,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9719,6 +10019,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9746,6 +10047,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9773,6 +10075,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9800,6 +10103,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9827,6 +10131,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9854,6 +10159,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9881,6 +10187,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9908,6 +10215,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9935,6 +10243,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -9962,6 +10271,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10003,6 +10313,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10030,6 +10341,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10057,6 +10369,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10112,6 +10425,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10139,6 +10453,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10166,6 +10481,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10200,6 +10516,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10227,6 +10544,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10254,6 +10572,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10281,6 +10600,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10308,6 +10628,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10335,6 +10656,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10362,6 +10684,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10389,6 +10712,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10437,6 +10761,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10464,6 +10789,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10491,6 +10817,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10518,6 +10845,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10545,6 +10873,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10572,6 +10901,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10599,6 +10929,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10626,6 +10957,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10653,6 +10985,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10715,6 +11048,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10742,6 +11076,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10769,6 +11104,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10796,6 +11132,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10865,6 +11202,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10899,6 +11237,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -10926,6 +11265,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11293,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -10980,6 +11321,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11007,6 +11349,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11055,6 +11398,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11082,6 +11426,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11130,6 +11475,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11157,6 +11503,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11184,6 +11531,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11246,6 +11594,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11287,6 +11636,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11314,6 +11664,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11341,6 +11692,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11368,6 +11720,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11395,6 +11748,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11464,6 +11818,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11491,6 +11846,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11518,6 +11874,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11545,6 +11902,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11579,6 +11937,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11613,6 +11972,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11640,6 +12000,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11667,6 +12028,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11694,6 +12056,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11721,6 +12084,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11748,6 +12112,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11775,6 +12140,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11802,6 +12168,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11829,6 +12196,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11856,6 +12224,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11883,6 +12252,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -11910,6 +12280,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -11937,6 +12308,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -11964,6 +12336,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -11991,6 +12364,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12053,6 +12427,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12087,6 +12462,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12114,6 +12490,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12141,6 +12518,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12168,6 +12546,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12195,6 +12574,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12250,6 +12630,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12277,6 +12658,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12304,6 +12686,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12331,6 +12714,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12358,6 +12742,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12385,6 +12770,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12412,6 +12798,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12439,6 +12826,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12508,6 +12896,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12535,6 +12924,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12562,6 +12952,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12596,6 +12987,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12623,6 +13015,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +13043,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +13092,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12725,6 +13120,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +13162,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12821,6 +13218,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12855,6 +13253,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12924,6 +13323,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -12951,6 +13351,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -12978,6 +13379,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13005,6 +13407,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13032,6 +13435,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13059,6 +13463,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13086,6 +13491,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13113,6 +13519,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13140,6 +13547,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13188,6 +13596,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13257,6 +13666,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13284,6 +13694,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13325,6 +13736,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13352,6 +13764,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13386,6 +13799,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13841,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13496,6 +13911,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13523,6 +13939,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13550,6 +13967,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13577,6 +13995,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13604,6 +14023,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13659,6 +14079,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13686,6 +14107,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13713,6 +14135,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13740,6 +14163,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13767,6 +14191,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13794,6 +14219,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13821,6 +14247,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13848,6 +14275,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13875,6 +14303,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -13902,6 +14331,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13964,6 +14394,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -13991,6 +14422,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14018,6 +14450,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14045,6 +14478,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14072,6 +14506,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14534,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14604,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14195,6 +14632,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14222,6 +14660,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14249,6 +14688,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14276,6 +14716,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14317,6 +14758,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14344,6 +14786,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14371,6 +14814,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14398,6 +14842,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14425,6 +14870,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14452,6 +14898,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14479,6 +14926,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14506,6 +14954,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14575,6 +15024,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14602,6 +15052,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14629,6 +15080,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14656,6 +15108,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14683,6 +15136,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14710,6 +15164,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14737,6 +15192,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14764,6 +15220,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14798,6 +15255,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14825,6 +15283,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14852,6 +15311,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14879,6 +15339,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14906,6 +15367,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -14933,6 +15395,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -14960,6 +15423,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -14987,6 +15451,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15056,6 +15521,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15083,6 +15549,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15110,6 +15577,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15137,6 +15605,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15164,6 +15633,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15191,6 +15661,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15218,6 +15689,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15259,6 +15731,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15801,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15355,6 +15829,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15382,6 +15857,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15409,6 +15885,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15436,6 +15913,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15463,6 +15941,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15504,6 +15983,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15531,6 +16011,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15558,6 +16039,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15585,6 +16067,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15612,6 +16095,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15646,6 +16130,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15673,6 +16158,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15700,6 +16186,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15727,6 +16214,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -15796,6 +16284,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15823,6 +16312,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15850,6 +16340,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15877,6 +16368,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15904,6 +16396,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -15931,6 +16424,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15958,6 +16452,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -15985,6 +16480,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16012,6 +16508,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16039,6 +16536,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16066,6 +16564,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16107,6 +16606,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16134,6 +16634,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16161,6 +16662,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16223,6 +16725,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16250,6 +16753,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16277,6 +16781,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16304,6 +16809,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16331,6 +16837,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16358,6 +16865,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16385,6 +16893,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16412,6 +16921,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16439,6 +16949,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16466,6 +16977,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16493,6 +17005,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16548,6 +17061,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16582,6 +17096,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16609,6 +17124,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16636,6 +17152,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16663,6 +17180,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16690,6 +17208,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16717,6 +17236,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16744,6 +17264,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16785,6 +17306,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +17376,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -16888,6 +17411,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16915,6 +17439,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -16942,6 +17467,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16969,6 +17495,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -16996,6 +17523,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17030,6 +17558,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17057,6 +17586,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17084,6 +17614,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17153,6 +17684,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17180,6 +17712,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17207,6 +17740,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17234,6 +17768,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17261,6 +17796,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17288,6 +17824,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17315,6 +17852,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17342,6 +17880,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17404,6 +17943,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17431,6 +17971,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17458,6 +17999,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17485,6 +18027,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17512,6 +18055,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17560,6 +18104,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17601,6 +18146,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17628,6 +18174,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17655,6 +18202,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17689,6 +18237,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17716,6 +18265,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17743,6 +18293,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17784,6 +18335,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17811,6 +18363,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17845,6 +18398,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17872,6 +18426,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17899,6 +18454,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17926,6 +18482,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17953,6 +18510,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -17980,6 +18538,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18007,6 +18566,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18076,6 +18636,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18103,6 +18664,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18130,6 +18692,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18157,6 +18720,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18184,6 +18748,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -18211,6 +18776,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18280,6 +18846,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18307,6 +18874,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18376,6 +18944,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18403,6 +18972,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18430,6 +19000,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18457,6 +19028,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18484,6 +19056,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18511,6 +19084,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18538,6 +19112,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18572,6 +19147,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18606,6 +19182,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18633,6 +19210,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18660,6 +19238,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18715,6 +19294,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18742,6 +19322,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18769,6 +19350,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18796,6 +19378,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18830,6 +19413,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18857,6 +19441,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18884,6 +19469,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18911,6 +19497,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18938,6 +19525,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -18972,6 +19560,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18999,6 +19588,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19026,6 +19616,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19053,6 +19644,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19080,6 +19672,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19107,6 +19700,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19728,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19161,6 +19756,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19195,6 +19791,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19222,6 +19819,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19249,6 +19847,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19276,6 +19875,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19303,6 +19903,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19330,6 +19931,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19364,6 +19966,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19398,6 +20001,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19425,6 +20029,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19452,6 +20057,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19479,6 +20085,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19506,6 +20113,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -19533,6 +20141,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19560,6 +20169,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19587,6 +20197,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19635,6 +20246,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19662,6 +20274,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19689,6 +20302,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19716,6 +20330,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19743,6 +20358,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19770,6 +20386,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19797,6 +20414,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19824,6 +20442,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19851,6 +20470,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -19920,6 +20540,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19947,6 +20568,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19974,6 +20596,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20001,6 +20624,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20035,6 +20659,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20062,6 +20687,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20089,6 +20715,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20116,6 +20743,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20143,6 +20771,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20184,6 +20813,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20211,6 +20841,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20252,6 +20883,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20279,6 +20911,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20348,6 +20981,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20410,6 +21044,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20437,6 +21072,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20506,6 +21142,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20533,6 +21170,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20560,6 +21198,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20587,6 +21226,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20614,6 +21254,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20641,6 +21282,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20668,6 +21310,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20695,6 +21338,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20729,6 +21373,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20756,6 +21401,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -20818,6 +21464,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20845,6 +21492,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20872,6 +21520,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -20906,6 +21555,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20940,6 +21590,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -20981,6 +21632,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21036,6 +21688,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21063,6 +21716,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21090,6 +21744,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21159,6 +21814,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21186,6 +21842,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21227,6 +21884,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21254,6 +21912,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21281,6 +21940,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21308,6 +21968,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21335,6 +21996,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21369,6 +22031,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21396,6 +22059,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21423,6 +22087,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21450,6 +22115,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21477,6 +22143,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21504,6 +22171,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21545,6 +22213,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21572,6 +22241,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21599,6 +22269,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21626,6 +22297,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21653,6 +22325,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -21701,6 +22374,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21728,6 +22402,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21755,6 +22430,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21782,6 +22458,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21809,6 +22486,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21836,6 +22514,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21884,6 +22563,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -21918,6 +22598,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21945,6 +22626,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -21972,6 +22654,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21999,6 +22682,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22026,6 +22710,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22053,6 +22738,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22080,6 +22766,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22121,6 +22808,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22148,6 +22836,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22175,6 +22864,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22202,6 +22892,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22920,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22962,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22311,6 +23004,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22352,6 +23046,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22379,6 +23074,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22413,6 +23109,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22440,6 +23137,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -22467,6 +23165,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22494,6 +23193,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22521,6 +23221,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22569,6 +23270,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22610,6 +23312,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22637,6 +23340,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22664,6 +23368,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22733,6 +23438,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22767,6 +23473,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22794,6 +23501,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22828,6 +23536,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22862,6 +23571,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22889,6 +23599,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22916,6 +23627,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -22943,6 +23655,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22970,6 +23683,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22997,6 +23711,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23024,6 +23739,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23051,6 +23767,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23078,6 +23795,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23105,6 +23823,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23160,6 +23879,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23187,6 +23907,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23221,6 +23942,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23248,6 +23970,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23275,6 +23998,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23316,6 +24040,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23343,6 +24068,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23370,6 +24096,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23397,6 +24124,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23424,6 +24152,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23451,6 +24180,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23485,6 +24215,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23512,6 +24243,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23546,6 +24278,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23573,6 +24306,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23621,6 +24355,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23648,6 +24383,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23675,6 +24411,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23702,6 +24439,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23729,6 +24467,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23756,6 +24495,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23783,6 +24523,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23810,6 +24551,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23837,6 +24579,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23864,6 +24607,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -23891,6 +24635,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -23918,6 +24663,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -23966,6 +24712,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24014,6 +24761,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24041,6 +24789,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24068,6 +24817,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24095,6 +24845,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24122,6 +24873,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24149,6 +24901,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24176,6 +24929,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24203,6 +24957,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24230,6 +24985,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24257,6 +25013,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24284,6 +25041,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24311,6 +25069,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24338,6 +25097,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24372,6 +25132,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24434,6 +25195,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24461,6 +25223,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24488,6 +25251,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24515,6 +25279,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +25321,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -24625,6 +25391,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24694,6 +25461,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24721,6 +25489,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24748,6 +25517,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24817,6 +25587,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24844,6 +25615,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24871,6 +25643,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24898,6 +25671,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -24932,6 +25706,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24973,6 +25748,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25000,6 +25776,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25027,6 +25804,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25054,6 +25832,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25081,6 +25860,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25108,6 +25888,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25135,6 +25916,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25162,6 +25944,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25189,6 +25972,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25230,6 +26014,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25257,6 +26042,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25284,6 +26070,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25318,6 +26105,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25345,6 +26133,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25393,6 +26182,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25427,6 +26217,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25454,6 +26245,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25481,6 +26273,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25508,6 +26301,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25535,6 +26329,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25562,6 +26357,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25589,6 +26385,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25616,6 +26413,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25650,6 +26448,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25677,6 +26476,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25704,6 +26504,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25738,6 +26539,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25765,6 +26567,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25792,6 +26595,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25840,6 +26644,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25867,6 +26672,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -25894,6 +26700,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25921,6 +26728,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25955,6 +26763,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25996,6 +26805,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26833,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26050,6 +26861,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26077,6 +26889,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26139,6 +26952,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26166,6 +26980,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26193,6 +27008,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26220,6 +27036,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26247,6 +27064,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26274,6 +27092,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26301,6 +27120,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26335,6 +27155,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26362,6 +27183,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26431,6 +27253,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26458,6 +27281,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26527,6 +27351,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26554,6 +27379,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26581,6 +27407,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26608,6 +27435,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26635,6 +27463,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26662,6 +27491,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26689,6 +27519,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26716,6 +27547,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26743,6 +27575,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26770,6 +27603,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26797,6 +27631,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +27694,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27764,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -26955,6 +27792,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -26982,6 +27820,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27009,6 +27848,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27036,6 +27876,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27070,6 +27911,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27097,6 +27939,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27124,6 +27967,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27172,6 +28016,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27199,6 +28044,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27240,6 +28086,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27267,6 +28114,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27308,6 +28156,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27335,6 +28184,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +28212,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27396,6 +28247,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27423,6 +28275,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27450,6 +28303,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27477,6 +28331,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27504,6 +28359,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27531,6 +28387,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27558,6 +28415,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27585,6 +28443,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27612,6 +28471,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27639,6 +28499,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27666,6 +28527,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27693,6 +28555,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27720,6 +28583,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27747,6 +28611,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27774,6 +28639,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +28667,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27849,6 +28716,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -27876,6 +28744,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27903,6 +28772,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -27930,6 +28800,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -27957,6 +28828,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27984,6 +28856,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28011,6 +28884,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28038,6 +28912,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28065,6 +28940,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28092,6 +28968,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28119,6 +28996,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28146,6 +29024,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28180,6 +29059,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28207,6 +29087,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28234,6 +29115,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28261,6 +29143,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28288,6 +29171,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28357,6 +29241,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28384,6 +29269,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28411,6 +29297,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28438,6 +29325,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28465,6 +29353,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28492,6 +29381,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28519,6 +29409,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28546,6 +29437,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28573,6 +29465,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28600,6 +29493,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28627,6 +29521,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28654,6 +29549,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28688,6 +29584,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28715,6 +29612,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28749,6 +29647,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28776,6 +29675,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28803,6 +29703,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28830,6 +29731,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -28857,6 +29759,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28912,6 +29815,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28939,6 +29843,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29008,6 +29913,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29077,6 +29983,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29104,6 +30011,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29131,6 +30039,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29158,6 +30067,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29185,6 +30095,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29226,6 +30137,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29253,6 +30165,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29280,6 +30193,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29335,6 +30249,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29362,6 +30277,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29389,6 +30305,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29416,6 +30333,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29457,6 +30375,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29484,6 +30403,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29518,6 +30438,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29545,6 +30466,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29572,6 +30494,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29599,6 +30522,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29626,6 +30550,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29660,6 +30585,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29687,6 +30613,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29714,6 +30641,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29741,6 +30669,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29768,6 +30697,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29795,6 +30725,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29822,6 +30753,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -29849,6 +30781,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29918,6 +30851,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -29945,6 +30879,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -29972,6 +30907,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -29999,6 +30935,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30026,6 +30963,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30053,6 +30991,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30080,6 +31019,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30107,6 +31047,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30148,6 +31089,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30175,6 +31117,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30202,6 +31145,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30229,6 +31173,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30256,6 +31201,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30283,6 +31229,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30310,6 +31257,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30337,6 +31285,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30364,6 +31313,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30391,6 +31341,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30418,6 +31369,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30445,6 +31397,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -30472,6 +31425,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30499,6 +31453,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30533,6 +31488,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30595,6 +31551,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30622,6 +31579,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30649,6 +31607,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30676,6 +31635,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30703,6 +31663,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30730,6 +31691,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30757,6 +31719,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30784,6 +31747,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30811,6 +31775,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30866,6 +31831,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -30893,6 +31859,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30920,6 +31887,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30947,6 +31915,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -30974,6 +31943,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31001,6 +31971,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31035,6 +32006,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31062,6 +32034,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31089,6 +32062,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31116,6 +32090,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31143,6 +32118,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31170,6 +32146,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31197,6 +32174,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31224,6 +32202,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31251,6 +32230,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31278,6 +32258,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31305,6 +32286,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31346,6 +32328,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +32384,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31428,6 +32412,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31455,6 +32440,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31482,6 +32468,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31509,6 +32496,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31536,6 +32524,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31563,6 +32552,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31590,6 +32580,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31645,6 +32636,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31672,6 +32664,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31699,6 +32692,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31754,6 +32748,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31788,6 +32783,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31843,6 +32839,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31877,6 +32874,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31904,6 +32902,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -31938,6 +32937,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31986,6 +32986,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32027,6 +33028,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32054,6 +33056,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32081,6 +33084,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32108,6 +33112,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32135,6 +33140,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32162,6 +33168,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32196,6 +33203,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32223,6 +33231,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32250,6 +33259,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32277,6 +33287,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32304,6 +33315,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32331,6 +33343,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32358,6 +33371,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32385,6 +33399,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32412,6 +33427,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32439,6 +33455,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32466,6 +33483,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32493,6 +33511,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32520,6 +33539,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32547,6 +33567,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32574,6 +33595,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32601,6 +33623,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32628,6 +33651,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32655,6 +33679,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32682,6 +33707,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32730,6 +33756,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32771,6 +33798,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32798,6 +33826,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32825,6 +33854,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32852,6 +33882,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32914,6 +33945,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -32941,6 +33973,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -32968,6 +34001,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32995,6 +34029,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33029,6 +34064,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33056,6 +34092,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33083,6 +34120,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33124,6 +34162,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33151,6 +34190,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33178,6 +34218,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33205,6 +34246,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33232,6 +34274,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33301,6 +34344,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33328,6 +34372,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33376,6 +34421,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33403,6 +34449,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33451,6 +34498,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +34526,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +34555,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33539,6 +34590,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33580,6 +34632,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33621,6 +34674,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33648,6 +34702,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33675,6 +34730,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33702,6 +34758,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33736,6 +34793,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33763,6 +34821,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33790,6 +34849,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +34877,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -33844,6 +34905,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -33871,6 +34933,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -33898,6 +34961,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33925,6 +34989,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +35017,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -33979,6 +35045,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34020,6 +35087,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34047,6 +35115,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34116,6 +35185,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34143,6 +35213,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34170,6 +35241,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34197,6 +35269,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34224,6 +35297,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34251,6 +35325,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34285,6 +35360,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34319,6 +35395,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34346,6 +35423,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34415,6 +35493,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34442,6 +35521,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34469,6 +35549,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34496,6 +35577,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34523,6 +35605,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34550,6 +35633,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34605,6 +35689,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34632,6 +35717,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34666,6 +35752,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +35780,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34720,6 +35808,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34747,6 +35836,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34774,6 +35864,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34801,6 +35892,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34828,6 +35920,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -34855,6 +35948,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -34903,6 +35997,7 @@
         {
             "id": "0xe02e8ddecbe302ba1a40107c726e3ee889b0ff10",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
@@ -34937,6 +36032,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34964,6 +36060,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34991,6 +36088,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35018,6 +36116,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +36144,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +36193,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35120,6 +36221,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35147,6 +36249,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35174,6 +36277,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35201,6 +36305,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35228,6 +36333,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35255,6 +36361,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35282,6 +36389,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35309,6 +36417,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35336,6 +36445,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35363,6 +36473,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35425,6 +36536,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35473,6 +36585,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35500,6 +36613,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35527,6 +36641,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35554,6 +36669,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35581,6 +36697,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35615,6 +36732,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35642,6 +36760,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35669,6 +36788,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35696,6 +36816,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35723,6 +36844,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35771,6 +36893,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35798,6 +36921,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -35825,6 +36949,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35852,6 +36977,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -35879,6 +37005,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35913,6 +37040,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -35940,6 +37068,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36009,6 +37138,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36057,6 +37187,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36112,6 +37243,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36153,6 +37285,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36180,6 +37313,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36249,6 +37383,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36276,6 +37411,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36303,6 +37439,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36330,6 +37467,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36357,6 +37495,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +37523,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36432,6 +37572,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36459,6 +37600,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36486,6 +37628,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36513,6 +37656,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36582,6 +37726,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36609,6 +37754,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36636,6 +37782,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36663,6 +37810,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36690,6 +37838,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36717,6 +37866,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36744,6 +37894,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36771,6 +37922,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36798,6 +37950,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36825,6 +37978,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36852,6 +38006,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -36886,6 +38041,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -36913,6 +38069,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -36940,6 +38097,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36967,6 +38125,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -36994,6 +38153,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37021,6 +38181,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37048,6 +38209,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37103,6 +38265,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37130,6 +38293,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37185,6 +38349,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37212,6 +38377,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37239,6 +38405,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37287,6 +38454,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37314,6 +38482,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37341,6 +38510,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37368,6 +38538,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37409,6 +38580,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37436,6 +38608,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37470,6 +38643,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37497,6 +38671,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37531,6 +38706,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37558,6 +38734,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37585,6 +38762,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37612,6 +38790,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37639,6 +38818,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37687,6 +38867,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37721,6 +38902,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37748,6 +38930,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -37782,6 +38965,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37809,6 +38993,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37836,6 +39021,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -37884,6 +39070,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37911,6 +39098,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37938,6 +39126,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -37986,6 +39175,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38013,6 +39203,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38040,6 +39231,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +39273,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38122,6 +39315,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38149,6 +39343,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38176,6 +39371,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38203,6 +39399,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38251,6 +39448,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38278,6 +39476,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38319,6 +39518,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38346,6 +39546,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38373,6 +39574,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38400,6 +39602,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38427,6 +39630,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38454,6 +39658,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38481,6 +39686,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38508,6 +39714,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38535,6 +39742,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38562,6 +39770,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38596,6 +39805,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38623,6 +39833,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38650,6 +39861,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38698,6 +39910,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38725,6 +39938,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38752,6 +39966,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38779,6 +39994,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38806,6 +40022,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -38833,6 +40050,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -38860,6 +40078,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -38887,6 +40106,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -38914,6 +40134,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38983,6 +40204,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39010,6 +40232,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39037,6 +40260,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39064,6 +40288,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39112,6 +40337,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39139,6 +40365,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39173,6 +40400,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39207,6 +40435,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39241,6 +40470,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39268,6 +40498,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39295,6 +40526,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39322,6 +40554,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39356,6 +40589,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39383,6 +40617,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39410,6 +40645,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39437,6 +40673,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39471,6 +40708,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39505,6 +40743,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39532,6 +40771,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39559,6 +40799,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39600,6 +40841,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39669,6 +40911,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39696,6 +40939,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39723,6 +40967,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39750,6 +40995,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39777,6 +41023,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39804,6 +41051,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39831,6 +41079,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39865,6 +41114,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39892,6 +41142,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -39919,6 +41170,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39988,6 +41240,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40015,6 +41268,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40042,6 +41296,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40069,6 +41324,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40138,6 +41394,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0xc2ce998972eafe5bf0f6fb85935587f725546482e757c917fc650d3b55d3f694.json
+++ b/test/testData/testPools/0xc2ce998972eafe5bf0f6fb85935587f725546482e757c917fc650d3b55d3f694.json
@@ -2541,7 +2541,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6042,7 +6041,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8387,7 +8385,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -34526,7 +34523,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0xc5b6dd6551d62ed8636e40e96b07d335a64c5513f2f143ed2133bb7e8009a68b.json
+++ b/test/testData/testPools/0xc5b6dd6551d62ed8636e40e96b07d335a64c5513f2f143ed2133bb7e8009a68b.json
@@ -1161,6 +1161,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2468,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5859,6 +5861,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8134,6 +8137,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8451,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14644,6 +14649,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -20178,6 +20184,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -33486,6 +33493,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",

--- a/test/testData/testPools/0xc942c544631edcd1d73a17354c1997ad20482736117c0fd86e9ffd25eae18623.json
+++ b/test/testData/testPools/0xc942c544631edcd1d73a17354c1997ad20482736117c0fd86e9ffd25eae18623.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -94,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -169,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -196,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -230,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -257,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -284,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -311,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -338,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -365,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -392,6 +405,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -419,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -467,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -508,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -535,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -562,6 +580,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +608,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -616,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -643,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -691,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -718,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -745,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -800,6 +825,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -848,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -875,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -902,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -929,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -956,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -997,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1024,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1065,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1092,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1161,6 +1196,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1230,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1257,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1284,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1311,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1338,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1365,6 +1406,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1392,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1419,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1467,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1494,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1542,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1569,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1596,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1623,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1664,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1691,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1718,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1745,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1772,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1799,6 +1854,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1826,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1867,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1894,6 +1952,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1987,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -1976,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2004,6 +2065,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2051,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2169,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2168,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2216,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2243,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2270,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2325,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2352,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2379,6 +2449,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2477,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2440,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2467,6 +2540,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2494,6 +2569,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2528,6 +2604,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2555,6 +2632,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2582,6 +2660,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2609,6 +2688,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2657,6 +2737,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2684,6 +2765,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2718,6 +2800,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2745,6 +2828,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2772,6 +2856,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2799,6 +2884,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2826,6 +2912,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2860,6 +2947,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2887,6 +2975,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2914,6 +3003,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2941,6 +3031,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -2975,6 +3066,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3044,6 +3136,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3078,6 +3171,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3105,6 +3199,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3132,6 +3227,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3159,6 +3255,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3200,6 +3297,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3227,6 +3325,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3254,6 +3353,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3281,6 +3381,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3308,6 +3409,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3335,6 +3437,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3376,6 +3479,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3424,6 +3528,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3451,6 +3556,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3478,6 +3584,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3505,6 +3612,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3532,6 +3640,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3601,6 +3710,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3628,6 +3738,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3655,6 +3766,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3682,6 +3794,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3709,6 +3822,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3736,6 +3850,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3763,6 +3878,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3790,6 +3906,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3824,6 +3941,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3851,6 +3969,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3878,6 +3997,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3905,6 +4025,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3939,6 +4060,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3966,6 +4088,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -3993,6 +4116,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4020,6 +4144,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4047,6 +4172,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4088,6 +4214,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4115,6 +4242,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4163,6 +4291,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4190,6 +4319,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4238,6 +4368,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4265,6 +4396,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4292,6 +4424,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4319,6 +4452,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4346,6 +4480,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4373,6 +4508,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4428,6 +4564,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4469,6 +4606,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4496,6 +4634,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4523,6 +4662,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4550,6 +4690,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4577,6 +4718,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4604,6 +4746,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4774,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4658,6 +4802,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4685,6 +4830,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4712,6 +4858,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4739,6 +4886,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4808,6 +4956,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4835,6 +4984,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4862,6 +5012,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4889,6 +5040,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -4930,6 +5082,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5152,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5026,6 +5180,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5053,6 +5208,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5080,6 +5236,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5114,6 +5271,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5141,6 +5299,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5168,6 +5327,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5195,6 +5355,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5222,6 +5383,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5249,6 +5411,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5276,6 +5439,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5303,6 +5467,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5495,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5357,6 +5523,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5412,6 +5579,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5439,6 +5607,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5473,6 +5642,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5500,6 +5670,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5527,6 +5698,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5554,6 +5726,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5581,6 +5754,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5608,6 +5782,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5635,6 +5810,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5669,6 +5845,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5696,6 +5873,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5723,6 +5901,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5778,6 +5957,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5805,6 +5985,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5832,6 +6013,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5859,6 +6041,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -5886,6 +6070,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5913,6 +6098,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5940,6 +6126,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5967,6 +6154,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5994,6 +6182,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6021,6 +6210,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6069,6 +6259,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6096,6 +6287,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6137,6 +6329,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6185,6 +6378,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6212,6 +6406,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6239,6 +6434,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6294,6 +6490,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6328,6 +6525,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6369,6 +6567,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6438,6 +6637,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6465,6 +6665,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6499,6 +6700,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6526,6 +6728,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6553,6 +6756,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6580,6 +6784,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6607,6 +6812,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6634,6 +6840,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6661,6 +6868,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6688,6 +6896,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6750,6 +6959,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6819,6 +7029,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6846,6 +7057,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6873,6 +7085,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6900,6 +7113,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6927,6 +7141,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6954,6 +7169,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -6988,6 +7204,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7015,6 +7232,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7042,6 +7260,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7069,6 +7288,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7103,6 +7323,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7130,6 +7351,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7157,6 +7379,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7184,6 +7407,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7239,6 +7463,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7266,6 +7491,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7293,6 +7519,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7320,6 +7547,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7347,6 +7575,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7374,6 +7603,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7401,6 +7631,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7428,6 +7659,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7455,6 +7687,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7482,6 +7715,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7551,6 +7785,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7827,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7855,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7646,6 +7883,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7673,6 +7911,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7700,6 +7939,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7727,6 +7967,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7761,6 +8002,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7788,6 +8030,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7822,6 +8065,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7849,6 +8093,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7876,6 +8121,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7924,6 +8170,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7951,6 +8198,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -7978,6 +8226,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8005,6 +8254,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8032,6 +8282,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8059,6 +8310,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8086,6 +8338,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8134,6 +8387,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8161,6 +8416,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8188,6 +8444,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8222,6 +8479,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8249,6 +8507,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8276,6 +8535,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8317,6 +8577,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8344,6 +8605,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8378,6 +8640,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8447,6 +8710,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8474,6 +8738,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8501,6 +8766,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8528,6 +8794,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8597,6 +8864,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8624,6 +8892,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8651,6 +8920,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8678,6 +8948,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8712,6 +8983,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8739,6 +9011,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8787,6 +9060,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8835,6 +9109,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8862,6 +9137,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +9165,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8916,6 +9193,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8943,6 +9221,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -8970,6 +9249,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8997,6 +9277,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9066,6 +9347,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9093,6 +9375,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9120,6 +9403,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9147,6 +9431,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9174,6 +9459,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9215,6 +9501,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9242,6 +9529,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -9311,6 +9599,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9359,6 +9648,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9386,6 +9676,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9455,6 +9746,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9503,6 +9795,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9530,6 +9823,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9557,6 +9851,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9584,6 +9879,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9611,6 +9907,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9638,6 +9935,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9665,6 +9963,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9692,6 +9991,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9719,6 +10019,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9746,6 +10047,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9773,6 +10075,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9800,6 +10103,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9827,6 +10131,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9854,6 +10159,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9881,6 +10187,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9908,6 +10215,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9935,6 +10243,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -9962,6 +10271,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10003,6 +10313,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10030,6 +10341,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10057,6 +10369,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10112,6 +10425,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10139,6 +10453,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10166,6 +10481,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10200,6 +10516,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10227,6 +10544,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10254,6 +10572,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10281,6 +10600,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10308,6 +10628,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10335,6 +10656,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10362,6 +10684,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10389,6 +10712,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10437,6 +10761,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10464,6 +10789,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10491,6 +10817,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10518,6 +10845,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10545,6 +10873,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10572,6 +10901,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10599,6 +10929,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10626,6 +10957,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10653,6 +10985,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10715,6 +11048,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10742,6 +11076,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10769,6 +11104,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10796,6 +11132,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10865,6 +11202,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10899,6 +11237,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -10926,6 +11265,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11293,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -10980,6 +11321,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11007,6 +11349,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11055,6 +11398,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11082,6 +11426,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11130,6 +11475,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11157,6 +11503,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11184,6 +11531,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11246,6 +11594,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11287,6 +11636,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11314,6 +11664,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11341,6 +11692,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11368,6 +11720,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11395,6 +11748,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11464,6 +11818,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11491,6 +11846,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11518,6 +11874,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11545,6 +11902,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11579,6 +11937,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11613,6 +11972,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11640,6 +12000,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11667,6 +12028,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11694,6 +12056,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11721,6 +12084,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11748,6 +12112,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11775,6 +12140,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11802,6 +12168,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11829,6 +12196,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11856,6 +12224,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11883,6 +12252,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -11910,6 +12280,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -11937,6 +12308,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -11964,6 +12336,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -11991,6 +12364,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12053,6 +12427,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12087,6 +12462,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12114,6 +12490,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12141,6 +12518,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12168,6 +12546,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12195,6 +12574,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12250,6 +12630,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12277,6 +12658,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12304,6 +12686,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12331,6 +12714,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12358,6 +12742,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12385,6 +12770,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12412,6 +12798,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12439,6 +12826,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12508,6 +12896,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12535,6 +12924,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12562,6 +12952,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12596,6 +12987,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12623,6 +13015,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +13043,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +13092,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12725,6 +13120,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +13162,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12821,6 +13218,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12855,6 +13253,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12924,6 +13323,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -12951,6 +13351,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -12978,6 +13379,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13005,6 +13407,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13032,6 +13435,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13059,6 +13463,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13086,6 +13491,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13113,6 +13519,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13140,6 +13547,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13188,6 +13596,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13257,6 +13666,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13284,6 +13694,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13325,6 +13736,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13352,6 +13764,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13386,6 +13799,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13841,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13496,6 +13911,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13523,6 +13939,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13550,6 +13967,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13577,6 +13995,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13604,6 +14023,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13659,6 +14079,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13686,6 +14107,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13713,6 +14135,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13740,6 +14163,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13767,6 +14191,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13794,6 +14219,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13821,6 +14247,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13848,6 +14275,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13875,6 +14303,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -13902,6 +14331,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13964,6 +14394,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -13991,6 +14422,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14018,6 +14450,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14045,6 +14478,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14072,6 +14506,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14534,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14604,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14195,6 +14632,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14222,6 +14660,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14249,6 +14688,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14276,6 +14716,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14317,6 +14758,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14344,6 +14786,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14371,6 +14814,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14398,6 +14842,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14425,6 +14870,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14452,6 +14898,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14479,6 +14926,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14506,6 +14954,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14575,6 +15024,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14602,6 +15052,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14629,6 +15080,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14656,6 +15108,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14683,6 +15136,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14710,6 +15164,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14737,6 +15192,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14764,6 +15220,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14798,6 +15255,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14825,6 +15283,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14852,6 +15311,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14879,6 +15339,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14906,6 +15367,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -14933,6 +15395,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -14960,6 +15423,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -14987,6 +15451,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15056,6 +15521,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15083,6 +15549,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15110,6 +15577,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15137,6 +15605,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15164,6 +15633,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15191,6 +15661,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15218,6 +15689,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15259,6 +15731,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15801,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15355,6 +15829,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15382,6 +15857,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15409,6 +15885,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15436,6 +15913,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15463,6 +15941,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15504,6 +15983,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15531,6 +16011,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15558,6 +16039,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15585,6 +16067,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15612,6 +16095,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15646,6 +16130,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15673,6 +16158,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15700,6 +16186,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15727,6 +16214,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -15796,6 +16284,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15823,6 +16312,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15850,6 +16340,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15877,6 +16368,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15904,6 +16396,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -15931,6 +16424,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15958,6 +16452,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -15985,6 +16480,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16012,6 +16508,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16039,6 +16536,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16066,6 +16564,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16107,6 +16606,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16134,6 +16634,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16161,6 +16662,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16223,6 +16725,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16250,6 +16753,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16277,6 +16781,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16304,6 +16809,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16331,6 +16837,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16358,6 +16865,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16385,6 +16893,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16412,6 +16921,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16439,6 +16949,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16466,6 +16977,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16493,6 +17005,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16548,6 +17061,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16582,6 +17096,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16609,6 +17124,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16636,6 +17152,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16663,6 +17180,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16690,6 +17208,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16717,6 +17236,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16744,6 +17264,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16785,6 +17306,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +17376,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -16888,6 +17411,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16915,6 +17439,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -16942,6 +17467,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16969,6 +17495,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -16996,6 +17523,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17030,6 +17558,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17057,6 +17586,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17084,6 +17614,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17153,6 +17684,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17180,6 +17712,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17207,6 +17740,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17234,6 +17768,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17261,6 +17796,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17288,6 +17824,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17315,6 +17852,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17342,6 +17880,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17404,6 +17943,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17431,6 +17971,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17458,6 +17999,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17485,6 +18027,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17512,6 +18055,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17560,6 +18104,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17601,6 +18146,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17628,6 +18174,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17655,6 +18202,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17689,6 +18237,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17716,6 +18265,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17743,6 +18293,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17784,6 +18335,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17811,6 +18363,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17845,6 +18398,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17872,6 +18426,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17899,6 +18454,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17926,6 +18482,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17953,6 +18510,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -17980,6 +18538,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18007,6 +18566,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18076,6 +18636,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18103,6 +18664,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18130,6 +18692,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18157,6 +18720,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18184,6 +18748,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -18211,6 +18776,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18280,6 +18846,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18307,6 +18874,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18376,6 +18944,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18403,6 +18972,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18430,6 +19000,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18457,6 +19028,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18484,6 +19056,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18511,6 +19084,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18538,6 +19112,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18572,6 +19147,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18606,6 +19182,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18633,6 +19210,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18660,6 +19238,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18715,6 +19294,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18742,6 +19322,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18769,6 +19350,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18796,6 +19378,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18830,6 +19413,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18857,6 +19441,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18884,6 +19469,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18911,6 +19497,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18938,6 +19525,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -18972,6 +19560,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18999,6 +19588,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19026,6 +19616,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19053,6 +19644,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19080,6 +19672,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19107,6 +19700,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19728,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19161,6 +19756,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19195,6 +19791,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19222,6 +19819,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19249,6 +19847,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19276,6 +19875,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19303,6 +19903,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19330,6 +19931,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19364,6 +19966,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19398,6 +20001,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19425,6 +20029,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19452,6 +20057,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19479,6 +20085,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19506,6 +20113,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -19533,6 +20141,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19560,6 +20169,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19587,6 +20197,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19635,6 +20246,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19662,6 +20274,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19689,6 +20302,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19716,6 +20330,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19743,6 +20358,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19770,6 +20386,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19797,6 +20414,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19824,6 +20442,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19851,6 +20470,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -19920,6 +20540,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19947,6 +20568,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19974,6 +20596,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20001,6 +20624,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20035,6 +20659,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20062,6 +20687,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20089,6 +20715,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20116,6 +20743,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20143,6 +20771,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20184,6 +20813,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20211,6 +20841,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20252,6 +20883,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20279,6 +20911,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20348,6 +20981,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20410,6 +21044,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20437,6 +21072,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20506,6 +21142,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20533,6 +21170,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20560,6 +21198,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20587,6 +21226,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20614,6 +21254,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20641,6 +21282,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20668,6 +21310,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20695,6 +21338,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20729,6 +21373,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20756,6 +21401,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -20818,6 +21464,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20845,6 +21492,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20872,6 +21520,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -20906,6 +21555,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20940,6 +21590,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -20981,6 +21632,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21036,6 +21688,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21063,6 +21716,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21090,6 +21744,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21159,6 +21814,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21186,6 +21842,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21227,6 +21884,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21254,6 +21912,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21281,6 +21940,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21308,6 +21968,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21335,6 +21996,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21369,6 +22031,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21396,6 +22059,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21423,6 +22087,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21450,6 +22115,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21477,6 +22143,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21504,6 +22171,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21545,6 +22213,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21572,6 +22241,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21599,6 +22269,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21626,6 +22297,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21653,6 +22325,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -21701,6 +22374,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21728,6 +22402,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21755,6 +22430,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21782,6 +22458,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21809,6 +22486,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21836,6 +22514,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21884,6 +22563,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -21918,6 +22598,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21945,6 +22626,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -21972,6 +22654,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21999,6 +22682,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22026,6 +22710,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22053,6 +22738,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22080,6 +22766,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22121,6 +22808,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22148,6 +22836,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22175,6 +22864,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22202,6 +22892,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22920,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22962,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22311,6 +23004,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22352,6 +23046,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22379,6 +23074,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22413,6 +23109,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22440,6 +23137,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -22467,6 +23165,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22494,6 +23193,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22521,6 +23221,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22569,6 +23270,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22610,6 +23312,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22637,6 +23340,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22664,6 +23368,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22733,6 +23438,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22767,6 +23473,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22794,6 +23501,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22828,6 +23536,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22862,6 +23571,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22889,6 +23599,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22916,6 +23627,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -22943,6 +23655,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22970,6 +23683,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22997,6 +23711,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23024,6 +23739,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23051,6 +23767,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23078,6 +23795,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23105,6 +23823,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23160,6 +23879,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23187,6 +23907,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23221,6 +23942,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23248,6 +23970,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23275,6 +23998,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23316,6 +24040,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23343,6 +24068,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23370,6 +24096,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23397,6 +24124,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23424,6 +24152,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23451,6 +24180,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23485,6 +24215,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23512,6 +24243,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23546,6 +24278,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23573,6 +24306,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23621,6 +24355,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23648,6 +24383,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23675,6 +24411,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23702,6 +24439,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23729,6 +24467,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23756,6 +24495,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23783,6 +24523,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23810,6 +24551,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23837,6 +24579,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23864,6 +24607,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -23891,6 +24635,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -23918,6 +24663,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -23966,6 +24712,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24014,6 +24761,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24041,6 +24789,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24068,6 +24817,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24095,6 +24845,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24122,6 +24873,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24149,6 +24901,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24176,6 +24929,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24203,6 +24957,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24230,6 +24985,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24257,6 +25013,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24284,6 +25041,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24311,6 +25069,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24338,6 +25097,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24372,6 +25132,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24434,6 +25195,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24461,6 +25223,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24488,6 +25251,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24515,6 +25279,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +25321,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -24625,6 +25391,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24694,6 +25461,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24721,6 +25489,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24748,6 +25517,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24817,6 +25587,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24844,6 +25615,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24871,6 +25643,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24898,6 +25671,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -24932,6 +25706,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24973,6 +25748,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25000,6 +25776,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25027,6 +25804,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25054,6 +25832,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25081,6 +25860,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25108,6 +25888,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25135,6 +25916,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25162,6 +25944,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25189,6 +25972,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25230,6 +26014,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25257,6 +26042,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25284,6 +26070,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25318,6 +26105,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25345,6 +26133,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25393,6 +26182,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25427,6 +26217,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25454,6 +26245,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25481,6 +26273,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25508,6 +26301,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25535,6 +26329,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25562,6 +26357,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25589,6 +26385,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25616,6 +26413,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25650,6 +26448,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25677,6 +26476,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25704,6 +26504,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25738,6 +26539,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25765,6 +26567,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25792,6 +26595,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25840,6 +26644,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25867,6 +26672,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -25894,6 +26700,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25921,6 +26728,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25955,6 +26763,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25996,6 +26805,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26833,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26050,6 +26861,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26077,6 +26889,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26139,6 +26952,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26166,6 +26980,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26193,6 +27008,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26220,6 +27036,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26247,6 +27064,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26274,6 +27092,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26301,6 +27120,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26335,6 +27155,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26362,6 +27183,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26431,6 +27253,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26458,6 +27281,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26527,6 +27351,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26554,6 +27379,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26581,6 +27407,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26608,6 +27435,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26635,6 +27463,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26662,6 +27491,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26689,6 +27519,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26716,6 +27547,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26743,6 +27575,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26770,6 +27603,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26797,6 +27631,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +27694,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27764,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -26955,6 +27792,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -26982,6 +27820,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27009,6 +27848,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27036,6 +27876,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27070,6 +27911,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27097,6 +27939,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27124,6 +27967,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27172,6 +28016,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27199,6 +28044,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27240,6 +28086,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27267,6 +28114,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27308,6 +28156,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27335,6 +28184,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +28212,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27396,6 +28247,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27423,6 +28275,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27450,6 +28303,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27477,6 +28331,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27504,6 +28359,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27531,6 +28387,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27558,6 +28415,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27585,6 +28443,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27612,6 +28471,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27639,6 +28499,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27666,6 +28527,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27693,6 +28555,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27720,6 +28583,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27747,6 +28611,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27774,6 +28639,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +28667,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27849,6 +28716,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -27876,6 +28744,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27903,6 +28772,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -27930,6 +28800,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -27957,6 +28828,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27984,6 +28856,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28011,6 +28884,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28038,6 +28912,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28065,6 +28940,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28092,6 +28968,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28119,6 +28996,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28146,6 +29024,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28180,6 +29059,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28207,6 +29087,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28234,6 +29115,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28261,6 +29143,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28288,6 +29171,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28357,6 +29241,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28384,6 +29269,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28411,6 +29297,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28438,6 +29325,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28465,6 +29353,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28492,6 +29381,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28519,6 +29409,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28546,6 +29437,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28573,6 +29465,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28600,6 +29493,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28627,6 +29521,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28654,6 +29549,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28688,6 +29584,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28715,6 +29612,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28749,6 +29647,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28776,6 +29675,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28803,6 +29703,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28830,6 +29731,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -28857,6 +29759,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28912,6 +29815,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28939,6 +29843,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29008,6 +29913,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29077,6 +29983,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29104,6 +30011,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29131,6 +30039,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29158,6 +30067,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29185,6 +30095,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29226,6 +30137,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29253,6 +30165,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29280,6 +30193,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29335,6 +30249,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29362,6 +30277,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29389,6 +30305,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29416,6 +30333,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29457,6 +30375,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29484,6 +30403,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29518,6 +30438,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29545,6 +30466,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29572,6 +30494,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29599,6 +30522,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29626,6 +30550,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29660,6 +30585,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29687,6 +30613,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29714,6 +30641,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29741,6 +30669,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29768,6 +30697,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29795,6 +30725,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29822,6 +30753,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -29849,6 +30781,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29918,6 +30851,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -29945,6 +30879,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -29972,6 +30907,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -29999,6 +30935,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30026,6 +30963,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30053,6 +30991,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30080,6 +31019,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30107,6 +31047,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30148,6 +31089,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30175,6 +31117,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30202,6 +31145,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30229,6 +31173,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30256,6 +31201,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30283,6 +31229,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30310,6 +31257,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30337,6 +31285,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30364,6 +31313,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30391,6 +31341,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30418,6 +31369,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30445,6 +31397,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -30472,6 +31425,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30499,6 +31453,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30533,6 +31488,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30595,6 +31551,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30622,6 +31579,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30649,6 +31607,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30676,6 +31635,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30703,6 +31663,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30730,6 +31691,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30757,6 +31719,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30784,6 +31747,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30811,6 +31775,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30866,6 +31831,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -30893,6 +31859,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30920,6 +31887,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30947,6 +31915,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -30974,6 +31943,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31001,6 +31971,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31035,6 +32006,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31062,6 +32034,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31089,6 +32062,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31116,6 +32090,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31143,6 +32118,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31170,6 +32146,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31197,6 +32174,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31224,6 +32202,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31251,6 +32230,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31278,6 +32258,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31305,6 +32286,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31346,6 +32328,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +32384,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31428,6 +32412,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31455,6 +32440,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31482,6 +32468,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31509,6 +32496,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31536,6 +32524,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31563,6 +32552,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31590,6 +32580,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31645,6 +32636,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31672,6 +32664,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31699,6 +32692,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31754,6 +32748,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31788,6 +32783,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31843,6 +32839,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31877,6 +32874,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31904,6 +32902,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -31938,6 +32937,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31986,6 +32986,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32027,6 +33028,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32054,6 +33056,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32081,6 +33084,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32108,6 +33112,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32135,6 +33140,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32162,6 +33168,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32196,6 +33203,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32223,6 +33231,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32250,6 +33259,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32277,6 +33287,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32304,6 +33315,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32331,6 +33343,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32358,6 +33371,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32385,6 +33399,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32412,6 +33427,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32439,6 +33455,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32466,6 +33483,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32493,6 +33511,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32520,6 +33539,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32547,6 +33567,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32574,6 +33595,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32601,6 +33623,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32628,6 +33651,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32655,6 +33679,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32682,6 +33707,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32730,6 +33756,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32771,6 +33798,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32798,6 +33826,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32825,6 +33854,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32852,6 +33882,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32914,6 +33945,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -32941,6 +33973,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -32968,6 +34001,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32995,6 +34029,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33029,6 +34064,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33056,6 +34092,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33083,6 +34120,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33124,6 +34162,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33151,6 +34190,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33178,6 +34218,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33205,6 +34246,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33232,6 +34274,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33301,6 +34344,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33328,6 +34372,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33376,6 +34421,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33403,6 +34449,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33451,6 +34498,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +34526,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +34555,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33539,6 +34590,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33580,6 +34632,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33621,6 +34674,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33648,6 +34702,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33675,6 +34730,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33702,6 +34758,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33736,6 +34793,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33763,6 +34821,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33790,6 +34849,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +34877,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -33844,6 +34905,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -33871,6 +34933,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -33898,6 +34961,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33925,6 +34989,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +35017,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -33979,6 +35045,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34020,6 +35087,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34047,6 +35115,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34116,6 +35185,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34143,6 +35213,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34170,6 +35241,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34197,6 +35269,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34224,6 +35297,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34251,6 +35325,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34285,6 +35360,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34319,6 +35395,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34346,6 +35423,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34415,6 +35493,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34442,6 +35521,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34469,6 +35549,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34496,6 +35577,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34523,6 +35605,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34550,6 +35633,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34605,6 +35689,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34632,6 +35717,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34666,6 +35752,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +35780,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34720,6 +35808,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34747,6 +35836,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34774,6 +35864,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34801,6 +35892,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34828,6 +35920,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -34855,6 +35948,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -34903,6 +35997,7 @@
         {
             "id": "0xe02e8ddecbe302ba1a40107c726e3ee889b0ff10",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
@@ -34937,6 +36032,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34964,6 +36060,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34991,6 +36088,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35018,6 +36116,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +36144,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +36193,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35120,6 +36221,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35147,6 +36249,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35174,6 +36277,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35201,6 +36305,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35228,6 +36333,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35255,6 +36361,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35282,6 +36389,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35309,6 +36417,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35336,6 +36445,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35363,6 +36473,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35425,6 +36536,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35473,6 +36585,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35500,6 +36613,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35527,6 +36641,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35554,6 +36669,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35581,6 +36697,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35615,6 +36732,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35642,6 +36760,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35669,6 +36788,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35696,6 +36816,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35723,6 +36844,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35771,6 +36893,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35798,6 +36921,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -35825,6 +36949,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35852,6 +36977,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -35879,6 +37005,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35913,6 +37040,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -35940,6 +37068,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -36009,6 +37138,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36057,6 +37187,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36112,6 +37243,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36153,6 +37285,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36180,6 +37313,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36249,6 +37383,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36276,6 +37411,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36303,6 +37439,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36330,6 +37467,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36357,6 +37495,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +37523,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36432,6 +37572,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36459,6 +37600,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36486,6 +37628,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36513,6 +37656,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36582,6 +37726,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36609,6 +37754,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36636,6 +37782,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36663,6 +37810,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36690,6 +37838,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36717,6 +37866,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36744,6 +37894,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36771,6 +37922,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36798,6 +37950,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36825,6 +37978,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36852,6 +38006,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -36886,6 +38041,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -36913,6 +38069,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -36940,6 +38097,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36967,6 +38125,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -36994,6 +38153,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -37021,6 +38181,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37048,6 +38209,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37103,6 +38265,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37130,6 +38293,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37185,6 +38349,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37212,6 +38377,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37239,6 +38405,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37287,6 +38454,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37314,6 +38482,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37341,6 +38510,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37368,6 +38538,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37409,6 +38580,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37436,6 +38608,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37470,6 +38643,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37497,6 +38671,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37531,6 +38706,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37558,6 +38734,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37585,6 +38762,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37612,6 +38790,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37639,6 +38818,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37687,6 +38867,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37721,6 +38902,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37748,6 +38930,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -37782,6 +38965,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37809,6 +38993,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37836,6 +39021,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -37884,6 +39070,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37911,6 +39098,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37938,6 +39126,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -37986,6 +39175,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -38013,6 +39203,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38040,6 +39231,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +39273,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38122,6 +39315,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38149,6 +39343,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38176,6 +39371,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38203,6 +39399,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38251,6 +39448,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38278,6 +39476,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38319,6 +39518,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38346,6 +39546,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38373,6 +39574,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38400,6 +39602,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38427,6 +39630,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38454,6 +39658,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38481,6 +39686,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38508,6 +39714,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38535,6 +39742,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38562,6 +39770,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38596,6 +39805,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38623,6 +39833,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38650,6 +39861,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38698,6 +39910,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38725,6 +39938,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38752,6 +39966,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38779,6 +39994,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38806,6 +40022,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -38833,6 +40050,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -38860,6 +40078,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -38887,6 +40106,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -38914,6 +40134,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38983,6 +40204,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39010,6 +40232,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39037,6 +40260,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39064,6 +40288,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39112,6 +40337,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39139,6 +40365,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39173,6 +40400,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39207,6 +40435,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39241,6 +40470,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39268,6 +40498,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39295,6 +40526,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39322,6 +40554,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39356,6 +40589,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39383,6 +40617,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39410,6 +40645,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39437,6 +40673,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39471,6 +40708,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39505,6 +40743,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39532,6 +40771,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39559,6 +40799,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39600,6 +40841,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39669,6 +40911,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39696,6 +40939,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39723,6 +40967,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39750,6 +40995,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39777,6 +41023,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39804,6 +41051,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39831,6 +41079,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39865,6 +41114,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39892,6 +41142,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -39919,6 +41170,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39988,6 +41240,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -40015,6 +41268,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40042,6 +41296,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40069,6 +41324,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40138,6 +41394,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0xc942c544631edcd1d73a17354c1997ad20482736117c0fd86e9ffd25eae18623.json
+++ b/test/testData/testPools/0xc942c544631edcd1d73a17354c1997ad20482736117c0fd86e9ffd25eae18623.json
@@ -2541,7 +2541,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6042,7 +6041,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8387,7 +8385,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -34526,7 +34523,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0xcacbae3bcfa3d5b8001022c0c9066abb66db43abb074dc6552430fde05aa9bb5.json
+++ b/test/testData/testPools/0xcacbae3bcfa3d5b8001022c0c9066abb66db43abb074dc6552430fde05aa9bb5.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xce3f018d5e66430057d70135ac7c027bd60992e25b3d9de961f18f4ae980d467.json
+++ b/test/testData/testPools/0xce3f018d5e66430057d70135ac7c027bd60992e25b3d9de961f18f4ae980d467.json
@@ -990,6 +990,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1017,6 +1018,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1288,6 +1290,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -1458,6 +1461,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -1485,6 +1489,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -1696,6 +1701,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2057,6 +2063,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2261,6 +2268,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2695,6 +2703,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2790,6 +2799,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2824,6 +2834,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2900,6 +2911,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3002,6 +3014,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3275,6 +3288,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -3302,6 +3316,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3363,6 +3378,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3505,6 +3521,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3871,6 +3888,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -4231,6 +4249,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4916,6 +4935,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -5086,6 +5106,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5188,6 +5209,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5269,6 +5291,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5608,6 +5631,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5826,6 +5850,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5895,6 +5920,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5949,6 +5975,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6118,6 +6145,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6199,6 +6227,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6335,6 +6364,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6504,6 +6534,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6755,6 +6786,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -7224,6 +7256,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7769,6 +7802,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7850,6 +7884,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8026,6 +8061,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8189,6 +8225,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8324,6 +8361,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8447,6 +8485,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8488,6 +8527,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8657,6 +8697,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -9030,6 +9071,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9343,6 +9385,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9493,6 +9536,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9758,6 +9802,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10043,6 +10088,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10138,6 +10184,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11231,6 +11278,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11360,6 +11408,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11468,6 +11517,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11549,6 +11599,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11822,6 +11873,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11849,6 +11901,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12510,6 +12563,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12848,6 +12902,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13133,6 +13188,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13377,6 +13433,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13588,6 +13645,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13615,6 +13673,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13663,6 +13722,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13731,6 +13791,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14051,6 +14112,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14222,6 +14284,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14290,6 +14353,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14351,6 +14415,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14392,6 +14457,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14488,6 +14554,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14867,6 +14934,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15037,6 +15105,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15064,6 +15133,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15133,6 +15203,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15390,6 +15461,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15540,6 +15612,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15648,6 +15721,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15729,6 +15803,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15925,6 +16000,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16224,6 +16300,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16293,6 +16370,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16692,6 +16770,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17323,6 +17402,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17513,6 +17593,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17750,6 +17831,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17819,6 +17901,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18022,6 +18105,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18307,6 +18391,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18708,6 +18793,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18891,6 +18977,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18945,6 +19032,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19149,6 +19237,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19991,6 +20080,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20072,6 +20162,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20099,6 +20190,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20187,6 +20279,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20437,6 +20530,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21074,6 +21168,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21687,6 +21782,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22185,6 +22281,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22584,6 +22681,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23133,6 +23231,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -23160,6 +23259,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -23201,6 +23301,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -23371,6 +23472,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23982,6 +24084,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24118,6 +24221,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -24274,6 +24378,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24687,6 +24792,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24795,6 +24901,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25446,6 +25553,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25487,6 +25595,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26120,6 +26229,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26581,6 +26691,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26927,6 +27038,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26954,6 +27066,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +27571,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27647,6 +27761,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27728,6 +27843,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27790,6 +27906,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27859,6 +27976,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -28055,6 +28173,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28266,6 +28385,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -28293,6 +28413,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28705,6 +28826,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28732,6 +28854,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28807,6 +28930,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28996,6 +29120,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -29138,6 +29263,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29504,6 +29630,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29788,6 +29915,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30008,6 +30136,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30157,6 +30286,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30753,6 +30883,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31133,6 +31264,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31349,6 +31481,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31993,6 +32126,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32250,6 +32384,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32305,6 +32440,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32440,6 +32576,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32747,6 +32884,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32842,6 +32980,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32985,6 +33124,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33343,6 +33483,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33559,6 +33700,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33818,6 +33960,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -34055,6 +34198,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34136,6 +34280,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34232,6 +34377,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34307,6 +34453,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34382,6 +34529,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34409,6 +34557,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34552,6 +34701,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34694,6 +34844,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34721,6 +34872,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35250,6 +35402,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35570,6 +35723,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35597,6 +35751,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35651,6 +35806,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35888,6 +36044,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35915,6 +36072,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35963,6 +36121,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36668,6 +36827,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37227,6 +37387,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37254,6 +37415,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37383,6 +37545,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37837,6 +38000,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38428,6 +38592,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38618,6 +38783,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38910,6 +39076,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38951,6 +39118,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39019,6 +39187,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39189,6 +39358,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39270,6 +39440,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39466,6 +39637,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39676,6 +39848,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39934,6 +40107,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40470,6 +40644,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40647,6 +40822,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40789,6 +40965,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xd3b9ce97141378c4c87726a3a139df3f24d44cd9187487ed1c1912b834f54f3b.json
+++ b/test/testData/testPools/0xd3b9ce97141378c4c87726a3a139df3f24d44cd9187487ed1c1912b834f54f3b.json
@@ -1161,6 +1161,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2468,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5859,6 +5861,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8134,6 +8137,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8451,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14644,6 +14649,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -20178,6 +20184,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -33486,6 +33493,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",

--- a/test/testData/testPools/0xd68826bf7ec8c83d250efac7d38567146a66bcaba9c415825736dcb6fbce2b46.json
+++ b/test/testData/testPools/0xd68826bf7ec8c83d250efac7d38567146a66bcaba9c415825736dcb6fbce2b46.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xd7236b8a38f11b4a67b7c2eca89b0bf69187a50e3deb9bfe9f215064ae63dcba.json
+++ b/test/testData/testPools/0xd7236b8a38f11b4a67b7c2eca89b0bf69187a50e3deb9bfe9f215064ae63dcba.json
@@ -1161,6 +1161,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2468,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5859,6 +5861,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8134,6 +8137,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8451,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14575,6 +14580,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -20143,6 +20149,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -33478,6 +33485,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",

--- a/test/testData/testPools/0xd8087d6392b331f1664c18d40e62cf89fdff63722404d7563011e44cbb1e6c4c.json
+++ b/test/testData/testPools/0xd8087d6392b331f1664c18d40e62cf89fdff63722404d7563011e44cbb1e6c4c.json
@@ -990,6 +990,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1017,6 +1018,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1288,6 +1290,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -1458,6 +1461,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -1485,6 +1489,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -1696,6 +1701,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2057,6 +2063,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2261,6 +2268,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2695,6 +2703,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2790,6 +2799,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2824,6 +2834,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2900,6 +2911,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3002,6 +3014,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3275,6 +3288,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -3302,6 +3316,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3363,6 +3378,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3505,6 +3521,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3871,6 +3888,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -4231,6 +4249,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4916,6 +4935,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -5086,6 +5106,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5188,6 +5209,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5269,6 +5291,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5608,6 +5631,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5826,6 +5850,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5895,6 +5920,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5949,6 +5975,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6118,6 +6145,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6199,6 +6227,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6335,6 +6364,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6504,6 +6534,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6755,6 +6786,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -7224,6 +7256,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7769,6 +7802,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7850,6 +7884,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8026,6 +8061,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8189,6 +8225,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8324,6 +8361,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8447,6 +8485,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8488,6 +8527,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8657,6 +8697,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -9030,6 +9071,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9343,6 +9385,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9493,6 +9536,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9758,6 +9802,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10043,6 +10088,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10138,6 +10184,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11231,6 +11278,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11360,6 +11408,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11468,6 +11517,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11549,6 +11599,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11822,6 +11873,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11849,6 +11901,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12510,6 +12563,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12848,6 +12902,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13133,6 +13188,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13377,6 +13433,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13588,6 +13645,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13615,6 +13673,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13663,6 +13722,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13731,6 +13791,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14051,6 +14112,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14222,6 +14284,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14290,6 +14353,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14351,6 +14415,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14392,6 +14457,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14488,6 +14554,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14867,6 +14934,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15037,6 +15105,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15064,6 +15133,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15133,6 +15203,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15390,6 +15461,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15540,6 +15612,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15648,6 +15721,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15729,6 +15803,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15925,6 +16000,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16224,6 +16300,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16293,6 +16370,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16692,6 +16770,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17323,6 +17402,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17513,6 +17593,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17750,6 +17831,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17819,6 +17901,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18022,6 +18105,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18307,6 +18391,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18708,6 +18793,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18891,6 +18977,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18945,6 +19032,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19149,6 +19237,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19991,6 +20080,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20072,6 +20162,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20099,6 +20190,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20187,6 +20279,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20437,6 +20530,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21074,6 +21168,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21687,6 +21782,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22185,6 +22281,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22584,6 +22681,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23133,6 +23231,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -23160,6 +23259,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -23201,6 +23301,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -23371,6 +23472,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23982,6 +24084,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24118,6 +24221,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -24274,6 +24378,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24687,6 +24792,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24795,6 +24901,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25446,6 +25553,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25487,6 +25595,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26120,6 +26229,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26581,6 +26691,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26927,6 +27038,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26954,6 +27066,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +27571,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27647,6 +27761,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27728,6 +27843,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27790,6 +27906,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27859,6 +27976,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -28055,6 +28173,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28266,6 +28385,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -28293,6 +28413,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28705,6 +28826,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28732,6 +28854,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28807,6 +28930,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28996,6 +29120,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -29138,6 +29263,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29504,6 +29630,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29788,6 +29915,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30008,6 +30136,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30157,6 +30286,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30753,6 +30883,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31133,6 +31264,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31349,6 +31481,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31993,6 +32126,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32250,6 +32384,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32305,6 +32440,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32440,6 +32576,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32747,6 +32884,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32842,6 +32980,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32985,6 +33124,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33343,6 +33483,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33559,6 +33700,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33818,6 +33960,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -34055,6 +34198,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34136,6 +34280,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34232,6 +34377,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34307,6 +34453,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34382,6 +34529,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34409,6 +34557,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34552,6 +34701,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34694,6 +34844,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34721,6 +34872,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35250,6 +35402,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35570,6 +35723,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35597,6 +35751,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35651,6 +35806,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35888,6 +36044,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35915,6 +36072,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35963,6 +36121,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36668,6 +36827,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37227,6 +37387,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37254,6 +37415,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37383,6 +37545,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37837,6 +38000,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38428,6 +38592,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38618,6 +38783,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38910,6 +39076,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38951,6 +39118,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39019,6 +39187,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39189,6 +39358,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39270,6 +39440,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39466,6 +39637,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39676,6 +39848,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39934,6 +40107,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40470,6 +40644,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40647,6 +40822,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40789,6 +40965,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xdbd9638d8df794dba5a330d29481e23e067d1387933cc95a558c8f93ea7b98ba.json
+++ b/test/testData/testPools/0xdbd9638d8df794dba5a330d29481e23e067d1387933cc95a558c8f93ea7b98ba.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -94,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -169,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -196,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -230,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -257,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -284,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -311,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -338,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -365,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -392,6 +405,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -419,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -467,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -508,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -535,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -562,6 +580,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +608,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -616,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -643,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -691,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -718,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -745,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -800,6 +825,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -848,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -875,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -902,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -929,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -956,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -997,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1024,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1065,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1092,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1161,6 +1196,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1230,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1257,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1284,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1311,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1338,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1365,6 +1406,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1392,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1419,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1467,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1494,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1542,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1569,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1596,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1623,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1664,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1691,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1718,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1745,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1772,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1799,6 +1854,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1826,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1867,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1894,6 +1952,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1987,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -1976,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2004,6 +2065,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2051,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2169,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2168,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2216,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2243,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2270,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2325,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2352,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2379,6 +2449,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2477,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2440,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2467,6 +2540,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2494,6 +2569,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2528,6 +2604,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2555,6 +2632,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2582,6 +2660,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2609,6 +2688,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2657,6 +2737,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2684,6 +2765,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2718,6 +2800,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2745,6 +2828,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2772,6 +2856,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2799,6 +2884,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2826,6 +2912,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2860,6 +2947,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2887,6 +2975,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2914,6 +3003,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2941,6 +3031,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -2975,6 +3066,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3044,6 +3136,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3078,6 +3171,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3105,6 +3199,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3132,6 +3227,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3159,6 +3255,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3200,6 +3297,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3227,6 +3325,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3254,6 +3353,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3281,6 +3381,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3308,6 +3409,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3335,6 +3437,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3376,6 +3479,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3424,6 +3528,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3451,6 +3556,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3478,6 +3584,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3505,6 +3612,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3532,6 +3640,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3601,6 +3710,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3628,6 +3738,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3655,6 +3766,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3682,6 +3794,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3709,6 +3822,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3736,6 +3850,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3763,6 +3878,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3790,6 +3906,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3824,6 +3941,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3851,6 +3969,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3878,6 +3997,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3905,6 +4025,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3939,6 +4060,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3966,6 +4088,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -3993,6 +4116,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4020,6 +4144,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4047,6 +4172,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4088,6 +4214,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4115,6 +4242,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4163,6 +4291,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4190,6 +4319,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4238,6 +4368,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4265,6 +4396,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4292,6 +4424,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4319,6 +4452,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4346,6 +4480,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4373,6 +4508,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4428,6 +4564,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4469,6 +4606,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4496,6 +4634,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4523,6 +4662,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4550,6 +4690,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4577,6 +4718,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4604,6 +4746,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4774,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4658,6 +4802,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4685,6 +4830,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4712,6 +4858,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4739,6 +4886,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4808,6 +4956,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4835,6 +4984,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4862,6 +5012,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4889,6 +5040,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -4930,6 +5082,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5152,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5026,6 +5180,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5053,6 +5208,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5080,6 +5236,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5114,6 +5271,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5141,6 +5299,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5168,6 +5327,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5195,6 +5355,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5222,6 +5383,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5249,6 +5411,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5276,6 +5439,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5303,6 +5467,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5495,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5357,6 +5523,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5412,6 +5579,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5439,6 +5607,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5473,6 +5642,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5500,6 +5670,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5527,6 +5698,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5554,6 +5726,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5581,6 +5754,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5608,6 +5782,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5635,6 +5810,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5669,6 +5845,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5696,6 +5873,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5723,6 +5901,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5778,6 +5957,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5805,6 +5985,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5832,6 +6013,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5859,6 +6041,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -5886,6 +6070,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5913,6 +6098,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5940,6 +6126,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5967,6 +6154,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5994,6 +6182,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6021,6 +6210,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6069,6 +6259,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6096,6 +6287,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6137,6 +6329,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6185,6 +6378,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6212,6 +6406,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6239,6 +6434,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6294,6 +6490,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6328,6 +6525,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6369,6 +6567,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6438,6 +6637,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6465,6 +6665,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6499,6 +6700,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6526,6 +6728,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6553,6 +6756,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6580,6 +6784,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6607,6 +6812,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6634,6 +6840,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6661,6 +6868,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6688,6 +6896,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6750,6 +6959,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6819,6 +7029,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6846,6 +7057,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6873,6 +7085,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6900,6 +7113,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6927,6 +7141,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6954,6 +7169,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -6988,6 +7204,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7015,6 +7232,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7042,6 +7260,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7069,6 +7288,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7103,6 +7323,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7130,6 +7351,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7157,6 +7379,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7184,6 +7407,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7239,6 +7463,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7266,6 +7491,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7293,6 +7519,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7320,6 +7547,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7347,6 +7575,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7374,6 +7603,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7401,6 +7631,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7428,6 +7659,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7455,6 +7687,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7482,6 +7715,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7551,6 +7785,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7827,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7855,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7646,6 +7883,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7673,6 +7911,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7700,6 +7939,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7727,6 +7967,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7761,6 +8002,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7788,6 +8030,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7822,6 +8065,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7849,6 +8093,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7876,6 +8121,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7924,6 +8170,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7951,6 +8198,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -7978,6 +8226,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8005,6 +8254,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8032,6 +8282,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8059,6 +8310,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8086,6 +8338,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8134,6 +8387,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8161,6 +8416,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8188,6 +8444,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8222,6 +8479,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8249,6 +8507,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8276,6 +8535,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8317,6 +8577,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8344,6 +8605,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8378,6 +8640,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8447,6 +8710,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8474,6 +8738,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8501,6 +8766,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8528,6 +8794,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8597,6 +8864,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8624,6 +8892,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8651,6 +8920,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8678,6 +8948,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8712,6 +8983,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8739,6 +9011,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8787,6 +9060,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8835,6 +9109,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8862,6 +9137,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +9165,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8916,6 +9193,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8943,6 +9221,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -8970,6 +9249,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8997,6 +9277,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9066,6 +9347,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9093,6 +9375,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9120,6 +9403,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9147,6 +9431,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9174,6 +9459,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9215,6 +9501,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9242,6 +9529,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -9311,6 +9599,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9359,6 +9648,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9386,6 +9676,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9455,6 +9746,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9503,6 +9795,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9530,6 +9823,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9557,6 +9851,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9584,6 +9879,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9611,6 +9907,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9638,6 +9935,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9665,6 +9963,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9692,6 +9991,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9719,6 +10019,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9746,6 +10047,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9773,6 +10075,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9800,6 +10103,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9827,6 +10131,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9854,6 +10159,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9881,6 +10187,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9908,6 +10215,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9935,6 +10243,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -9962,6 +10271,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10003,6 +10313,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10030,6 +10341,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10057,6 +10369,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10112,6 +10425,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10139,6 +10453,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10166,6 +10481,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10200,6 +10516,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10227,6 +10544,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10254,6 +10572,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10281,6 +10600,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10308,6 +10628,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10335,6 +10656,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10362,6 +10684,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10389,6 +10712,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10437,6 +10761,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10464,6 +10789,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10491,6 +10817,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10518,6 +10845,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10545,6 +10873,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10572,6 +10901,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10599,6 +10929,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10626,6 +10957,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10653,6 +10985,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10715,6 +11048,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10742,6 +11076,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10769,6 +11104,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10796,6 +11132,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10865,6 +11202,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10899,6 +11237,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -10926,6 +11265,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11293,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -10980,6 +11321,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11007,6 +11349,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11055,6 +11398,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11082,6 +11426,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11130,6 +11475,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11157,6 +11503,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11184,6 +11531,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11246,6 +11594,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11287,6 +11636,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11314,6 +11664,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11341,6 +11692,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11368,6 +11720,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11395,6 +11748,7 @@
         {
             "id": "0x4b3fa856cef9aa85ed9bbfa8992d6138c5f150e6",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -11464,6 +11818,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11533,6 +11888,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11560,6 +11916,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11587,6 +11944,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11614,6 +11972,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11648,6 +12007,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11682,6 +12042,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11709,6 +12070,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11736,6 +12098,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11763,6 +12126,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11790,6 +12154,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11817,6 +12182,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11844,6 +12210,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11871,6 +12238,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11898,6 +12266,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11925,6 +12294,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11952,6 +12322,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -11979,6 +12350,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12006,6 +12378,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12033,6 +12406,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12060,6 +12434,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12122,6 +12497,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12156,6 +12532,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12183,6 +12560,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12210,6 +12588,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12237,6 +12616,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12264,6 +12644,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12319,6 +12700,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12346,6 +12728,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12373,6 +12756,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12400,6 +12784,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12427,6 +12812,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12454,6 +12840,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12481,6 +12868,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12508,6 +12896,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12577,6 +12966,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12604,6 +12994,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12631,6 +13022,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12665,6 +13057,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12692,6 +13085,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +13113,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +13162,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12794,6 +13190,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +13232,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12890,6 +13288,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12924,6 +13323,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12993,6 +13393,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13020,6 +13421,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13047,6 +13449,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13074,6 +13477,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13101,6 +13505,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13128,6 +13533,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13155,6 +13561,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13182,6 +13589,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13209,6 +13617,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13257,6 +13666,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13326,6 +13736,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13353,6 +13764,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13394,6 +13806,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13421,6 +13834,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13455,6 +13869,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13911,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13565,6 +13981,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13592,6 +14009,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13619,6 +14037,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13646,6 +14065,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13673,6 +14093,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13728,6 +14149,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13755,6 +14177,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13782,6 +14205,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13809,6 +14233,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13836,6 +14261,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13863,6 +14289,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13890,6 +14317,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13917,6 +14345,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13944,6 +14373,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -13971,6 +14401,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14033,6 +14464,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14060,6 +14492,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14087,6 +14520,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14114,6 +14548,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14141,6 +14576,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14604,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14674,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14264,6 +14702,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14291,6 +14730,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14318,6 +14758,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14345,6 +14786,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14386,6 +14828,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14413,6 +14856,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14440,6 +14884,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14467,6 +14912,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14494,6 +14940,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14521,6 +14968,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14548,6 +14996,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14575,6 +15024,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14644,6 +15094,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14671,6 +15122,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14698,6 +15150,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14725,6 +15178,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14752,6 +15206,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14779,6 +15234,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14806,6 +15262,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14833,6 +15290,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14867,6 +15325,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14894,6 +15353,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14921,6 +15381,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14948,6 +15409,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14975,6 +15437,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15002,6 +15465,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15029,6 +15493,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15056,6 +15521,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15125,6 +15591,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15152,6 +15619,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15179,6 +15647,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15206,6 +15675,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15233,6 +15703,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15260,6 +15731,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15287,6 +15759,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15328,6 +15801,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15871,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15424,6 +15899,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15451,6 +15927,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15478,6 +15955,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15505,6 +15983,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15532,6 +16011,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15573,6 +16053,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15600,6 +16081,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15627,6 +16109,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15654,6 +16137,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15681,6 +16165,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15715,6 +16200,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15742,6 +16228,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15769,6 +16256,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15796,6 +16284,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -15865,6 +16354,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15892,6 +16382,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15919,6 +16410,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15946,6 +16438,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15973,6 +16466,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16000,6 +16494,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16027,6 +16522,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16054,6 +16550,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16081,6 +16578,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16108,6 +16606,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16135,6 +16634,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16176,6 +16676,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16203,6 +16704,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16230,6 +16732,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16292,6 +16795,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16319,6 +16823,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16346,6 +16851,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16373,6 +16879,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16400,6 +16907,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16427,6 +16935,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16454,6 +16963,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16481,6 +16991,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16508,6 +17019,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16535,6 +17047,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16562,6 +17075,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16617,6 +17131,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16651,6 +17166,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16678,6 +17194,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16705,6 +17222,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16732,6 +17250,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16759,6 +17278,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16786,6 +17306,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16813,6 +17334,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16854,6 +17376,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17446,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -16957,6 +17481,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16984,6 +17509,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17011,6 +17537,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17038,6 +17565,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17065,6 +17593,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17099,6 +17628,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17126,6 +17656,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17153,6 +17684,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17222,6 +17754,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17249,6 +17782,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17276,6 +17810,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17303,6 +17838,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17330,6 +17866,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17357,6 +17894,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17384,6 +17922,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17411,6 +17950,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17473,6 +18013,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17500,6 +18041,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17527,6 +18069,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17554,6 +18097,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17581,6 +18125,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17629,6 +18174,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17670,6 +18216,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17697,6 +18244,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17724,6 +18272,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17758,6 +18307,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17785,6 +18335,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17812,6 +18363,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17853,6 +18405,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17880,6 +18433,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17914,6 +18468,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17941,6 +18496,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17968,6 +18524,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17995,6 +18552,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18022,6 +18580,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18049,6 +18608,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18076,6 +18636,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18145,6 +18706,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18172,6 +18734,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18199,6 +18762,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18226,6 +18790,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18253,6 +18818,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -18280,6 +18846,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18349,6 +18916,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18376,6 +18944,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18445,6 +19014,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18472,6 +19042,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18499,6 +19070,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18526,6 +19098,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18553,6 +19126,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18580,6 +19154,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18607,6 +19182,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18641,6 +19217,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18675,6 +19252,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18702,6 +19280,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18729,6 +19308,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18784,6 +19364,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18811,6 +19392,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18838,6 +19420,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18865,6 +19448,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18899,6 +19483,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18926,6 +19511,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18953,6 +19539,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18980,6 +19567,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19007,6 +19595,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19041,6 +19630,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19068,6 +19658,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19095,6 +19686,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19122,6 +19714,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19149,6 +19742,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19176,6 +19770,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19798,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19230,6 +19826,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19264,6 +19861,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19291,6 +19889,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19318,6 +19917,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19345,6 +19945,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19372,6 +19973,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19399,6 +20001,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19433,6 +20036,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19460,6 +20064,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19487,6 +20092,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19514,6 +20120,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19541,6 +20148,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -19568,6 +20176,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19595,6 +20204,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19622,6 +20232,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19670,6 +20281,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19697,6 +20309,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19724,6 +20337,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19751,6 +20365,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19778,6 +20393,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19805,6 +20421,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19832,6 +20449,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19859,6 +20477,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19886,6 +20505,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -19955,6 +20575,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19982,6 +20603,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20009,6 +20631,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20036,6 +20659,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20070,6 +20694,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20097,6 +20722,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20124,6 +20750,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20151,6 +20778,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20178,6 +20806,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20219,6 +20848,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20246,6 +20876,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20287,6 +20918,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20314,6 +20946,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20383,6 +21016,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20445,6 +21079,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20472,6 +21107,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20541,6 +21177,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20568,6 +21205,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20595,6 +21233,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20622,6 +21261,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20649,6 +21289,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20676,6 +21317,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20703,6 +21345,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20730,6 +21373,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20764,6 +21408,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20791,6 +21436,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -20853,6 +21499,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20880,6 +21527,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20907,6 +21555,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -20941,6 +21590,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20975,6 +21625,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21016,6 +21667,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21071,6 +21723,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21098,6 +21751,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21125,6 +21779,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21194,6 +21849,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21221,6 +21877,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21262,6 +21919,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21289,6 +21947,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21316,6 +21975,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21343,6 +22003,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21370,6 +22031,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21404,6 +22066,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21431,6 +22094,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21458,6 +22122,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21485,6 +22150,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21512,6 +22178,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21539,6 +22206,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21580,6 +22248,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21607,6 +22276,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21634,6 +22304,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21661,6 +22332,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21688,6 +22360,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -21736,6 +22409,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21763,6 +22437,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21790,6 +22465,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21817,6 +22493,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21844,6 +22521,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21871,6 +22549,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21919,6 +22598,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -21953,6 +22633,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21980,6 +22661,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22007,6 +22689,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22034,6 +22717,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22061,6 +22745,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22088,6 +22773,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22115,6 +22801,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22156,6 +22843,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22183,6 +22871,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22210,6 +22899,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22237,6 +22927,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22955,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22997,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22346,6 +23039,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22387,6 +23081,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22414,6 +23109,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22448,6 +23144,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22475,6 +23172,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -22502,6 +23200,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22529,6 +23228,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22556,6 +23256,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22604,6 +23305,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22645,6 +23347,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22672,6 +23375,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22699,6 +23403,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22768,6 +23473,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22802,6 +23508,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22829,6 +23536,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22863,6 +23571,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22897,6 +23606,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22924,6 +23634,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22951,6 +23662,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -22978,6 +23690,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23005,6 +23718,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23032,6 +23746,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23059,6 +23774,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23086,6 +23802,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23113,6 +23830,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23140,6 +23858,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23195,6 +23914,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23222,6 +23942,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23256,6 +23977,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23283,6 +24005,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23310,6 +24033,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23351,6 +24075,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23378,6 +24103,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23405,6 +24131,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23432,6 +24159,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23459,6 +24187,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23486,6 +24215,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23520,6 +24250,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23547,6 +24278,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23581,6 +24313,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23608,6 +24341,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23656,6 +24390,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23683,6 +24418,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23710,6 +24446,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23737,6 +24474,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23764,6 +24502,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23791,6 +24530,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23818,6 +24558,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23845,6 +24586,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23872,6 +24614,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23899,6 +24642,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -23926,6 +24670,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -23953,6 +24698,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24001,6 +24747,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24049,6 +24796,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24076,6 +24824,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24103,6 +24852,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24130,6 +24880,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24157,6 +24908,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24184,6 +24936,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24211,6 +24964,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24238,6 +24992,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24265,6 +25020,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24292,6 +25048,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24319,6 +25076,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24346,6 +25104,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24373,6 +25132,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24407,6 +25167,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24469,6 +25230,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24496,6 +25258,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24523,6 +25286,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24550,6 +25314,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +25356,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -24660,6 +25426,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24729,6 +25496,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24756,6 +25524,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24783,6 +25552,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24852,6 +25622,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24879,6 +25650,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24906,6 +25678,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24933,6 +25706,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -24967,6 +25741,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25008,6 +25783,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25035,6 +25811,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25062,6 +25839,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25089,6 +25867,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25116,6 +25895,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25143,6 +25923,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25170,6 +25951,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25197,6 +25979,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25224,6 +26007,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25265,6 +26049,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25292,6 +26077,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25319,6 +26105,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25353,6 +26140,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25380,6 +26168,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25428,6 +26217,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25462,6 +26252,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25489,6 +26280,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25516,6 +26308,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25543,6 +26336,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25570,6 +26364,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25597,6 +26392,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25624,6 +26420,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25651,6 +26448,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25685,6 +26483,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25712,6 +26511,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25739,6 +26539,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25773,6 +26574,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25800,6 +26602,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25827,6 +26630,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25875,6 +26679,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25902,6 +26707,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -25929,6 +26735,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25956,6 +26763,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25990,6 +26798,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26031,6 +26840,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26868,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26085,6 +26896,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26112,6 +26924,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26174,6 +26987,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26201,6 +27015,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26228,6 +27043,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26255,6 +27071,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26282,6 +27099,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26309,6 +27127,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26336,6 +27155,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26370,6 +27190,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26397,6 +27218,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26466,6 +27288,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26493,6 +27316,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26562,6 +27386,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26589,6 +27414,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26616,6 +27442,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26643,6 +27470,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26670,6 +27498,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26697,6 +27526,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26724,6 +27554,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26751,6 +27582,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26778,6 +27610,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26805,6 +27638,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26832,6 +27666,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27729,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27799,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -26990,6 +27827,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27017,6 +27855,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27044,6 +27883,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27071,6 +27911,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27105,6 +27946,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27132,6 +27974,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27159,6 +28002,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27207,6 +28051,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27234,6 +28079,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27275,6 +28121,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27302,6 +28149,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27343,6 +28191,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27370,6 +28219,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +28247,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27431,6 +28282,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +28310,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27485,6 +28338,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27512,6 +28366,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27539,6 +28394,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27566,6 +28422,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27593,6 +28450,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27620,6 +28478,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27647,6 +28506,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27674,6 +28534,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27701,6 +28562,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27728,6 +28590,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27755,6 +28618,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27782,6 +28646,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27809,6 +28674,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +28702,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27884,6 +28751,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -27911,6 +28779,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27938,6 +28807,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -27965,6 +28835,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -27992,6 +28863,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28019,6 +28891,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28046,6 +28919,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28073,6 +28947,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28100,6 +28975,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28127,6 +29003,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28154,6 +29031,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28181,6 +29059,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28215,6 +29094,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28242,6 +29122,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28269,6 +29150,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28296,6 +29178,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28323,6 +29206,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28392,6 +29276,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28419,6 +29304,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28446,6 +29332,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28473,6 +29360,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28500,6 +29388,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28527,6 +29416,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28554,6 +29444,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28581,6 +29472,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28608,6 +29500,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28635,6 +29528,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28662,6 +29556,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28689,6 +29584,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28723,6 +29619,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28750,6 +29647,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28784,6 +29682,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28811,6 +29710,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28838,6 +29738,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28865,6 +29766,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -28892,6 +29794,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28947,6 +29850,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28974,6 +29878,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29043,6 +29948,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29112,6 +30018,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29139,6 +30046,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29166,6 +30074,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29193,6 +30102,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29220,6 +30130,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29261,6 +30172,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29288,6 +30200,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29315,6 +30228,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29370,6 +30284,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29397,6 +30312,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29424,6 +30340,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29451,6 +30368,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29492,6 +30410,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29519,6 +30438,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29553,6 +30473,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29580,6 +30501,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29607,6 +30529,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29634,6 +30557,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29661,6 +30585,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29695,6 +30620,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29722,6 +30648,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29749,6 +30676,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29776,6 +30704,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29803,6 +30732,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29830,6 +30760,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29857,6 +30788,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29926,6 +30858,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -29953,6 +30886,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -29980,6 +30914,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30007,6 +30942,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30034,6 +30970,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30061,6 +30998,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30088,6 +31026,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30115,6 +31054,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30156,6 +31096,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30183,6 +31124,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30210,6 +31152,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30237,6 +31180,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30264,6 +31208,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30291,6 +31236,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30318,6 +31264,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30345,6 +31292,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30372,6 +31320,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30399,6 +31348,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30426,6 +31376,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30453,6 +31404,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -30480,6 +31432,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30507,6 +31460,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30541,6 +31495,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30603,6 +31558,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30630,6 +31586,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30657,6 +31614,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30684,6 +31642,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30711,6 +31670,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30738,6 +31698,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30765,6 +31726,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30792,6 +31754,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30819,6 +31782,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30874,6 +31838,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -30901,6 +31866,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30928,6 +31894,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30955,6 +31922,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -30982,6 +31950,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31009,6 +31978,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31043,6 +32013,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31070,6 +32041,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31097,6 +32069,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31124,6 +32097,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31151,6 +32125,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31178,6 +32153,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31205,6 +32181,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31232,6 +32209,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31259,6 +32237,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31286,6 +32265,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31313,6 +32293,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31354,6 +32335,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +32391,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31436,6 +32419,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31463,6 +32447,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31490,6 +32475,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31517,6 +32503,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31544,6 +32531,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31571,6 +32559,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31598,6 +32587,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31653,6 +32643,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31680,6 +32671,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31707,6 +32699,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31762,6 +32755,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31796,6 +32790,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31851,6 +32846,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31885,6 +32881,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31912,6 +32909,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -31946,6 +32944,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31994,6 +32993,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32035,6 +33035,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32062,6 +33063,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32089,6 +33091,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32116,6 +33119,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32143,6 +33147,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32170,6 +33175,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32204,6 +33210,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32231,6 +33238,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32258,6 +33266,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32285,6 +33294,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32312,6 +33322,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32339,6 +33350,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32366,6 +33378,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32393,6 +33406,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32420,6 +33434,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32447,6 +33462,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32474,6 +33490,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32501,6 +33518,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32528,6 +33546,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32555,6 +33574,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32582,6 +33602,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32609,6 +33630,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32636,6 +33658,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32663,6 +33686,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32690,6 +33714,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32738,6 +33763,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32779,6 +33805,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32806,6 +33833,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32833,6 +33861,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32860,6 +33889,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32922,6 +33952,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -32949,6 +33980,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -32976,6 +34008,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33003,6 +34036,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33037,6 +34071,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33064,6 +34099,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33091,6 +34127,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33132,6 +34169,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33159,6 +34197,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33186,6 +34225,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33213,6 +34253,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33240,6 +34281,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33309,6 +34351,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33336,6 +34379,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33384,6 +34428,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33411,6 +34456,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33459,6 +34505,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +34533,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +34562,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33547,6 +34597,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33588,6 +34639,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33629,6 +34681,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33656,6 +34709,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33683,6 +34737,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33710,6 +34765,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33744,6 +34800,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33771,6 +34828,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33798,6 +34856,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +34884,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -33852,6 +34912,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -33879,6 +34940,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -33906,6 +34968,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33933,6 +34996,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33960,6 +35024,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -33987,6 +35052,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34028,6 +35094,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34055,6 +35122,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34124,6 +35192,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34151,6 +35220,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34178,6 +35248,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34205,6 +35276,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34232,6 +35304,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34259,6 +35332,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34293,6 +35367,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34327,6 +35402,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34354,6 +35430,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34423,6 +35500,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34450,6 +35528,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34477,6 +35556,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34504,6 +35584,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +35612,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34558,6 +35640,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34613,6 +35696,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34640,6 +35724,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34674,6 +35759,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +35787,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34728,6 +35815,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34755,6 +35843,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34782,6 +35871,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34809,6 +35899,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34836,6 +35927,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -34863,6 +35955,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -34911,6 +36004,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34938,6 +36032,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34965,6 +36060,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34992,6 +36088,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +36116,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +36165,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35094,6 +36193,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35121,6 +36221,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35148,6 +36249,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35175,6 +36277,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35202,6 +36305,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35229,6 +36333,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35256,6 +36361,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35283,6 +36389,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35310,6 +36417,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35337,6 +36445,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35399,6 +36508,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35447,6 +36557,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35474,6 +36585,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35501,6 +36613,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35528,6 +36641,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35555,6 +36669,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35589,6 +36704,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35616,6 +36732,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35643,6 +36760,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35670,6 +36788,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35697,6 +36816,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35745,6 +36865,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35772,6 +36893,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -35799,6 +36921,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35826,6 +36949,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -35853,6 +36977,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35887,6 +37012,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -35914,6 +37040,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -35983,6 +37110,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36031,6 +37159,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36086,6 +37215,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36127,6 +37257,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36154,6 +37285,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36223,6 +37355,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36250,6 +37383,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36277,6 +37411,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36304,6 +37439,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36331,6 +37467,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +37495,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36406,6 +37544,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36433,6 +37572,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36460,6 +37600,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36487,6 +37628,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36556,6 +37698,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36583,6 +37726,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36610,6 +37754,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36637,6 +37782,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36664,6 +37810,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36691,6 +37838,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36718,6 +37866,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36745,6 +37894,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36772,6 +37922,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36799,6 +37950,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36826,6 +37978,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -36860,6 +38013,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -36887,6 +38041,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -36914,6 +38069,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36941,6 +38097,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -36968,6 +38125,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -36995,6 +38153,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37022,6 +38181,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37077,6 +38237,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37104,6 +38265,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37159,6 +38321,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37186,6 +38349,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37213,6 +38377,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37261,6 +38426,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37288,6 +38454,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37315,6 +38482,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37342,6 +38510,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37383,6 +38552,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37410,6 +38580,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37444,6 +38615,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37471,6 +38643,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37505,6 +38678,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37532,6 +38706,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37559,6 +38734,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37586,6 +38762,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37613,6 +38790,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37661,6 +38839,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37695,6 +38874,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37722,6 +38902,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -37756,6 +38937,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37783,6 +38965,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37810,6 +38993,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -37858,6 +39042,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37885,6 +39070,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37912,6 +39098,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -37960,6 +39147,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -37987,6 +39175,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38014,6 +39203,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +39245,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38096,6 +39287,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38123,6 +39315,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38150,6 +39343,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38177,6 +39371,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38225,6 +39420,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38252,6 +39448,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38293,6 +39490,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38320,6 +39518,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38347,6 +39546,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38374,6 +39574,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38401,6 +39602,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38428,6 +39630,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38455,6 +39658,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38482,6 +39686,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38509,6 +39714,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38536,6 +39742,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38570,6 +39777,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38597,6 +39805,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38624,6 +39833,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38672,6 +39882,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38699,6 +39910,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38726,6 +39938,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38753,6 +39966,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38780,6 +39994,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -38807,6 +40022,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -38834,6 +40050,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -38861,6 +40078,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -38888,6 +40106,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38957,6 +40176,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38984,6 +40204,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39011,6 +40232,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39038,6 +40260,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39086,6 +40309,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39113,6 +40337,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39147,6 +40372,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39181,6 +40407,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39215,6 +40442,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39242,6 +40470,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39269,6 +40498,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39296,6 +40526,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39330,6 +40561,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39357,6 +40589,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39384,6 +40617,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39411,6 +40645,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39445,6 +40680,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39479,6 +40715,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39506,6 +40743,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39533,6 +40771,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39574,6 +40813,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39643,6 +40883,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39670,6 +40911,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39697,6 +40939,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39724,6 +40967,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39751,6 +40995,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39778,6 +41023,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39805,6 +41051,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39839,6 +41086,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39866,6 +41114,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -39893,6 +41142,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39962,6 +41212,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -39989,6 +41240,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40016,6 +41268,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40043,6 +41296,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40112,6 +41366,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0xdbd9638d8df794dba5a330d29481e23e067d1387933cc95a558c8f93ea7b98ba.json
+++ b/test/testData/testPools/0xdbd9638d8df794dba5a330d29481e23e067d1387933cc95a558c8f93ea7b98ba.json
@@ -2541,7 +2541,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6042,7 +6041,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8387,7 +8385,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -34533,7 +34530,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0xddfa94487c65b7b432fd750212a32d9e2f273a60e6b42983974b2bc0927998eb.json
+++ b/test/testData/testPools/0xddfa94487c65b7b432fd750212a32d9e2f273a60e6b42983974b2bc0927998eb.json
@@ -990,6 +990,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1017,6 +1018,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1288,6 +1290,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -1458,6 +1461,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -1485,6 +1489,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -1696,6 +1701,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2057,6 +2063,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2261,6 +2268,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2695,6 +2703,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2790,6 +2799,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2824,6 +2834,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2900,6 +2911,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3002,6 +3014,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3275,6 +3288,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -3302,6 +3316,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3363,6 +3378,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3505,6 +3521,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3871,6 +3888,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -4231,6 +4249,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4916,6 +4935,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -5086,6 +5106,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5188,6 +5209,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5269,6 +5291,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5608,6 +5631,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5826,6 +5850,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5895,6 +5920,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5949,6 +5975,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6118,6 +6145,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6199,6 +6227,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6335,6 +6364,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6504,6 +6534,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6755,6 +6786,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -7224,6 +7256,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7769,6 +7802,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7850,6 +7884,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8026,6 +8061,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8189,6 +8225,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8324,6 +8361,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8447,6 +8485,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8488,6 +8527,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8657,6 +8697,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -9030,6 +9071,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9343,6 +9385,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9493,6 +9536,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9758,6 +9802,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10043,6 +10088,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10138,6 +10184,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11231,6 +11278,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11360,6 +11408,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11468,6 +11517,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11549,6 +11599,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11822,6 +11873,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11849,6 +11901,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12510,6 +12563,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12848,6 +12902,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13133,6 +13188,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13377,6 +13433,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13588,6 +13645,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13615,6 +13673,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13663,6 +13722,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13731,6 +13791,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14051,6 +14112,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14222,6 +14284,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14290,6 +14353,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14351,6 +14415,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14392,6 +14457,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14488,6 +14554,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14867,6 +14934,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15037,6 +15105,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15064,6 +15133,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15133,6 +15203,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15390,6 +15461,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15540,6 +15612,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15648,6 +15721,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15729,6 +15803,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15925,6 +16000,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16224,6 +16300,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16293,6 +16370,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16692,6 +16770,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17323,6 +17402,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17513,6 +17593,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17750,6 +17831,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17819,6 +17901,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18022,6 +18105,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18307,6 +18391,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18708,6 +18793,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18891,6 +18977,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18945,6 +19032,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19149,6 +19237,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19991,6 +20080,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20072,6 +20162,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20099,6 +20190,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20187,6 +20279,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20437,6 +20530,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21074,6 +21168,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21687,6 +21782,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22185,6 +22281,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22584,6 +22681,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23133,6 +23231,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -23160,6 +23259,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -23201,6 +23301,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -23371,6 +23472,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23982,6 +24084,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24118,6 +24221,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -24274,6 +24378,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24687,6 +24792,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24795,6 +24901,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25446,6 +25553,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25487,6 +25595,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26120,6 +26229,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26581,6 +26691,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26927,6 +27038,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26954,6 +27066,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +27571,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27647,6 +27761,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27728,6 +27843,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27790,6 +27906,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27859,6 +27976,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -28055,6 +28173,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28266,6 +28385,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -28293,6 +28413,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28705,6 +28826,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28732,6 +28854,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28807,6 +28930,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28996,6 +29120,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -29138,6 +29263,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29504,6 +29630,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29788,6 +29915,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30008,6 +30136,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30157,6 +30286,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30753,6 +30883,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31133,6 +31264,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31349,6 +31481,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31993,6 +32126,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32250,6 +32384,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32305,6 +32440,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32440,6 +32576,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32747,6 +32884,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32842,6 +32980,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32985,6 +33124,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33343,6 +33483,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33559,6 +33700,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33818,6 +33960,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -34055,6 +34198,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34136,6 +34280,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34232,6 +34377,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34307,6 +34453,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34382,6 +34529,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34409,6 +34557,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34552,6 +34701,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34694,6 +34844,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34721,6 +34872,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35250,6 +35402,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35570,6 +35723,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35597,6 +35751,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35651,6 +35806,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35888,6 +36044,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35915,6 +36072,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35963,6 +36121,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36668,6 +36827,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37227,6 +37387,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37254,6 +37415,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37383,6 +37545,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37837,6 +38000,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38428,6 +38592,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38618,6 +38783,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38910,6 +39076,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38951,6 +39118,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39019,6 +39187,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39189,6 +39358,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39270,6 +39440,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39466,6 +39637,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39676,6 +39848,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39934,6 +40107,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40470,6 +40644,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40647,6 +40822,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40789,6 +40965,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xe5028956be2588276c2a68c8317714d73bdb74aa5857e6d8b7d1d83d1668c529.json
+++ b/test/testData/testPools/0xe5028956be2588276c2a68c8317714d73bdb74aa5857e6d8b7d1d83d1668c529.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xe956c08ac8cb1b7e6e7b248488c2aa690651d98d2bc1a7d54cd914ecef7c0c27.json
+++ b/test/testData/testPools/0xe956c08ac8cb1b7e6e7b248488c2aa690651d98d2bc1a7d54cd914ecef7c0c27.json
@@ -990,6 +990,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1017,6 +1018,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1288,6 +1290,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -1458,6 +1461,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -1485,6 +1489,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -1696,6 +1701,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2057,6 +2063,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2261,6 +2268,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2695,6 +2703,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2790,6 +2799,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2824,6 +2834,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2900,6 +2911,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3002,6 +3014,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3275,6 +3288,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -3302,6 +3316,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3363,6 +3378,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3505,6 +3521,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3871,6 +3888,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -4231,6 +4249,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4916,6 +4935,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -5086,6 +5106,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5188,6 +5209,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5269,6 +5291,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5608,6 +5631,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5826,6 +5850,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5895,6 +5920,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5949,6 +5975,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6118,6 +6145,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6199,6 +6227,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6335,6 +6364,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6504,6 +6534,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6755,6 +6786,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -7224,6 +7256,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7769,6 +7802,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7850,6 +7884,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8026,6 +8061,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8189,6 +8225,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8324,6 +8361,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8447,6 +8485,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8488,6 +8527,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8657,6 +8697,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -9030,6 +9071,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9343,6 +9385,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9493,6 +9536,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9758,6 +9802,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10043,6 +10088,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10138,6 +10184,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11231,6 +11278,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11360,6 +11408,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11468,6 +11517,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11549,6 +11599,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11822,6 +11873,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11849,6 +11901,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12510,6 +12563,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12848,6 +12902,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13133,6 +13188,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13377,6 +13433,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13588,6 +13645,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13615,6 +13673,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13663,6 +13722,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13731,6 +13791,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14051,6 +14112,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14222,6 +14284,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14290,6 +14353,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14351,6 +14415,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14392,6 +14457,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14488,6 +14554,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14867,6 +14934,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15037,6 +15105,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15064,6 +15133,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15133,6 +15203,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15390,6 +15461,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15540,6 +15612,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15648,6 +15721,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15729,6 +15803,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15925,6 +16000,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16224,6 +16300,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16293,6 +16370,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16692,6 +16770,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17323,6 +17402,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17513,6 +17593,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17750,6 +17831,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17819,6 +17901,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18022,6 +18105,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18307,6 +18391,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18708,6 +18793,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18891,6 +18977,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18945,6 +19032,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19149,6 +19237,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19991,6 +20080,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20072,6 +20162,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20099,6 +20190,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20187,6 +20279,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20437,6 +20530,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21074,6 +21168,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21687,6 +21782,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22185,6 +22281,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22584,6 +22681,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23133,6 +23231,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -23160,6 +23259,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -23201,6 +23301,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -23371,6 +23472,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23982,6 +24084,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24118,6 +24221,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -24274,6 +24378,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24687,6 +24792,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24795,6 +24901,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25446,6 +25553,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25487,6 +25595,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26120,6 +26229,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26581,6 +26691,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26927,6 +27038,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26954,6 +27066,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +27571,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27647,6 +27761,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27728,6 +27843,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27790,6 +27906,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27859,6 +27976,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -28055,6 +28173,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28266,6 +28385,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -28293,6 +28413,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28705,6 +28826,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28732,6 +28854,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28807,6 +28930,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28996,6 +29120,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -29138,6 +29263,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29504,6 +29630,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29788,6 +29915,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30008,6 +30136,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30157,6 +30286,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30753,6 +30883,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31133,6 +31264,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31349,6 +31481,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31993,6 +32126,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32250,6 +32384,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32305,6 +32440,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32440,6 +32576,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32747,6 +32884,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32842,6 +32980,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32985,6 +33124,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33343,6 +33483,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33559,6 +33700,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33818,6 +33960,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -34055,6 +34198,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34136,6 +34280,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34232,6 +34377,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34307,6 +34453,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34382,6 +34529,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34409,6 +34557,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34552,6 +34701,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34694,6 +34844,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34721,6 +34872,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35250,6 +35402,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35570,6 +35723,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35597,6 +35751,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35651,6 +35806,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35888,6 +36044,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35915,6 +36072,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35963,6 +36121,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36668,6 +36827,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37227,6 +37387,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37254,6 +37415,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37383,6 +37545,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37837,6 +38000,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38428,6 +38592,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38618,6 +38783,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38910,6 +39076,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38951,6 +39118,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39019,6 +39187,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39189,6 +39358,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39270,6 +39440,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39466,6 +39637,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39676,6 +39848,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39934,6 +40107,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40470,6 +40644,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40647,6 +40822,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40789,6 +40965,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xea8838d8d150852b7d2e30a620ca7f03f183b9905a6781b13bec86be02f505a2.json
+++ b/test/testData/testPools/0xea8838d8d150852b7d2e30a620ca7f03f183b9905a6781b13bec86be02f505a2.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -40,6 +41,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -67,6 +69,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -94,6 +97,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +125,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -169,6 +174,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -196,6 +202,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -230,6 +237,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -257,6 +265,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -284,6 +293,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -311,6 +321,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -338,6 +349,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -365,6 +377,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -392,6 +405,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -419,6 +433,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -467,6 +482,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -508,6 +524,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -535,6 +552,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -562,6 +580,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +608,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -616,6 +636,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -643,6 +664,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -691,6 +713,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -718,6 +741,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -745,6 +769,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -800,6 +825,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -848,6 +874,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -875,6 +902,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -902,6 +930,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -929,6 +958,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -956,6 +986,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -997,6 +1028,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1024,6 +1056,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1065,6 +1098,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1092,6 +1126,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1161,6 +1196,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1230,6 +1266,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1257,6 +1294,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1284,6 +1322,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1311,6 +1350,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1338,6 +1378,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1365,6 +1406,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1392,6 +1434,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1419,6 +1462,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1467,6 +1511,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1494,6 +1539,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1542,6 +1588,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1569,6 +1616,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1596,6 +1644,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1623,6 +1672,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1664,6 +1714,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1691,6 +1742,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1718,6 +1770,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1745,6 +1798,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1772,6 +1826,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1799,6 +1854,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1826,6 +1882,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -1867,6 +1924,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -1894,6 +1952,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1987,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -1976,6 +2036,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2004,6 +2065,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2051,6 +2113,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2169,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2168,6 +2232,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2216,6 +2281,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2243,6 +2309,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2270,6 +2337,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2325,6 +2393,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2352,6 +2421,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2379,6 +2449,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2477,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2440,6 +2512,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2467,6 +2540,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2494,6 +2569,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2528,6 +2604,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2555,6 +2632,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2582,6 +2660,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2609,6 +2688,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2657,6 +2737,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2684,6 +2765,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2718,6 +2800,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2745,6 +2828,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2772,6 +2856,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2799,6 +2884,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -2826,6 +2912,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2860,6 +2947,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2887,6 +2975,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -2914,6 +3003,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -2941,6 +3031,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -2975,6 +3066,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3044,6 +3136,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3078,6 +3171,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3105,6 +3199,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3132,6 +3227,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3159,6 +3255,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3200,6 +3297,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3227,6 +3325,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3254,6 +3353,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3281,6 +3381,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3308,6 +3409,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3335,6 +3437,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3376,6 +3479,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3424,6 +3528,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3451,6 +3556,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3478,6 +3584,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3505,6 +3612,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3532,6 +3640,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3601,6 +3710,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3628,6 +3738,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3655,6 +3766,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3682,6 +3794,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -3709,6 +3822,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -3736,6 +3850,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -3763,6 +3878,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -3790,6 +3906,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -3824,6 +3941,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -3851,6 +3969,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3878,6 +3997,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -3905,6 +4025,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3939,6 +4060,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3966,6 +4088,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -3993,6 +4116,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4020,6 +4144,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4047,6 +4172,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4088,6 +4214,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4115,6 +4242,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4163,6 +4291,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4190,6 +4319,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4238,6 +4368,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4265,6 +4396,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4292,6 +4424,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4319,6 +4452,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4346,6 +4480,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4373,6 +4508,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4428,6 +4564,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4469,6 +4606,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4496,6 +4634,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4523,6 +4662,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4550,6 +4690,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4577,6 +4718,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4604,6 +4746,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4774,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4658,6 +4802,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -4685,6 +4830,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -4712,6 +4858,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4739,6 +4886,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -4808,6 +4956,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -4835,6 +4984,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4862,6 +5012,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4889,6 +5040,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -4930,6 +5082,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5152,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5026,6 +5180,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5053,6 +5208,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5080,6 +5236,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5114,6 +5271,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5141,6 +5299,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5168,6 +5327,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5195,6 +5355,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5222,6 +5383,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5249,6 +5411,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5276,6 +5439,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5303,6 +5467,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5495,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5357,6 +5523,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5412,6 +5579,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5439,6 +5607,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5473,6 +5642,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5500,6 +5670,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5527,6 +5698,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -5554,6 +5726,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -5581,6 +5754,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -5608,6 +5782,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5635,6 +5810,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -5669,6 +5845,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5696,6 +5873,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5723,6 +5901,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -5778,6 +5957,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -5805,6 +5985,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -5832,6 +6013,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -5859,6 +6041,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -5886,6 +6070,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -5913,6 +6098,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5940,6 +6126,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5967,6 +6154,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5994,6 +6182,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6021,6 +6210,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6069,6 +6259,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6096,6 +6287,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6137,6 +6329,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6185,6 +6378,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6212,6 +6406,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6239,6 +6434,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6294,6 +6490,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6328,6 +6525,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6369,6 +6567,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6438,6 +6637,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6465,6 +6665,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -6499,6 +6700,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -6526,6 +6728,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -6553,6 +6756,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6580,6 +6784,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6607,6 +6812,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -6634,6 +6840,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -6661,6 +6868,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6688,6 +6896,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -6750,6 +6959,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6819,6 +7029,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -6846,6 +7057,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6873,6 +7085,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6900,6 +7113,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6927,6 +7141,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6954,6 +7169,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -6988,6 +7204,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7015,6 +7232,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7042,6 +7260,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7069,6 +7288,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7103,6 +7323,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7130,6 +7351,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7157,6 +7379,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7184,6 +7407,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7239,6 +7463,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7266,6 +7491,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7293,6 +7519,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7320,6 +7547,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7347,6 +7575,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -7374,6 +7603,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -7401,6 +7631,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -7428,6 +7659,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7455,6 +7687,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -7482,6 +7715,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -7551,6 +7785,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7827,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7855,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -7646,6 +7883,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -7673,6 +7911,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -7700,6 +7939,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7727,6 +7967,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -7761,6 +8002,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7788,6 +8030,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -7822,6 +8065,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7849,6 +8093,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -7876,6 +8121,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -7924,6 +8170,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -7951,6 +8198,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -7978,6 +8226,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8005,6 +8254,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8032,6 +8282,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8059,6 +8310,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8086,6 +8338,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8134,6 +8387,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8161,6 +8416,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8188,6 +8444,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8222,6 +8479,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8249,6 +8507,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8276,6 +8535,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8317,6 +8577,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -8344,6 +8605,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8378,6 +8640,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -8447,6 +8710,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8474,6 +8738,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8501,6 +8766,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8528,6 +8794,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -8597,6 +8864,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8624,6 +8892,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -8651,6 +8920,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -8678,6 +8948,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -8712,6 +8983,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -8739,6 +9011,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8787,6 +9060,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -8835,6 +9109,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8862,6 +9137,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +9165,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8916,6 +9193,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -8943,6 +9221,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -8970,6 +9249,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8997,6 +9277,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9066,6 +9347,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9093,6 +9375,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9120,6 +9403,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9147,6 +9431,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9174,6 +9459,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9215,6 +9501,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -9242,6 +9529,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -9311,6 +9599,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -9359,6 +9648,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9386,6 +9676,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9455,6 +9746,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -9503,6 +9795,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -9530,6 +9823,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -9557,6 +9851,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -9584,6 +9879,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -9611,6 +9907,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -9638,6 +9935,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9665,6 +9963,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -9692,6 +9991,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9719,6 +10019,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -9746,6 +10047,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -9773,6 +10075,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -9800,6 +10103,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9827,6 +10131,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -9854,6 +10159,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9881,6 +10187,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -9908,6 +10215,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -9935,6 +10243,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -9962,6 +10271,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10003,6 +10313,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10030,6 +10341,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10057,6 +10369,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10112,6 +10425,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -10139,6 +10453,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -10166,6 +10481,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -10200,6 +10516,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -10227,6 +10544,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -10254,6 +10572,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10281,6 +10600,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -10308,6 +10628,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -10335,6 +10656,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10362,6 +10684,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10389,6 +10712,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10437,6 +10761,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10464,6 +10789,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10491,6 +10817,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10518,6 +10845,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -10545,6 +10873,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -10572,6 +10901,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10599,6 +10929,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -10626,6 +10957,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -10653,6 +10985,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10715,6 +11048,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -10742,6 +11076,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -10769,6 +11104,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -10796,6 +11132,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -10865,6 +11202,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10899,6 +11237,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -10926,6 +11265,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11293,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -10980,6 +11321,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11007,6 +11349,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -11055,6 +11398,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -11082,6 +11426,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11130,6 +11475,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11157,6 +11503,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11184,6 +11531,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -11246,6 +11594,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -11287,6 +11636,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -11314,6 +11664,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -11341,6 +11692,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -11368,6 +11720,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11395,6 +11748,7 @@
         {
             "id": "0x4b3fa856cef9aa85ed9bbfa8992d6138c5f150e6",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -11464,6 +11818,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11533,6 +11888,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11560,6 +11916,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11587,6 +11944,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -11614,6 +11972,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11648,6 +12007,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -11682,6 +12042,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -11709,6 +12070,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11736,6 +12098,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -11763,6 +12126,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -11790,6 +12154,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -11817,6 +12182,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -11844,6 +12210,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11871,6 +12238,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -11898,6 +12266,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -11925,6 +12294,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -11952,6 +12322,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -11979,6 +12350,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12006,6 +12378,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12033,6 +12406,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -12060,6 +12434,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12122,6 +12497,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12156,6 +12532,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -12183,6 +12560,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12210,6 +12588,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12237,6 +12616,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12264,6 +12644,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12319,6 +12700,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12346,6 +12728,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -12373,6 +12756,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12400,6 +12784,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -12427,6 +12812,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12454,6 +12840,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12481,6 +12868,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12508,6 +12896,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12577,6 +12966,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -12604,6 +12994,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12631,6 +13022,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -12665,6 +13057,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -12692,6 +13085,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +13113,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +13162,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12794,6 +13190,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +13232,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12890,6 +13288,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12924,6 +13323,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -12993,6 +13393,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13020,6 +13421,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -13047,6 +13449,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13074,6 +13477,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -13101,6 +13505,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13128,6 +13533,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13155,6 +13561,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13182,6 +13589,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -13209,6 +13617,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13257,6 +13666,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13326,6 +13736,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13353,6 +13764,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13394,6 +13806,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13421,6 +13834,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -13455,6 +13869,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13911,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13565,6 +13981,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -13592,6 +14009,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13619,6 +14037,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13646,6 +14065,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -13673,6 +14093,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -13728,6 +14149,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13755,6 +14177,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13782,6 +14205,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -13809,6 +14233,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13836,6 +14261,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -13863,6 +14289,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -13890,6 +14317,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13917,6 +14345,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -13944,6 +14373,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -13971,6 +14401,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14033,6 +14464,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -14060,6 +14492,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -14087,6 +14520,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -14114,6 +14548,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -14141,6 +14576,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14604,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14674,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14264,6 +14702,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -14291,6 +14730,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -14318,6 +14758,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -14345,6 +14786,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14386,6 +14828,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -14413,6 +14856,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -14440,6 +14884,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -14467,6 +14912,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -14494,6 +14940,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14521,6 +14968,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14548,6 +14996,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14575,6 +15024,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -14644,6 +15094,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14671,6 +15122,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14698,6 +15150,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -14725,6 +15178,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -14752,6 +15206,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14779,6 +15234,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -14806,6 +15262,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14833,6 +15290,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14867,6 +15325,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -14894,6 +15353,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -14921,6 +15381,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -14948,6 +15409,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14975,6 +15437,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15002,6 +15465,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -15029,6 +15493,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15056,6 +15521,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -15125,6 +15591,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -15152,6 +15619,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -15179,6 +15647,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15206,6 +15675,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -15233,6 +15703,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -15260,6 +15731,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15287,6 +15759,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15328,6 +15801,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15871,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15424,6 +15899,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15451,6 +15927,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -15478,6 +15955,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15505,6 +15983,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15532,6 +16011,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -15573,6 +16053,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -15600,6 +16081,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -15627,6 +16109,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -15654,6 +16137,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -15681,6 +16165,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -15715,6 +16200,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -15742,6 +16228,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15769,6 +16256,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -15796,6 +16284,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -15865,6 +16354,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15892,6 +16382,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -15919,6 +16410,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -15946,6 +16438,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -15973,6 +16466,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16000,6 +16494,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16027,6 +16522,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -16054,6 +16550,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16081,6 +16578,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -16108,6 +16606,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -16135,6 +16634,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16176,6 +16676,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -16203,6 +16704,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16230,6 +16732,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16292,6 +16795,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -16319,6 +16823,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16346,6 +16851,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16373,6 +16879,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -16400,6 +16907,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -16427,6 +16935,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16454,6 +16963,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -16481,6 +16991,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16508,6 +17019,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -16535,6 +17047,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -16562,6 +17075,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16617,6 +17131,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16651,6 +17166,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -16678,6 +17194,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16705,6 +17222,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16732,6 +17250,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -16759,6 +17278,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16786,6 +17306,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -16813,6 +17334,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -16854,6 +17376,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17446,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -16957,6 +17481,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -16984,6 +17509,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17011,6 +17537,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17038,6 +17565,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -17065,6 +17593,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -17099,6 +17628,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17126,6 +17656,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17153,6 +17684,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -17222,6 +17754,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -17249,6 +17782,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17276,6 +17810,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17303,6 +17838,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17330,6 +17866,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -17357,6 +17894,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17384,6 +17922,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17411,6 +17950,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17473,6 +18013,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -17500,6 +18041,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -17527,6 +18069,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -17554,6 +18097,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -17581,6 +18125,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -17629,6 +18174,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17670,6 +18216,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17697,6 +18244,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17724,6 +18272,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -17758,6 +18307,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17785,6 +18335,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17812,6 +18363,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17853,6 +18405,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -17880,6 +18433,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -17914,6 +18468,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17941,6 +18496,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -17968,6 +18524,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17995,6 +18552,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18022,6 +18580,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -18049,6 +18608,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18076,6 +18636,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18145,6 +18706,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18172,6 +18734,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -18199,6 +18762,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18226,6 +18790,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18253,6 +18818,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -18280,6 +18846,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -18349,6 +18916,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -18376,6 +18944,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18445,6 +19014,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -18472,6 +19042,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18499,6 +19070,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18526,6 +19098,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18553,6 +19126,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -18580,6 +19154,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -18607,6 +19182,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -18641,6 +19217,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -18675,6 +19252,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18702,6 +19280,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18729,6 +19308,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -18784,6 +19364,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18811,6 +19392,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18838,6 +19420,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -18865,6 +19448,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -18899,6 +19483,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -18926,6 +19511,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -18953,6 +19539,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18980,6 +19567,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19007,6 +19595,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -19041,6 +19630,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19068,6 +19658,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -19095,6 +19686,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19122,6 +19714,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -19149,6 +19742,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -19176,6 +19770,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19798,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19230,6 +19826,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19264,6 +19861,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19291,6 +19889,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19318,6 +19917,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -19345,6 +19945,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19372,6 +19973,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19399,6 +20001,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -19433,6 +20036,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -19460,6 +20064,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -19487,6 +20092,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -19514,6 +20120,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19541,6 +20148,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -19568,6 +20176,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19595,6 +20204,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -19622,6 +20232,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19670,6 +20281,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19697,6 +20309,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -19724,6 +20337,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -19751,6 +20365,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -19778,6 +20393,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -19805,6 +20421,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -19832,6 +20449,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19859,6 +20477,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -19886,6 +20505,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -19955,6 +20575,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19982,6 +20603,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20009,6 +20631,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20036,6 +20659,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -20070,6 +20694,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20097,6 +20722,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -20124,6 +20750,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20151,6 +20778,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20178,6 +20806,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20219,6 +20848,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20246,6 +20876,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20287,6 +20918,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20314,6 +20946,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -20383,6 +21016,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -20445,6 +21079,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -20472,6 +21107,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20541,6 +21177,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20568,6 +21205,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20595,6 +21233,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -20622,6 +21261,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -20649,6 +21289,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -20676,6 +21317,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -20703,6 +21345,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -20730,6 +21373,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -20764,6 +21408,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20791,6 +21436,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -20853,6 +21499,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20880,6 +21527,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -20907,6 +21555,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -20941,6 +21590,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20975,6 +21625,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -21016,6 +21667,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21071,6 +21723,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -21098,6 +21751,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -21125,6 +21779,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21194,6 +21849,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -21221,6 +21877,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -21262,6 +21919,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21289,6 +21947,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21316,6 +21975,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21343,6 +22003,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21370,6 +22031,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -21404,6 +22066,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -21431,6 +22094,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -21458,6 +22122,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -21485,6 +22150,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -21512,6 +22178,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -21539,6 +22206,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -21580,6 +22248,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -21607,6 +22276,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21634,6 +22304,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -21661,6 +22332,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -21688,6 +22360,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -21736,6 +22409,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21763,6 +22437,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21790,6 +22465,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -21817,6 +22493,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21844,6 +22521,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -21871,6 +22549,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21919,6 +22598,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -21953,6 +22633,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21980,6 +22661,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22007,6 +22689,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22034,6 +22717,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22061,6 +22745,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -22088,6 +22773,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22115,6 +22801,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -22156,6 +22843,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22183,6 +22871,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -22210,6 +22899,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -22237,6 +22927,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22955,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22997,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22346,6 +23039,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -22387,6 +23081,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22414,6 +23109,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -22448,6 +23144,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22475,6 +23172,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -22502,6 +23200,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22529,6 +23228,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -22556,6 +23256,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -22604,6 +23305,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22645,6 +23347,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22672,6 +23375,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22699,6 +23403,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22768,6 +23473,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -22802,6 +23508,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -22829,6 +23536,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22863,6 +23571,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -22897,6 +23606,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -22924,6 +23634,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -22951,6 +23662,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -22978,6 +23690,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23005,6 +23718,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23032,6 +23746,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23059,6 +23774,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23086,6 +23802,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23113,6 +23830,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23140,6 +23858,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23195,6 +23914,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23222,6 +23942,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23256,6 +23977,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23283,6 +24005,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23310,6 +24033,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23351,6 +24075,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -23378,6 +24103,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23405,6 +24131,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23432,6 +24159,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23459,6 +24187,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23486,6 +24215,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -23520,6 +24250,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23547,6 +24278,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -23581,6 +24313,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23608,6 +24341,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23656,6 +24390,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -23683,6 +24418,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -23710,6 +24446,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23737,6 +24474,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -23764,6 +24502,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -23791,6 +24530,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23818,6 +24558,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23845,6 +24586,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -23872,6 +24614,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -23899,6 +24642,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -23926,6 +24670,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -23953,6 +24698,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -24001,6 +24747,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -24049,6 +24796,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -24076,6 +24824,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -24103,6 +24852,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -24130,6 +24880,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24157,6 +24908,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -24184,6 +24936,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24211,6 +24964,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24238,6 +24992,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -24265,6 +25020,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -24292,6 +25048,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -24319,6 +25076,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -24346,6 +25104,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24373,6 +25132,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24407,6 +25167,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24469,6 +25230,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24496,6 +25258,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -24523,6 +25286,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24550,6 +25314,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +25356,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -24660,6 +25426,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -24729,6 +25496,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -24756,6 +25524,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24783,6 +25552,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24852,6 +25622,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24879,6 +25650,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24906,6 +25678,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -24933,6 +25706,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -24967,6 +25741,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25008,6 +25783,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25035,6 +25811,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -25062,6 +25839,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -25089,6 +25867,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -25116,6 +25895,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25143,6 +25923,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -25170,6 +25951,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25197,6 +25979,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25224,6 +26007,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25265,6 +26049,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -25292,6 +26077,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -25319,6 +26105,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -25353,6 +26140,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -25380,6 +26168,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25428,6 +26217,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25462,6 +26252,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -25489,6 +26280,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25516,6 +26308,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25543,6 +26336,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25570,6 +26364,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -25597,6 +26392,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -25624,6 +26420,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -25651,6 +26448,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25685,6 +26483,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25712,6 +26511,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25739,6 +26539,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25773,6 +26574,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -25800,6 +26602,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -25827,6 +26630,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25875,6 +26679,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25902,6 +26707,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -25929,6 +26735,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25956,6 +26763,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25990,6 +26798,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26031,6 +26840,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26868,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26085,6 +26896,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26112,6 +26924,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -26174,6 +26987,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -26201,6 +27015,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -26228,6 +27043,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26255,6 +27071,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -26282,6 +27099,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26309,6 +27127,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26336,6 +27155,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26370,6 +27190,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -26397,6 +27218,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26466,6 +27288,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -26493,6 +27316,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -26562,6 +27386,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26589,6 +27414,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26616,6 +27442,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -26643,6 +27470,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -26670,6 +27498,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26697,6 +27526,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -26724,6 +27554,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -26751,6 +27582,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26778,6 +27610,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -26805,6 +27638,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26832,6 +27666,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27729,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27799,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -26990,6 +27827,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -27017,6 +27855,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -27044,6 +27883,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -27071,6 +27911,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27105,6 +27946,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27132,6 +27974,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -27159,6 +28002,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27207,6 +28051,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27234,6 +28079,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27275,6 +28121,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -27302,6 +28149,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -27343,6 +28191,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -27370,6 +28219,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +28247,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27431,6 +28282,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +28310,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -27485,6 +28338,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27512,6 +28366,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -27539,6 +28394,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -27566,6 +28422,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -27593,6 +28450,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -27620,6 +28478,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27647,6 +28506,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -27674,6 +28534,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -27701,6 +28562,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -27728,6 +28590,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27755,6 +28618,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27782,6 +28646,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -27809,6 +28674,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +28702,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27884,6 +28751,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -27911,6 +28779,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27938,6 +28807,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -27965,6 +28835,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -27992,6 +28863,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28019,6 +28891,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -28046,6 +28919,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28073,6 +28947,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -28100,6 +28975,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28127,6 +29003,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -28154,6 +29031,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -28181,6 +29059,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -28215,6 +29094,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -28242,6 +29122,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28269,6 +29150,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -28296,6 +29178,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28323,6 +29206,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -28392,6 +29276,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28419,6 +29304,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -28446,6 +29332,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28473,6 +29360,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28500,6 +29388,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28527,6 +29416,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -28554,6 +29444,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28581,6 +29472,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -28608,6 +29500,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28635,6 +29528,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28662,6 +29556,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28689,6 +29584,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -28723,6 +29619,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -28750,6 +29647,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28784,6 +29682,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -28811,6 +29710,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -28838,6 +29738,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -28865,6 +29766,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -28892,6 +29794,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28947,6 +29850,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28974,6 +29878,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29043,6 +29948,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29112,6 +30018,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29139,6 +30046,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29166,6 +30074,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29193,6 +30102,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -29220,6 +30130,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -29261,6 +30172,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29288,6 +30200,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -29315,6 +30228,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -29370,6 +30284,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29397,6 +30312,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -29424,6 +30340,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29451,6 +30368,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29492,6 +30410,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -29519,6 +30438,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -29553,6 +30473,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -29580,6 +30501,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29607,6 +30529,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -29634,6 +30557,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -29661,6 +30585,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -29695,6 +30620,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29722,6 +30648,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -29749,6 +30676,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29776,6 +30704,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29803,6 +30732,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -29830,6 +30760,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -29857,6 +30788,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -29926,6 +30858,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -29953,6 +30886,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -29980,6 +30914,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -30007,6 +30942,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30034,6 +30970,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30061,6 +30998,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -30088,6 +31026,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30115,6 +31054,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30156,6 +31096,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -30183,6 +31124,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -30210,6 +31152,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -30237,6 +31180,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30264,6 +31208,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -30291,6 +31236,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30318,6 +31264,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -30345,6 +31292,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -30372,6 +31320,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -30399,6 +31348,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -30426,6 +31376,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -30453,6 +31404,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -30480,6 +31432,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30507,6 +31460,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30541,6 +31495,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30603,6 +31558,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -30630,6 +31586,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -30657,6 +31614,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -30684,6 +31642,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -30711,6 +31670,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -30738,6 +31698,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -30765,6 +31726,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -30792,6 +31754,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -30819,6 +31782,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30874,6 +31838,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -30901,6 +31866,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -30928,6 +31894,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30955,6 +31922,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -30982,6 +31950,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31009,6 +31978,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -31043,6 +32013,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -31070,6 +32041,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -31097,6 +32069,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31124,6 +32097,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31151,6 +32125,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -31178,6 +32153,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -31205,6 +32181,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31232,6 +32209,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31259,6 +32237,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -31286,6 +32265,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -31313,6 +32293,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -31354,6 +32335,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +32391,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31436,6 +32419,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31463,6 +32447,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31490,6 +32475,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31517,6 +32503,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31544,6 +32531,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31571,6 +32559,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -31598,6 +32587,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -31653,6 +32643,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -31680,6 +32671,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31707,6 +32699,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31762,6 +32755,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -31796,6 +32790,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31851,6 +32846,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31885,6 +32881,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31912,6 +32909,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -31946,6 +32944,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31994,6 +32993,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -32035,6 +33035,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -32062,6 +33063,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32089,6 +33091,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32116,6 +33119,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -32143,6 +33147,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -32170,6 +33175,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32204,6 +33210,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -32231,6 +33238,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -32258,6 +33266,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -32285,6 +33294,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -32312,6 +33322,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32339,6 +33350,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32366,6 +33378,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32393,6 +33406,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -32420,6 +33434,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -32447,6 +33462,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32474,6 +33490,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32501,6 +33518,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -32528,6 +33546,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -32555,6 +33574,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -32582,6 +33602,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -32609,6 +33630,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32636,6 +33658,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32663,6 +33686,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32690,6 +33714,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -32738,6 +33763,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32779,6 +33805,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32806,6 +33833,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -32833,6 +33861,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -32860,6 +33889,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32922,6 +33952,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -32949,6 +33980,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -32976,6 +34008,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33003,6 +34036,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -33037,6 +34071,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33064,6 +34099,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -33091,6 +34127,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -33132,6 +34169,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -33159,6 +34197,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33186,6 +34225,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -33213,6 +34253,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -33240,6 +34281,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33309,6 +34351,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -33336,6 +34379,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33384,6 +34428,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -33411,6 +34456,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33459,6 +34505,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +34533,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +34562,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33547,6 +34597,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -33588,6 +34639,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33629,6 +34681,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -33656,6 +34709,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33683,6 +34737,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -33710,6 +34765,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -33744,6 +34800,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33771,6 +34828,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -33798,6 +34856,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +34884,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -33852,6 +34912,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -33879,6 +34940,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -33906,6 +34968,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33933,6 +34996,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33960,6 +35024,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -33987,6 +35052,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -34028,6 +35094,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34055,6 +35122,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34124,6 +35192,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -34151,6 +35220,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34178,6 +35248,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34205,6 +35276,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34232,6 +35304,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -34259,6 +35332,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -34293,6 +35367,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34327,6 +35402,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34354,6 +35430,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34423,6 +35500,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -34450,6 +35528,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -34477,6 +35556,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34504,6 +35584,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +35612,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34558,6 +35640,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -34613,6 +35696,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34640,6 +35724,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -34674,6 +35759,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +35787,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34728,6 +35815,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -34755,6 +35843,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34782,6 +35871,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -34809,6 +35899,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -34836,6 +35927,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -34863,6 +35955,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -34911,6 +36004,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34938,6 +36032,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34965,6 +36060,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34992,6 +36088,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +36116,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +36165,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35094,6 +36193,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35121,6 +36221,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -35148,6 +36249,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35175,6 +36277,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35202,6 +36305,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35229,6 +36333,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -35256,6 +36361,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35283,6 +36389,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35310,6 +36417,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35337,6 +36445,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35399,6 +36508,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35447,6 +36557,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35474,6 +36585,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -35501,6 +36613,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35528,6 +36641,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -35555,6 +36669,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -35589,6 +36704,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35616,6 +36732,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35643,6 +36760,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -35670,6 +36788,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -35697,6 +36816,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35745,6 +36865,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -35772,6 +36893,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -35799,6 +36921,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -35826,6 +36949,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -35853,6 +36977,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35887,6 +37012,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -35914,6 +37040,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -35983,6 +37110,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36031,6 +37159,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36086,6 +37215,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36127,6 +37257,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36154,6 +37285,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36223,6 +37355,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -36250,6 +37383,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36277,6 +37411,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -36304,6 +37439,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -36331,6 +37467,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +37495,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36406,6 +37544,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -36433,6 +37572,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -36460,6 +37600,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36487,6 +37628,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36556,6 +37698,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -36583,6 +37726,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -36610,6 +37754,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -36637,6 +37782,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -36664,6 +37810,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36691,6 +37838,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36718,6 +37866,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36745,6 +37894,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -36772,6 +37922,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -36799,6 +37950,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -36826,6 +37978,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -36860,6 +38013,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -36887,6 +38041,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -36914,6 +38069,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36941,6 +38097,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -36968,6 +38125,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -36995,6 +38153,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37022,6 +38181,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37077,6 +38237,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37104,6 +38265,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -37159,6 +38321,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -37186,6 +38349,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37213,6 +38377,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37261,6 +38426,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -37288,6 +38454,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -37315,6 +38482,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37342,6 +38510,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -37383,6 +38552,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37410,6 +38580,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37444,6 +38615,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37471,6 +38643,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -37505,6 +38678,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37532,6 +38706,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37559,6 +38734,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37586,6 +38762,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -37613,6 +38790,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -37661,6 +38839,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37695,6 +38874,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -37722,6 +38902,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -37756,6 +38937,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -37783,6 +38965,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -37810,6 +38993,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -37858,6 +39042,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37885,6 +39070,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -37912,6 +39098,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -37960,6 +39147,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -37987,6 +39175,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38014,6 +39203,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +39245,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38096,6 +39287,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -38123,6 +39315,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38150,6 +39343,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38177,6 +39371,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38225,6 +39420,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -38252,6 +39448,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -38293,6 +39490,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38320,6 +39518,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -38347,6 +39546,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38374,6 +39574,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38401,6 +39602,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38428,6 +39630,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -38455,6 +39658,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -38482,6 +39686,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38509,6 +39714,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38536,6 +39742,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -38570,6 +39777,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38597,6 +39805,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38624,6 +39833,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38672,6 +39882,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -38699,6 +39910,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -38726,6 +39938,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38753,6 +39966,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -38780,6 +39994,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -38807,6 +40022,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -38834,6 +40050,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -38861,6 +40078,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -38888,6 +40106,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38957,6 +40176,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38984,6 +40204,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39011,6 +40232,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -39038,6 +40260,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39086,6 +40309,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -39113,6 +40337,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39147,6 +40372,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -39181,6 +40407,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -39215,6 +40442,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39242,6 +40470,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39269,6 +40498,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39296,6 +40526,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -39330,6 +40561,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -39357,6 +40589,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -39384,6 +40617,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -39411,6 +40645,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39445,6 +40680,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -39479,6 +40715,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39506,6 +40743,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39533,6 +40771,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -39574,6 +40813,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39643,6 +40883,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -39670,6 +40911,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39697,6 +40939,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39724,6 +40967,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -39751,6 +40995,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39778,6 +41023,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39805,6 +41051,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39839,6 +41086,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39866,6 +41114,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -39893,6 +41142,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39962,6 +41212,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -39989,6 +41240,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -40016,6 +41268,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40043,6 +41296,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40112,6 +41366,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0xea8838d8d150852b7d2e30a620ca7f03f183b9905a6781b13bec86be02f505a2.json
+++ b/test/testData/testPools/0xea8838d8d150852b7d2e30a620ca7f03f183b9905a6781b13bec86be02f505a2.json
@@ -2541,7 +2541,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6042,7 +6041,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8387,7 +8385,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -34533,7 +34530,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0xec1351e006668709c87ab4a3c402c8fd1a9136619293b1322e15183746f22293.json
+++ b/test/testData/testPools/0xec1351e006668709c87ab4a3c402c8fd1a9136619293b1322e15183746f22293.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11545,6 +11598,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11883,6 +11937,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12168,6 +12223,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12412,6 +12468,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12623,6 +12680,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12650,6 +12708,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12698,6 +12757,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12766,6 +12826,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13086,6 +13147,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13257,6 +13319,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13325,6 +13388,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13386,6 +13450,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13427,6 +13492,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13523,6 +13589,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13902,6 +13969,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14072,6 +14140,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14099,6 +14168,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14168,6 +14238,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14425,6 +14496,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14575,6 +14647,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14683,6 +14756,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14764,6 +14838,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14960,6 +15035,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15259,6 +15335,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15328,6 +15405,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15727,6 +15805,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16358,6 +16437,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16548,6 +16628,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16785,6 +16866,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16854,6 +16936,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17057,6 +17140,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17342,6 +17426,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17743,6 +17828,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17926,6 +18012,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17980,6 +18067,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18184,6 +18272,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19026,6 +19115,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19107,6 +19197,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19134,6 +19225,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19222,6 +19314,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19506,6 +19599,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20143,6 +20237,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20756,6 +20851,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21254,6 +21350,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21653,6 +21750,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22202,6 +22300,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22229,6 +22328,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22270,6 +22370,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22440,6 +22541,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23051,6 +23153,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23187,6 +23290,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23343,6 +23447,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23756,6 +23861,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23864,6 +23970,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24515,6 +24622,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24556,6 +24664,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25189,6 +25298,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25650,6 +25760,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -25996,6 +26107,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26023,6 +26135,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26527,6 +26640,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26716,6 +26830,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26797,6 +26912,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26859,6 +26975,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26928,6 +27045,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27124,6 +27242,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27335,6 +27454,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27362,6 +27482,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27774,6 +27895,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27801,6 +27923,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27876,6 +27999,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28065,6 +28189,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28207,6 +28332,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28573,6 +28699,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28857,6 +28984,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29077,6 +29205,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29226,6 +29355,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29849,6 +29979,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30229,6 +30360,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30445,6 +30577,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31089,6 +31222,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31346,6 +31480,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31401,6 +31536,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31536,6 +31672,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31843,6 +31980,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31938,6 +32076,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32081,6 +32220,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32439,6 +32579,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32655,6 +32796,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32914,6 +33056,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33151,6 +33294,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33232,6 +33376,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33328,6 +33473,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33403,6 +33549,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33478,6 +33625,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33505,6 +33653,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33648,6 +33797,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33790,6 +33940,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33817,6 +33968,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34346,6 +34498,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34666,6 +34819,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34693,6 +34847,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34747,6 +34902,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35018,6 +35174,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35045,6 +35202,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35093,6 +35251,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35798,6 +35957,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36357,6 +36517,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36384,6 +36545,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36513,6 +36675,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36967,6 +37130,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37558,6 +37722,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37748,6 +37913,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38040,6 +38206,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38081,6 +38248,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38149,6 +38317,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38319,6 +38488,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38400,6 +38570,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38596,6 +38767,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38806,6 +38978,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39064,6 +39237,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39600,6 +39774,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39777,6 +39952,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39919,6 +40095,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xec9c0dc4f427a7f1753ced4daccd74a8d59a3c51865abb306a8e92a0b7db345a.json
+++ b/test/testData/testPools/0xec9c0dc4f427a7f1753ced4daccd74a8d59a3c51865abb306a8e92a0b7db345a.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -827,6 +832,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1392,6 +1399,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1826,6 +1834,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1921,6 +1930,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1955,6 +1965,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2031,6 +2042,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2133,6 +2145,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2406,6 +2419,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2433,6 +2447,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2494,6 +2509,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2636,6 +2652,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3002,6 +3019,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3362,6 +3380,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4047,6 +4066,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4217,6 +4237,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4319,6 +4340,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4400,6 +4422,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4739,6 +4762,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4957,6 +4981,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5026,6 +5051,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5080,6 +5106,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5249,6 +5276,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5330,6 +5358,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5466,6 +5495,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5635,6 +5665,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5886,6 +5917,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6355,6 +6387,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6900,6 +6933,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6981,6 +7015,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7157,6 +7192,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7320,6 +7356,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7455,6 +7492,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7578,6 +7616,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7619,6 +7658,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7788,6 +7828,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8161,6 +8202,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8474,6 +8516,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8624,6 +8667,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8889,6 +8933,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9174,6 +9219,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9269,6 +9315,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10362,6 +10409,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10491,6 +10539,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10599,6 +10648,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10680,6 +10730,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10953,6 +11004,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10980,6 +11032,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11641,6 +11694,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11979,6 +12033,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12264,6 +12319,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12508,6 +12564,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12719,6 +12776,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12746,6 +12804,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12794,6 +12853,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12862,6 +12922,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13182,6 +13243,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13353,6 +13415,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13421,6 +13484,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13482,6 +13546,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13523,6 +13588,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13619,6 +13685,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13998,6 +14065,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14195,6 +14263,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14222,6 +14291,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14291,6 +14361,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14548,6 +14619,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14698,6 +14770,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14806,6 +14879,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14887,6 +14961,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15083,6 +15158,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15382,6 +15458,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15451,6 +15528,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15850,6 +15928,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16481,6 +16560,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16671,6 +16751,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16908,6 +16989,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16977,6 +17059,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17180,6 +17263,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17465,6 +17549,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17866,6 +17951,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18049,6 +18135,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18103,6 +18190,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18307,6 +18395,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19149,6 +19238,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19230,6 +19320,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19257,6 +19348,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19345,6 +19437,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19595,6 +19688,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20232,6 +20326,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20845,6 +20940,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21343,6 +21439,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21742,6 +21839,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22291,6 +22389,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22318,6 +22417,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22359,6 +22459,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22529,6 +22630,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23140,6 +23242,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23276,6 +23379,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23432,6 +23536,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23845,6 +23950,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23953,6 +24059,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24604,6 +24711,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24645,6 +24753,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25278,6 +25387,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25739,6 +25849,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26085,6 +26196,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26112,6 +26224,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26616,6 +26729,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26805,6 +26919,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26886,6 +27001,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26948,6 +27064,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27017,6 +27134,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27213,6 +27331,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27424,6 +27543,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27451,6 +27571,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27863,6 +27984,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27890,6 +28012,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27965,6 +28088,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28154,6 +28278,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28296,6 +28421,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28662,6 +28788,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28946,6 +29073,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29166,6 +29294,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29315,6 +29444,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29911,6 +30041,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30291,6 +30422,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30534,6 +30666,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31178,6 +31311,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31435,6 +31569,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31490,6 +31625,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31625,6 +31761,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31932,6 +32069,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32027,6 +32165,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32170,6 +32309,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32528,6 +32668,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32744,6 +32885,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33003,6 +33145,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33240,6 +33383,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33321,6 +33465,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33417,6 +33562,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33492,6 +33638,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33567,6 +33714,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33594,6 +33742,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33737,6 +33886,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33764,6 +33914,7 @@
         {
             "id": "0xd8e72a62e214864cbd9381cc04fa1006a8c8fb10",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23b608675a2b2fb1890d3abbd85c5775c51691d5",
@@ -33948,6 +34099,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33975,6 +34127,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34504,6 +34657,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34824,6 +34978,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34851,6 +35006,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34905,6 +35061,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35142,6 +35299,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35169,6 +35327,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35217,6 +35376,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35922,6 +36082,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36481,6 +36642,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36508,6 +36670,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36637,6 +36800,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37091,6 +37255,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37682,6 +37847,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37872,6 +38038,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38164,6 +38331,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38205,6 +38373,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38273,6 +38442,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38443,6 +38613,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38524,6 +38695,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38720,6 +38892,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38930,6 +39103,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39188,6 +39362,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39724,6 +39899,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39901,6 +40077,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40043,6 +40220,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xedf81b3087eec79b94af1730de6a4532749541fc5fbf5b3a3cd553d910dbbbc8.json
+++ b/test/testData/testPools/0xedf81b3087eec79b94af1730de6a4532749541fc5fbf5b3a3cd553d910dbbbc8.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xef63986beadea3f78acf5afc7665f8087f798627d4a094df134a4f643dda8057.json
+++ b/test/testData/testPools/0xef63986beadea3f78acf5afc7665f8087f798627d4a094df134a4f643dda8057.json
@@ -1188,6 +1188,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2460,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5946,6 +5948,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8235,6 +8238,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8579,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14900,6 +14905,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -20591,6 +20597,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20865,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30095,6 +30103,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -34102,6 +34111,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",

--- a/test/testData/testPools/0xf1432b7fd3a114eac740e0e8f9c271805acd2f673cf8b9df9958bf7d393b3ae4.json
+++ b/test/testData/testPools/0xf1432b7fd3a114eac740e0e8f9c271805acd2f673cf8b9df9958bf7d393b3ae4.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xf36183ce11febc716e85efcfb40040ad7c4a370e2bbe1b645bd5b9e893b3fc0e.json
+++ b/test/testData/testPools/0xf36183ce11febc716e85efcfb40040ad7c4a370e2bbe1b645bd5b9e893b3fc0e.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xf4b9d3efbe306a94a8487d15fc80f9e701b42bfedcbd6246574d5278690c4a37.json
+++ b/test/testData/testPools/0xf4b9d3efbe306a94a8487d15fc80f9e701b42bfedcbd6246574d5278690c4a37.json
@@ -990,6 +990,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1017,6 +1018,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1288,6 +1290,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -1458,6 +1461,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -1485,6 +1489,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -1696,6 +1701,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2057,6 +2063,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2261,6 +2268,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2695,6 +2703,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2790,6 +2799,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2824,6 +2834,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2900,6 +2911,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3002,6 +3014,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3275,6 +3288,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -3302,6 +3316,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3363,6 +3378,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3505,6 +3521,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3871,6 +3888,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -4231,6 +4249,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4916,6 +4935,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -5086,6 +5106,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5188,6 +5209,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5269,6 +5291,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5608,6 +5631,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5826,6 +5850,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5895,6 +5920,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5949,6 +5975,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6118,6 +6145,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6199,6 +6227,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6335,6 +6364,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6504,6 +6534,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6755,6 +6786,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -7224,6 +7256,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7769,6 +7802,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7850,6 +7884,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8026,6 +8061,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8189,6 +8225,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8324,6 +8361,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8447,6 +8485,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8488,6 +8527,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8657,6 +8697,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -9030,6 +9071,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9343,6 +9385,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9493,6 +9536,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9758,6 +9802,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10043,6 +10088,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10138,6 +10184,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11231,6 +11278,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11360,6 +11408,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11468,6 +11517,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11549,6 +11599,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11822,6 +11873,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11849,6 +11901,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12510,6 +12563,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12848,6 +12902,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13133,6 +13188,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13377,6 +13433,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13588,6 +13645,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13615,6 +13673,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13663,6 +13722,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13731,6 +13791,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14051,6 +14112,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14222,6 +14284,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14290,6 +14353,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14351,6 +14415,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14392,6 +14457,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14488,6 +14554,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14867,6 +14934,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15037,6 +15105,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15064,6 +15133,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15133,6 +15203,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15390,6 +15461,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15540,6 +15612,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15648,6 +15721,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15729,6 +15803,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15925,6 +16000,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16224,6 +16300,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16293,6 +16370,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16692,6 +16770,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17323,6 +17402,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17513,6 +17593,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17750,6 +17831,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17819,6 +17901,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18022,6 +18105,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18307,6 +18391,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18708,6 +18793,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18891,6 +18977,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18945,6 +19032,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19149,6 +19237,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19991,6 +20080,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20072,6 +20162,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20099,6 +20190,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20187,6 +20279,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20437,6 +20530,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21074,6 +21168,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21687,6 +21782,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22185,6 +22281,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22584,6 +22681,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23133,6 +23231,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -23160,6 +23259,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -23201,6 +23301,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -23371,6 +23472,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23982,6 +24084,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24118,6 +24221,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -24274,6 +24378,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24687,6 +24792,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24795,6 +24901,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25446,6 +25553,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25487,6 +25595,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26120,6 +26229,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26581,6 +26691,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26927,6 +27038,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26954,6 +27066,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +27571,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27647,6 +27761,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27728,6 +27843,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27790,6 +27906,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27859,6 +27976,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -28055,6 +28173,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28266,6 +28385,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -28293,6 +28413,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28705,6 +28826,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28732,6 +28854,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28807,6 +28930,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28996,6 +29120,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -29138,6 +29263,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29504,6 +29630,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29788,6 +29915,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30008,6 +30136,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30157,6 +30286,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30753,6 +30883,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31133,6 +31264,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31349,6 +31481,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31993,6 +32126,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32250,6 +32384,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32305,6 +32440,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32440,6 +32576,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32747,6 +32884,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32842,6 +32980,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32985,6 +33124,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33343,6 +33483,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33559,6 +33700,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33818,6 +33960,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -34055,6 +34198,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34136,6 +34280,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34232,6 +34377,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34307,6 +34453,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34382,6 +34529,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34409,6 +34557,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34552,6 +34701,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34694,6 +34844,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34721,6 +34872,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35250,6 +35402,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35570,6 +35723,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35597,6 +35751,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35651,6 +35806,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35888,6 +36044,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35915,6 +36072,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35963,6 +36121,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36668,6 +36827,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37227,6 +37387,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37254,6 +37415,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37383,6 +37545,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37837,6 +38000,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38428,6 +38592,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38618,6 +38783,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38910,6 +39076,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38951,6 +39118,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39019,6 +39187,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39189,6 +39358,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39270,6 +39440,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39466,6 +39637,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39676,6 +39848,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39934,6 +40107,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40470,6 +40644,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40647,6 +40822,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40789,6 +40965,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xf521d8b5c199c57a5544f478af253e619eb0d05b4cb09e8298f3a704d8f119f0.json
+++ b/test/testData/testPools/0xf521d8b5c199c57a5544f478af253e619eb0d05b4cb09e8298f3a704d8f119f0.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xf5bf68fb418a0c2ed7e31f1972cdf5ccbad1375093aa0707c1e382d162be8d18.json
+++ b/test/testData/testPools/0xf5bf68fb418a0c2ed7e31f1972cdf5ccbad1375093aa0707c1e382d162be8d18.json
@@ -1161,6 +1161,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2468,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5859,6 +5861,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -8134,6 +8137,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8451,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14644,6 +14649,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -20178,6 +20184,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -33486,6 +33493,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",

--- a/test/testData/testPools/0xf6e67f7aa877caa7add6d4c85ef2737bc342a578ab8ecb4b62ddaba15fe1c6ca.json
+++ b/test/testData/testPools/0xf6e67f7aa877caa7add6d4c85ef2737bc342a578ab8ecb4b62ddaba15fe1c6ca.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xf75d7ed8a5dc324f0220cd91119afc8b354ba17686f0812ba79f6dee4dc1173c.json
+++ b/test/testData/testPools/0xf75d7ed8a5dc324f0220cd91119afc8b354ba17686f0812ba79f6dee4dc1173c.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xf946ea7c1e43120a30ccfd240632d0abd4175e55a8c7ecfa6de1bd0663c9c9d2.json
+++ b/test/testData/testPools/0xf946ea7c1e43120a30ccfd240632d0abd4175e55a8c7ecfa6de1bd0663c9c9d2.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -392,6 +394,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -562,6 +565,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -589,6 +593,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -800,6 +805,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1161,6 +1167,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1365,6 +1372,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1799,6 +1807,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1894,6 +1903,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1928,6 +1938,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2004,6 +2015,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2106,6 +2118,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2379,6 +2392,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2406,6 +2420,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2467,6 +2482,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2609,6 +2625,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2975,6 +2992,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3335,6 +3353,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4020,6 +4039,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4190,6 +4210,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4292,6 +4313,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4373,6 +4395,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4712,6 +4735,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4930,6 +4954,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4999,6 +5024,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5053,6 +5079,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5222,6 +5249,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5303,6 +5331,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5439,6 +5468,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5608,6 +5638,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5859,6 +5890,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6328,6 +6360,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6873,6 +6906,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -6954,6 +6988,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7130,6 +7165,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7293,6 +7329,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7428,6 +7465,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7551,6 +7589,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7592,6 +7631,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7761,6 +7801,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8134,6 +8175,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8447,6 +8489,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8597,6 +8640,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8862,6 +8906,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9147,6 +9192,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9242,6 +9288,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10335,6 +10382,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -10464,6 +10512,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10572,6 +10621,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10653,6 +10703,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10926,6 +10977,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10953,6 +11005,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11614,6 +11667,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11952,6 +12006,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12237,6 +12292,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12481,6 +12537,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12692,6 +12749,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12719,6 +12777,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12767,6 +12826,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12835,6 +12895,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13155,6 +13216,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13326,6 +13388,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13394,6 +13457,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13455,6 +13519,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13496,6 +13561,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13592,6 +13658,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -13971,6 +14038,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14141,6 +14209,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14168,6 +14237,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14237,6 +14307,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14494,6 +14565,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14644,6 +14716,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -14752,6 +14825,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -14833,6 +14907,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15029,6 +15104,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15328,6 +15404,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15397,6 +15474,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15796,6 +15874,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16427,6 +16506,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16617,6 +16697,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -16854,6 +16935,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -16923,6 +17005,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17126,6 +17209,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17411,6 +17495,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17812,6 +17897,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -17995,6 +18081,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18049,6 +18136,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18253,6 +18341,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19095,6 +19184,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19176,6 +19266,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19203,6 +19294,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19291,6 +19383,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19541,6 +19634,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20178,6 +20272,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20791,6 +20886,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21289,6 +21385,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21688,6 +21785,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22237,6 +22335,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -22264,6 +22363,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22305,6 +22405,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22475,6 +22576,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23086,6 +23188,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23222,6 +23325,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23378,6 +23482,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -23791,6 +23896,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -23899,6 +24005,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -24550,6 +24657,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -24591,6 +24699,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25224,6 +25333,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -25685,6 +25795,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26031,6 +26142,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26058,6 +26170,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26562,6 +26675,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -26751,6 +26865,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26832,6 +26947,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26894,6 +27010,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26963,6 +27080,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27159,6 +27277,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27370,6 +27489,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27397,6 +27517,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -27809,6 +27930,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27836,6 +27958,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27911,6 +28034,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28100,6 +28224,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28242,6 +28367,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28608,6 +28734,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28892,6 +29019,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29112,6 +29240,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29261,6 +29390,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -29857,6 +29987,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30237,6 +30368,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -30453,6 +30585,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31097,6 +31230,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -31354,6 +31488,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31409,6 +31544,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31544,6 +31680,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -31851,6 +31988,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31946,6 +32084,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32089,6 +32228,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -32447,6 +32587,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -32663,6 +32804,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32922,6 +33064,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33159,6 +33302,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33240,6 +33384,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33336,6 +33481,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -33411,6 +33557,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33486,6 +33633,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -33513,6 +33661,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -33656,6 +33805,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33798,6 +33948,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -33825,6 +33976,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -34354,6 +34506,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34674,6 +34827,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -34701,6 +34855,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -34755,6 +34910,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -34992,6 +35148,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35019,6 +35176,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35067,6 +35225,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -35772,6 +35931,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -36331,6 +36491,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36358,6 +36519,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36487,6 +36649,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36941,6 +37104,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -37532,6 +37696,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37722,6 +37887,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38014,6 +38180,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38055,6 +38222,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38123,6 +38291,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -38293,6 +38462,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -38374,6 +38544,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -38570,6 +38741,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38780,6 +38952,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39038,6 +39211,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39574,6 +39748,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39751,6 +39926,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -39893,6 +40069,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xfab93b6aece1282a829e8bdcdf2a1aee193a10134279a0a16c989ca71644e85b.json
+++ b/test/testData/testPools/0xfab93b6aece1282a829e8bdcdf2a1aee193a10134279a0a16c989ca71644e85b.json
@@ -13,6 +13,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -42,6 +43,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -71,6 +73,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -100,6 +103,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -129,6 +133,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -182,6 +187,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -211,6 +217,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -248,6 +255,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -277,6 +285,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -306,6 +315,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -335,6 +345,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -364,6 +375,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -393,6 +405,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -422,6 +435,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -451,6 +465,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -504,6 +519,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -549,6 +565,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -578,6 +595,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -607,6 +625,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -636,6 +655,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -665,6 +685,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -694,6 +715,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -747,6 +769,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -776,6 +799,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -805,6 +829,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -866,6 +891,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -919,6 +945,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -948,6 +975,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -977,6 +1005,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -1006,6 +1035,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -1035,6 +1065,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1080,6 +1111,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1109,6 +1141,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1154,6 +1187,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1183,6 +1217,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1260,6 +1295,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1337,6 +1373,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1366,6 +1403,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -1395,6 +1433,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -1424,6 +1463,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1453,6 +1493,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1482,6 +1523,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1511,6 +1553,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -1540,6 +1583,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1593,6 +1637,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -1622,6 +1667,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1675,6 +1721,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1704,6 +1751,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1733,6 +1781,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1762,6 +1811,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1807,6 +1857,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -1836,6 +1887,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -1865,6 +1917,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1894,6 +1947,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1923,6 +1977,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -1952,6 +2007,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1981,6 +2037,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -2026,6 +2083,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -2055,6 +2113,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2092,6 +2151,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2145,6 +2205,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2175,6 +2236,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2227,6 +2289,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2288,6 +2351,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2357,6 +2421,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -2410,6 +2475,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2439,6 +2505,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -2468,6 +2535,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -2529,6 +2597,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -2558,6 +2627,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -2587,6 +2657,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2616,6 +2687,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2653,6 +2725,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -2682,6 +2755,8 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2711,6 +2786,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2748,6 +2824,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2777,6 +2854,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -2806,6 +2884,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -2835,6 +2914,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2888,6 +2968,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -2917,6 +2998,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -2954,6 +3036,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2983,6 +3066,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -3012,6 +3096,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3041,6 +3126,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -3070,6 +3156,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3107,6 +3194,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -3136,6 +3224,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -3165,6 +3254,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -3194,6 +3284,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3231,6 +3322,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3308,6 +3400,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3345,6 +3438,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3374,6 +3468,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -3403,6 +3498,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -3432,6 +3528,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3477,6 +3574,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3506,6 +3604,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3535,6 +3634,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -3564,6 +3664,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3593,6 +3694,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3622,6 +3724,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -3667,6 +3770,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -3720,6 +3824,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3749,6 +3854,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -3778,6 +3884,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -3807,6 +3914,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3836,6 +3944,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3913,6 +4022,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3942,6 +4052,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -3971,6 +4082,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4000,6 +4112,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -4029,6 +4142,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -4058,6 +4172,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -4087,6 +4202,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -4116,6 +4232,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -4153,6 +4270,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -4182,6 +4300,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4211,6 +4330,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -4240,6 +4360,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4277,6 +4398,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4306,6 +4428,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4335,6 +4458,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4364,6 +4488,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4393,6 +4518,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -4438,6 +4564,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4467,6 +4594,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4520,6 +4648,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -4549,6 +4678,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4602,6 +4732,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4631,6 +4762,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -4660,6 +4792,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4689,6 +4822,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -4718,6 +4852,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4747,6 +4882,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4808,6 +4944,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -4853,6 +4990,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -4882,6 +5020,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -4911,6 +5050,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -4940,6 +5080,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4969,6 +5110,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -4998,6 +5140,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5027,6 +5170,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5056,6 +5200,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -5085,6 +5230,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5114,6 +5260,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5143,6 +5290,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -5220,6 +5368,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -5249,6 +5398,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5278,6 +5428,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5307,6 +5458,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5352,6 +5504,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5429,6 +5582,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5458,6 +5612,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -5487,6 +5642,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5516,6 +5672,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5553,6 +5710,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -5582,6 +5740,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5611,6 +5770,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -5640,6 +5800,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5669,6 +5830,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5698,6 +5860,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5727,6 +5890,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5756,6 +5920,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5785,6 +5950,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5814,6 +5980,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5875,6 +6042,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -5904,6 +6072,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5941,6 +6110,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5970,6 +6140,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -5999,6 +6170,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -6028,6 +6200,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -6057,6 +6230,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -6086,6 +6260,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6115,6 +6290,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -6152,6 +6328,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6181,6 +6358,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -6210,6 +6388,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -6271,6 +6450,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -6300,6 +6480,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -6329,6 +6510,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -6358,6 +6540,8 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6387,6 +6571,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -6416,6 +6601,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6445,6 +6631,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6474,6 +6661,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6503,6 +6691,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6532,6 +6721,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6585,6 +6775,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -6614,6 +6805,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -6659,6 +6851,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6712,6 +6905,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -6741,6 +6935,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -6770,6 +6965,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -6831,6 +7027,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6868,6 +7065,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6913,6 +7111,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6990,6 +7189,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7019,6 +7219,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -7056,6 +7257,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -7085,6 +7287,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -7114,6 +7317,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7143,6 +7347,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7172,6 +7377,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -7201,6 +7407,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -7230,6 +7437,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7259,6 +7467,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -7328,6 +7537,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -7405,6 +7615,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -7434,6 +7645,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7463,6 +7675,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7492,6 +7705,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7521,6 +7735,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7550,6 +7765,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7587,6 +7803,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7616,6 +7833,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7645,6 +7863,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7674,6 +7893,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -7711,6 +7931,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -7740,6 +7961,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7769,6 +7991,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7798,6 +8021,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -7859,6 +8083,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -7888,6 +8113,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -7917,6 +8143,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7946,6 +8173,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7975,6 +8203,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -8004,6 +8233,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -8033,6 +8263,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -8062,6 +8293,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8091,6 +8323,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -8120,6 +8353,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -8197,6 +8431,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8242,6 +8477,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8271,6 +8507,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -8300,6 +8537,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -8329,6 +8567,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -8358,6 +8597,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8387,6 +8627,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -8424,6 +8665,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8453,6 +8695,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -8490,6 +8733,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8519,6 +8763,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -8548,6 +8793,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -8601,6 +8847,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -8630,6 +8877,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8659,6 +8907,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8688,6 +8937,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8717,6 +8967,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8746,6 +8997,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8775,6 +9027,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -8828,6 +9081,8 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8857,6 +9112,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -8886,6 +9142,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8923,6 +9180,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8952,6 +9210,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8981,6 +9240,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9026,6 +9286,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9055,6 +9316,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9092,6 +9354,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -9169,6 +9432,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9198,6 +9462,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9227,6 +9492,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9256,6 +9522,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -9333,6 +9600,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9362,6 +9630,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -9391,6 +9660,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -9420,6 +9690,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -9457,6 +9728,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9486,6 +9758,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -9539,6 +9812,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -9592,6 +9866,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9621,6 +9896,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9650,6 +9926,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9679,6 +9956,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -9708,6 +9986,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9737,6 +10016,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9766,6 +10046,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9843,6 +10124,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9872,6 +10154,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -9901,6 +10184,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -9930,6 +10214,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9959,6 +10244,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -10004,6 +10290,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -10033,6 +10320,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10110,6 +10398,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -10163,6 +10452,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -10192,6 +10482,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -10269,6 +10560,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -10322,6 +10614,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -10351,6 +10644,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -10380,6 +10674,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -10409,6 +10704,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -10438,6 +10734,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -10467,6 +10764,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10496,6 +10794,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -10525,6 +10824,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -10554,6 +10854,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -10583,6 +10884,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10612,6 +10914,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -10641,6 +10944,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10670,6 +10974,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -10699,6 +11004,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +11034,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -10757,6 +11064,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -10786,6 +11094,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10815,6 +11124,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10860,6 +11170,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10889,6 +11200,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10918,6 +11230,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10979,6 +11292,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -11008,6 +11322,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -11037,6 +11352,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -11074,6 +11390,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -11103,6 +11420,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11132,6 +11450,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11161,6 +11480,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -11190,6 +11510,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -11219,6 +11540,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11248,6 +11570,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11277,6 +11600,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11330,6 +11654,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11359,6 +11684,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11388,6 +11714,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11417,6 +11744,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -11446,6 +11774,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -11475,6 +11804,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11504,6 +11834,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -11533,6 +11864,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -11562,6 +11894,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11631,6 +11964,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -11660,6 +11994,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -11689,6 +12024,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -11718,6 +12054,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -11795,6 +12132,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -11832,6 +12170,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11861,6 +12200,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11890,6 +12230,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11919,6 +12260,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11948,6 +12290,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -12001,6 +12344,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -12030,6 +12374,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12083,6 +12428,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12112,6 +12458,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12141,6 +12488,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12210,6 +12558,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -12255,6 +12604,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -12284,6 +12634,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -12313,6 +12664,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -12342,6 +12694,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12371,6 +12724,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12448,6 +12802,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12477,6 +12832,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12506,6 +12862,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -12535,6 +12892,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12572,6 +12930,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -12609,6 +12968,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -12638,6 +12998,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12667,6 +13028,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12696,6 +13058,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -12725,6 +13088,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -12754,6 +13118,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -12783,6 +13148,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12812,6 +13178,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -12841,6 +13208,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12870,6 +13238,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12899,6 +13268,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12928,6 +13298,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12957,6 +13328,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12986,6 +13358,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -13015,6 +13388,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13084,6 +13458,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13121,6 +13496,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -13150,6 +13526,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13179,6 +13556,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13208,6 +13586,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13237,6 +13616,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13298,6 +13678,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13327,6 +13708,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -13356,6 +13738,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13385,6 +13768,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13414,6 +13798,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13443,6 +13828,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13472,6 +13858,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13501,6 +13888,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13578,6 +13966,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -13607,6 +13996,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -13636,6 +14026,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -13673,6 +14064,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -13702,6 +14094,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13731,6 +14124,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13784,6 +14178,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13813,6 +14208,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13858,6 +14254,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13919,6 +14316,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -13956,6 +14354,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -14033,6 +14432,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -14062,6 +14462,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -14091,6 +14492,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14120,6 +14522,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -14149,6 +14552,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14178,6 +14582,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14207,6 +14612,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14236,6 +14642,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -14265,6 +14672,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -14318,6 +14726,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14395,6 +14804,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14424,6 +14834,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14469,6 +14880,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14498,6 +14910,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -14535,6 +14948,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14580,6 +14994,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14657,6 +15072,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -14686,6 +15102,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14715,6 +15132,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14744,6 +15162,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -14773,6 +15192,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -14834,6 +15254,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14863,6 +15284,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -14892,6 +15314,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -14921,6 +15344,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14950,6 +15374,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -14979,6 +15404,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -15008,6 +15434,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15037,6 +15464,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -15066,6 +15494,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -15095,6 +15524,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15164,6 +15594,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -15193,6 +15624,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -15222,6 +15654,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15251,6 +15684,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -15280,6 +15714,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15309,6 +15744,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15386,6 +15822,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15415,6 +15852,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -15444,6 +15882,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -15473,6 +15912,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -15502,6 +15942,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15547,6 +15988,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -15576,6 +16018,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -15605,6 +16048,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -15634,6 +16078,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -15663,6 +16108,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15692,6 +16138,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15721,6 +16168,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15750,6 +16198,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -15827,6 +16276,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15856,6 +16306,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15885,6 +16336,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15914,6 +16366,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15943,6 +16396,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15972,6 +16426,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -16001,6 +16456,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16030,6 +16486,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16067,6 +16524,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -16096,6 +16554,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -16125,6 +16584,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -16154,6 +16614,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16183,6 +16644,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -16212,6 +16674,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -16241,6 +16704,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16270,6 +16734,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -16347,6 +16812,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -16376,6 +16842,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -16405,6 +16872,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16434,6 +16902,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -16463,6 +16932,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -16492,6 +16962,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16521,6 +16992,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -16566,6 +17038,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16643,6 +17116,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16672,6 +17146,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -16701,6 +17176,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16730,6 +17206,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -16759,6 +17236,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16788,6 +17266,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -16833,6 +17312,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16862,6 +17342,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -16891,6 +17372,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -16920,6 +17402,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -16949,6 +17432,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16986,6 +17470,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -17015,6 +17500,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17044,6 +17530,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -17073,6 +17560,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17150,6 +17638,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17179,6 +17668,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -17208,6 +17698,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -17237,6 +17728,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -17266,6 +17758,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -17295,6 +17788,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17324,6 +17818,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -17353,6 +17848,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17382,6 +17878,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -17411,6 +17908,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -17440,6 +17938,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17485,6 +17984,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17514,6 +18014,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17543,6 +18044,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -17612,6 +18114,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17641,6 +18144,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17670,6 +18174,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17699,6 +18204,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -17728,6 +18234,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -17757,6 +18264,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17786,6 +18294,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -17815,6 +18324,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17844,6 +18354,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -17873,6 +18384,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -17902,6 +18414,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17963,6 +18476,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -18000,6 +18514,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -18029,6 +18544,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18058,6 +18574,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18087,6 +18604,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -18116,6 +18634,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -18145,6 +18664,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -18174,6 +18694,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -18219,6 +18740,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -18296,6 +18818,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18333,6 +18856,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -18362,6 +18886,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -18391,6 +18916,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -18420,6 +18946,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -18449,6 +18976,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -18486,6 +19014,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18515,6 +19044,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18544,6 +19074,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18621,6 +19152,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -18650,6 +19182,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -18679,6 +19212,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18708,6 +19242,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18737,6 +19272,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -18766,6 +19302,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18795,6 +19332,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18824,6 +19362,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18893,6 +19432,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -18922,6 +19462,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -18951,6 +19492,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -18980,6 +19522,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -19009,6 +19552,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -19062,6 +19606,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19107,6 +19652,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -19136,6 +19682,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -19165,6 +19712,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -19202,6 +19750,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -19231,6 +19780,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19260,6 +19810,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19305,6 +19856,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -19334,6 +19886,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -19371,6 +19924,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -19400,6 +19954,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -19429,6 +19984,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19458,6 +20014,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -19487,6 +20044,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -19516,6 +20074,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19545,6 +20104,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -19622,6 +20182,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19651,6 +20212,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -19680,6 +20242,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19709,6 +20272,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19738,6 +20302,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19767,6 +20332,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -19844,6 +20410,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -19873,6 +20440,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -19950,6 +20518,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -19979,6 +20548,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -20008,6 +20578,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20037,6 +20608,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -20066,6 +20638,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -20095,6 +20668,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -20124,6 +20698,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -20161,6 +20736,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -20198,6 +20774,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20227,6 +20804,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -20256,6 +20834,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -20317,6 +20896,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20346,6 +20926,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20375,6 +20956,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -20404,6 +20986,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -20441,6 +21024,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -20470,6 +21054,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -20499,6 +21084,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20528,6 +21114,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -20557,6 +21144,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -20594,6 +21182,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20623,6 +21212,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -20652,6 +21242,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20681,6 +21272,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -20710,6 +21302,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -20739,6 +21332,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20768,6 +21362,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20797,6 +21392,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20834,6 +21430,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20863,6 +21460,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20892,6 +21490,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -20921,6 +21520,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20950,6 +21550,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -20979,6 +21580,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -21016,6 +21618,7 @@
         {
             "id": "0x7a672f0f4f67496d7179c1626ee9adead175e719",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21053,6 +21656,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -21082,6 +21686,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -21111,6 +21716,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -21140,6 +21746,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21169,6 +21776,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21198,6 +21806,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21227,6 +21836,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -21256,6 +21866,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -21309,6 +21920,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21338,6 +21950,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -21367,6 +21980,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -21396,6 +22010,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -21425,6 +22040,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -21454,6 +22070,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -21483,6 +22100,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -21512,6 +22130,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -21541,6 +22160,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -21618,6 +22238,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21647,6 +22268,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21676,6 +22298,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21705,6 +22328,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -21742,6 +22366,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21771,6 +22396,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -21800,6 +22426,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -21829,6 +22456,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21858,6 +22486,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21903,6 +22532,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21932,6 +22562,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21977,6 +22608,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22006,6 +22638,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -22083,6 +22716,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -22152,6 +22786,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -22181,6 +22816,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22258,6 +22894,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22287,6 +22924,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22316,6 +22954,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -22345,6 +22984,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -22374,6 +23014,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -22403,6 +23044,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -22432,6 +23074,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -22461,6 +23104,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -22498,6 +23142,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22527,6 +23172,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22596,6 +23242,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22625,6 +23272,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -22654,6 +23302,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -22691,6 +23340,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22728,6 +23378,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -22773,6 +23424,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -22834,6 +23486,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -22863,6 +23516,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -22892,6 +23546,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -22969,6 +23624,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -22998,6 +23654,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -23043,6 +23700,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23072,6 +23730,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23101,6 +23760,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23130,6 +23790,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23159,6 +23820,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -23196,6 +23858,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -23225,6 +23888,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -23254,6 +23918,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -23283,6 +23948,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -23312,6 +23978,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -23341,6 +24008,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -23386,6 +24054,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -23415,6 +24084,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23444,6 +24114,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -23473,6 +24144,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -23502,6 +24174,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23555,6 +24228,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23584,6 +24258,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23613,6 +24288,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -23642,6 +24318,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23671,6 +24348,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -23700,6 +24378,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -23753,6 +24432,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23790,6 +24470,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23819,6 +24500,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23848,6 +24530,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23877,6 +24560,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23906,6 +24590,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -23935,6 +24620,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23964,6 +24650,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -24009,6 +24696,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -24038,6 +24726,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -24067,6 +24756,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -24096,6 +24786,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -24125,6 +24816,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -24170,6 +24862,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -24215,6 +24908,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -24260,6 +24954,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24289,6 +24984,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -24326,6 +25022,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -24355,6 +25052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -24384,6 +25082,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24413,6 +25112,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -24442,6 +25142,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -24495,6 +25196,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -24540,6 +25242,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24569,6 +25272,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24598,6 +25302,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24675,6 +25380,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -24712,6 +25418,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -24741,6 +25448,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24778,6 +25486,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -24815,6 +25524,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -24844,6 +25554,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -24873,6 +25584,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -24902,6 +25614,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24931,6 +25644,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -24960,6 +25674,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -24989,6 +25704,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25018,6 +25734,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25047,6 +25764,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -25076,6 +25794,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -25137,6 +25856,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -25166,6 +25886,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -25203,6 +25924,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25232,6 +25954,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25261,6 +25984,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -25306,6 +26030,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -25335,6 +26060,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25364,6 +26090,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25393,6 +26120,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25422,6 +26150,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -25451,6 +26180,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -25488,6 +26218,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25517,6 +26248,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -25554,6 +26286,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25583,6 +26316,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -25636,6 +26370,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -25665,6 +26400,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -25694,6 +26430,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -25723,6 +26460,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -25752,6 +26490,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -25781,6 +26520,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -25810,6 +26550,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -25839,6 +26580,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -25868,6 +26610,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -25897,6 +26640,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25926,6 +26670,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -25955,6 +26700,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -26008,6 +26754,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -26061,6 +26808,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -26090,6 +26838,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -26119,6 +26868,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -26148,6 +26898,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26177,6 +26928,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -26206,6 +26958,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26235,6 +26988,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -26264,6 +27018,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -26293,6 +27048,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -26322,6 +27078,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -26351,6 +27108,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -26380,6 +27138,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -26409,6 +27168,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26446,6 +27206,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -26515,6 +27276,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26544,6 +27306,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -26573,6 +27336,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26602,6 +27366,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26647,6 +27412,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26724,6 +27490,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -26801,6 +27568,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -26830,6 +27598,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -26859,6 +27628,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -26936,6 +27706,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26965,6 +27736,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -26994,6 +27766,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -27023,6 +27796,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27060,6 +27834,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27105,6 +27880,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27134,6 +27910,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -27163,6 +27940,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -27192,6 +27970,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -27221,6 +28000,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27250,6 +28030,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -27279,6 +28060,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27308,6 +28090,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -27337,6 +28120,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -27382,6 +28166,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -27411,6 +28196,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -27440,6 +28226,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -27477,6 +28264,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -27506,6 +28294,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -27559,6 +28348,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27596,6 +28386,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -27625,6 +28416,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27654,6 +28446,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -27683,6 +28476,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -27712,6 +28506,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -27741,6 +28536,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -27770,6 +28566,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -27799,6 +28596,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -27836,6 +28634,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -27865,6 +28664,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27894,6 +28694,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -27931,6 +28732,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -27960,6 +28762,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -27989,6 +28792,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28042,6 +28846,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28071,6 +28876,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -28100,6 +28906,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28129,6 +28936,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28166,6 +28974,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28211,6 +29020,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -28240,6 +29050,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28269,6 +29080,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28298,6 +29110,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -28367,6 +29180,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -28396,6 +29210,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -28425,6 +29240,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28454,6 +29270,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -28483,6 +29300,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28512,6 +29330,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -28541,6 +29360,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -28578,6 +29398,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -28607,6 +29428,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -28684,6 +29506,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -28713,6 +29536,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -28790,6 +29614,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -28819,6 +29644,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -28848,6 +29674,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -28877,6 +29704,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -28906,6 +29734,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28935,6 +29764,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -28964,6 +29794,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -28993,6 +29824,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29022,6 +29854,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -29051,6 +29884,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -29080,6 +29914,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29149,6 +29984,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -29226,6 +30062,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -29255,6 +30092,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -29284,6 +30122,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -29313,6 +30152,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -29342,6 +30182,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -29379,6 +30220,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -29408,6 +30250,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -29437,6 +30280,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -29490,6 +30334,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29519,6 +30364,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -29564,6 +30410,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -29593,6 +30440,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -29638,6 +30486,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -29667,6 +30516,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -29696,6 +30546,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -29733,6 +30584,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29762,6 +30614,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29791,6 +30644,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29820,6 +30674,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -29849,6 +30704,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -29878,6 +30734,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -29907,6 +30764,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -29936,6 +30794,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29965,6 +30824,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -29994,6 +30854,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -30023,6 +30884,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -30052,6 +30914,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30081,6 +30944,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30110,6 +30974,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -30139,6 +31004,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30168,6 +31034,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30221,6 +31088,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -30250,6 +31118,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30279,6 +31148,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -30308,6 +31178,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -30337,6 +31208,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30366,6 +31238,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -30395,6 +31268,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -30424,6 +31298,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -30453,6 +31328,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -30482,6 +31358,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -30511,6 +31388,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -30540,6 +31418,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -30577,6 +31456,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -30606,6 +31486,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30635,6 +31516,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -30664,6 +31546,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -30693,6 +31576,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -30770,6 +31654,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30799,6 +31684,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -30828,6 +31714,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -30857,6 +31744,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30886,6 +31774,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30915,6 +31804,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -30944,6 +31834,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30973,6 +31864,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -31002,6 +31894,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31031,6 +31924,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31060,6 +31954,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31089,6 +31984,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -31126,6 +32022,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -31155,6 +32052,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -31192,6 +32090,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -31221,6 +32120,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -31250,6 +32150,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -31279,6 +32180,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -31308,6 +32210,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31369,6 +32272,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31398,6 +32302,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31475,6 +32380,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -31552,6 +32458,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31581,6 +32488,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31610,6 +32518,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -31639,6 +32548,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31668,6 +32578,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -31713,6 +32624,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -31742,6 +32654,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -31771,6 +32684,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -31832,6 +32746,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -31861,6 +32776,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -31890,6 +32806,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31919,6 +32836,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -31964,6 +32882,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -31993,6 +32912,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -32030,6 +32950,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -32059,6 +32980,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -32088,6 +33010,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -32117,6 +33040,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -32146,6 +33070,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -32183,6 +33108,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32212,6 +33138,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -32241,6 +33168,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -32270,6 +33198,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -32299,6 +33228,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -32328,6 +33258,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -32357,6 +33288,7 @@
         {
             "id": "0xc00889fa539512a941677c38b29320ea15607de8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x633ee3fbe5ffc05bd44ecd8240732ff9ef9dee1d",
@@ -32386,6 +33318,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32463,6 +33396,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -32492,6 +33426,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -32521,6 +33456,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -32550,6 +33486,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -32579,6 +33516,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32608,6 +33546,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -32637,6 +33576,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -32666,6 +33606,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32711,6 +33652,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -32740,6 +33682,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -32769,6 +33712,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -32798,6 +33742,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -32827,6 +33772,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -32856,6 +33802,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -32885,6 +33832,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -32914,6 +33862,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -32943,6 +33892,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -32972,6 +33922,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -33001,6 +33952,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -33030,6 +33982,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -33059,6 +34012,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -33088,6 +34042,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33125,6 +34080,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -33194,6 +34150,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -33223,6 +34180,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -33252,6 +34210,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -33281,6 +34240,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -33310,6 +34270,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -33339,6 +34300,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -33368,6 +34330,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -33397,6 +34360,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -33426,6 +34390,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -33487,6 +34452,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -33516,6 +34482,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -33545,6 +34512,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -33574,6 +34542,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -33603,6 +34572,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -33632,6 +34602,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33669,6 +34640,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -33698,6 +34670,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -33727,6 +34700,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -33756,6 +34730,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -33785,6 +34760,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -33814,6 +34790,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -33843,6 +34820,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33872,6 +34850,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -33901,6 +34880,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -33930,6 +34910,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -33959,6 +34940,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -34004,6 +34986,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -34065,6 +35048,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34094,6 +35078,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34123,6 +35108,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -34152,6 +35138,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34181,6 +35168,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -34210,6 +35198,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -34239,6 +35228,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -34268,6 +35258,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -34329,6 +35320,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -34358,6 +35350,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34387,6 +35380,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34448,6 +35442,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -34485,6 +35480,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34546,6 +35542,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34583,6 +35580,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -34612,6 +35610,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -34649,6 +35648,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34702,6 +35702,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -34747,6 +35748,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -34776,6 +35778,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -34805,6 +35808,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -34834,6 +35838,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -34863,6 +35868,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -34892,6 +35898,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -34929,6 +35936,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -34958,6 +35966,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -34987,6 +35996,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -35016,6 +36026,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -35045,6 +36056,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35074,6 +36086,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35103,6 +36116,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35132,6 +36146,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -35161,6 +36176,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -35190,6 +36206,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -35219,6 +36236,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35248,6 +36266,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -35277,6 +36296,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -35306,6 +36326,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -35335,6 +36356,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -35364,6 +36386,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35393,6 +36416,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -35422,6 +36446,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35451,6 +36476,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -35504,6 +36530,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35549,6 +36576,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35578,6 +36606,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -35607,6 +36636,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -35636,6 +36666,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35705,6 +36736,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -35734,6 +36766,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -35763,6 +36796,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35792,6 +36826,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -35829,6 +36864,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -35858,6 +36894,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -35887,6 +36924,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -35932,6 +36970,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -35961,6 +37000,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35990,6 +37030,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -36019,6 +37060,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -36048,6 +37090,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36125,6 +37168,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -36154,6 +37198,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -36207,6 +37252,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -36236,6 +37282,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36289,6 +37336,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36318,6 +37366,8 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -36347,6 +37397,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -36384,6 +37435,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -36429,6 +37481,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36474,6 +37527,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -36503,6 +37557,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36532,6 +37587,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -36561,6 +37617,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -36598,6 +37655,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -36627,6 +37685,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -36656,6 +37715,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -36685,6 +37745,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -36714,6 +37775,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -36743,6 +37805,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -36772,6 +37835,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36801,6 +37865,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36830,6 +37895,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -36859,6 +37925,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -36904,6 +37971,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36933,6 +38001,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37010,6 +38079,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -37039,6 +38109,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37068,6 +38139,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37097,6 +38169,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37126,6 +38199,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -37155,6 +38229,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -37192,6 +38267,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37229,6 +38305,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -37258,6 +38335,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37335,6 +38413,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -37364,6 +38443,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -37393,6 +38473,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -37422,6 +38503,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37451,6 +38533,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37480,6 +38563,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -37541,6 +38625,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -37570,6 +38655,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -37607,6 +38693,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -37636,6 +38723,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -37665,6 +38753,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -37694,6 +38783,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -37723,6 +38813,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -37752,6 +38843,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -37781,6 +38873,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37810,6 +38903,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -37863,6 +38957,7 @@
         {
             "id": "0xe02e8ddecbe302ba1a40107c726e3ee889b0ff10",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
@@ -37900,6 +38995,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -37929,6 +39025,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -37958,6 +39055,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37987,6 +39085,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38016,6 +39115,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38069,6 +39169,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -38098,6 +39199,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -38127,6 +39229,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -38156,6 +39259,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38185,6 +39289,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38214,6 +39319,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38243,6 +39349,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -38272,6 +39379,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38301,6 +39409,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38330,6 +39439,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -38359,6 +39469,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38428,6 +39539,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38481,6 +39593,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38510,6 +39623,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -38539,6 +39653,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38568,6 +39683,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -38597,6 +39713,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -38634,6 +39751,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -38663,6 +39781,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38692,6 +39811,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38721,6 +39841,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -38750,6 +39871,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -38803,6 +39925,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -38832,6 +39955,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -38861,6 +39985,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -38890,6 +40015,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -38919,6 +40045,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38956,6 +40083,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -38985,6 +40113,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -39062,6 +40191,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39115,6 +40245,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39176,6 +40307,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39221,6 +40353,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39250,6 +40383,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -39327,6 +40461,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -39356,6 +40491,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39385,6 +40521,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -39414,6 +40551,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -39443,6 +40581,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -39472,6 +40611,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39525,6 +40665,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -39554,6 +40695,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -39583,6 +40725,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39612,6 +40755,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39689,6 +40833,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -39718,6 +40863,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -39747,6 +40893,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -39776,6 +40923,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39805,6 +40953,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39834,6 +40983,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -39863,6 +41013,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39892,6 +41043,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -39921,6 +41073,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -39950,6 +41103,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -39979,6 +41133,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -40016,6 +41171,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -40045,6 +41201,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -40074,6 +41231,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40103,6 +41261,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -40132,6 +41291,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -40161,6 +41321,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -40190,6 +41351,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -40251,6 +41413,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -40280,6 +41443,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -40341,6 +41505,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -40370,6 +41535,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -40399,6 +41565,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -40452,6 +41619,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -40481,6 +41649,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -40510,6 +41679,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40539,6 +41709,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -40584,6 +41755,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40613,6 +41785,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40650,6 +41823,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -40679,6 +41853,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -40716,6 +41891,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40745,6 +41921,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40774,6 +41951,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40803,6 +41981,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -40832,6 +42011,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -40885,6 +42065,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -40922,6 +42103,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -40951,6 +42133,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -40988,6 +42171,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -41017,6 +42201,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -41046,6 +42231,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -41099,6 +42285,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -41128,6 +42315,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -41157,6 +42345,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -41210,6 +42399,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -41239,6 +42429,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41268,6 +42459,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -41313,6 +42505,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -41358,6 +42551,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -41387,6 +42581,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -41416,6 +42611,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -41445,6 +42641,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41498,6 +42695,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -41527,6 +42725,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -41572,6 +42771,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -41601,6 +42801,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -41630,6 +42831,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41659,6 +42861,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -41688,6 +42891,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -41717,6 +42921,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -41746,6 +42951,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -41775,6 +42981,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -41804,6 +43011,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -41833,6 +43041,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -41870,6 +43079,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -41899,6 +43109,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -41928,6 +43139,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -41981,6 +43193,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -42010,6 +43223,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -42039,6 +43253,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -42068,6 +43283,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -42097,6 +43313,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -42126,6 +43343,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -42155,6 +43373,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -42184,6 +43403,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -42213,6 +43433,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -42290,6 +43511,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -42319,6 +43541,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -42348,6 +43571,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -42377,6 +43601,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -42430,6 +43655,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -42459,6 +43685,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -42496,6 +43723,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -42533,6 +43761,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -42570,6 +43799,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -42599,6 +43829,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -42628,6 +43859,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -42657,6 +43889,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -42694,6 +43927,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -42723,6 +43957,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -42752,6 +43987,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -42781,6 +44017,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -42818,6 +44055,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -42855,6 +44093,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -42884,6 +44123,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -42913,6 +44153,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -42958,6 +44199,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -43035,6 +44277,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -43064,6 +44307,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -43093,6 +44337,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -43122,6 +44367,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -43151,6 +44397,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -43180,6 +44427,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -43209,6 +44457,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -43246,6 +44495,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -43275,6 +44525,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -43304,6 +44555,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -43381,6 +44633,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -43410,6 +44663,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -43439,6 +44693,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -43468,6 +44723,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -43545,6 +44801,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/0xfab93b6aece1282a829e8bdcdf2a1aee193a10134279a0a16c989ca71644e85b.json
+++ b/test/testData/testPools/0xfab93b6aece1282a829e8bdcdf2a1aee193a10134279a0a16c989ca71644e85b.json
@@ -2756,7 +2756,6 @@
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6541,7 +6540,6 @@
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
             "swapEnabled": true,
-            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -9081,7 +9079,6 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {
@@ -37366,7 +37363,6 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
-            "swapEnabled": true,
             "swapEnabled": true,
             "tokens": [
                 {

--- a/test/testData/testPools/0xfc687c72aa619a5c4eb5f5597a2bd69ef1157848243700b57926d36060a6dedc.json
+++ b/test/testData/testPools/0xfc687c72aa619a5c4eb5f5597a2bd69ef1157848243700b57926d36060a6dedc.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/0xfdd81d285a2d103a8d6dac5c68d9bcc48cc107590656c0ab44cd8877c75a9430.json
+++ b/test/testData/testPools/0xfdd81d285a2d103a8d6dac5c68d9bcc48cc107590656c0ab44cd8877c75a9430.json
@@ -94,6 +94,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -121,6 +122,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -419,6 +421,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -589,6 +592,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -616,6 +620,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -854,6 +859,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1188,6 +1194,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1419,6 +1426,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1853,6 +1861,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1948,6 +1957,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1982,6 +1992,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2057,6 +2068,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2371,6 +2383,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2398,6 +2411,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2459,6 +2473,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2601,6 +2616,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2642,6 +2658,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3008,6 +3025,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3368,6 +3386,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4053,6 +4072,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4223,6 +4243,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4325,6 +4346,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4406,6 +4428,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4772,6 +4795,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5017,6 +5041,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5086,6 +5111,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5140,6 +5166,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5309,6 +5336,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5390,6 +5418,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5526,6 +5555,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5695,6 +5725,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5946,6 +5977,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6456,6 +6488,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6974,6 +7007,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7055,6 +7089,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7231,6 +7266,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7394,6 +7430,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7529,6 +7566,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7652,6 +7690,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7693,6 +7732,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7862,6 +7902,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8235,6 +8276,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8575,6 +8617,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8725,6 +8768,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8990,6 +9034,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9275,6 +9320,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9370,6 +9416,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10497,6 +10544,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10551,6 +10599,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10728,6 +10777,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10809,6 +10859,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11136,6 +11187,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11163,6 +11215,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11836,6 +11889,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12174,6 +12228,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12459,6 +12514,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12703,6 +12759,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12914,6 +12971,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12941,6 +12999,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12989,6 +13048,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13057,6 +13117,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13343,6 +13404,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13514,6 +13576,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13582,6 +13645,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13643,6 +13707,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13684,6 +13749,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13725,6 +13791,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13821,6 +13888,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14227,6 +14295,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14397,6 +14466,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14424,6 +14494,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14493,6 +14564,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14750,6 +14822,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14900,6 +14973,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15042,6 +15116,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15123,6 +15198,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15319,6 +15395,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15618,6 +15695,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15687,6 +15765,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16120,6 +16199,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16751,6 +16831,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16941,6 +17022,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17178,6 +17260,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17247,6 +17330,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17450,6 +17534,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17762,6 +17847,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17980,6 +18066,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18198,6 +18285,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18381,6 +18469,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18435,6 +18524,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18639,6 +18729,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19481,6 +19572,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19562,6 +19654,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19589,6 +19682,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19677,6 +19771,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19927,6 +20022,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20591,6 +20687,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20858,6 +20955,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21265,6 +21363,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21763,6 +21862,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22162,6 +22262,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22738,6 +22839,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22779,6 +22881,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22949,6 +23052,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23337,6 +23441,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23385,6 +23490,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23608,6 +23714,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23744,6 +23851,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23873,6 +23981,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24286,6 +24395,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24394,6 +24504,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25018,6 +25129,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25059,6 +25171,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25692,6 +25805,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26180,6 +26294,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26526,6 +26641,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26553,6 +26669,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27057,6 +27174,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27246,6 +27364,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27327,6 +27446,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27389,6 +27509,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27458,6 +27579,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27654,6 +27776,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27865,6 +27988,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27892,6 +28016,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28304,6 +28429,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28331,6 +28457,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28406,6 +28533,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28595,6 +28723,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28737,6 +28866,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29130,6 +29260,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +29572,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29661,6 +29793,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29810,6 +29943,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30095,6 +30229,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30460,6 +30595,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30840,6 +30976,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31083,6 +31220,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31754,6 +31892,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32011,6 +32150,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32066,6 +32206,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32201,6 +32342,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32508,6 +32650,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32603,6 +32746,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32746,6 +32890,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33104,6 +33249,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33320,6 +33466,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33579,6 +33726,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33775,6 +33923,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33856,6 +34005,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33952,6 +34102,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34027,6 +34178,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34102,6 +34254,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34129,6 +34282,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34272,6 +34426,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34531,6 +34686,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34558,6 +34714,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35060,6 +35217,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35407,6 +35565,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35434,6 +35593,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35488,6 +35648,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35725,6 +35886,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35752,6 +35914,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35800,6 +35963,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36504,6 +36668,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37063,6 +37228,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37090,6 +37256,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37219,6 +37386,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37700,6 +37868,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38291,6 +38460,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38454,6 +38624,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38746,6 +38917,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38787,6 +38959,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38855,6 +39028,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39025,6 +39199,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39106,6 +39281,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39302,6 +39478,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39458,6 +39635,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39546,6 +39724,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39804,6 +39983,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40388,6 +40568,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40565,6 +40746,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40680,6 +40862,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/20210521-bal-weth-infinite.json
+++ b/test/testData/testPools/20210521-bal-weth-infinite.json
@@ -624,6 +624,7 @@
             "id": "0x7eb878107af0440f9e776f999ce053d277c8aca8000200000000000000000012",
             "poolType": "Weighted",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",

--- a/test/testData/testPools/25178485-blockKovan.json
+++ b/test/testData/testPools/25178485-blockKovan.json
@@ -17,6 +17,7 @@
             "id": "0x01abc00e86c7e258823b9a055fd62ca6cf61a16300020000000000000000003e",
             "poolType": "Weighted",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e84056760c8d8c3dd2c1980585acdf42183fc61",
@@ -44,6 +45,7 @@
             "id": "0x021c343c6180f03ce9e48fae3ff432309b9af19900020000000000000000000f",
             "poolType": "Weighted",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -71,6 +73,7 @@
             "id": "0x0297e37f1873d2dab4487aa67cd56b58e2f27875000200000000000000000002",
             "poolType": "Weighted",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -98,6 +101,7 @@
             "id": "0x03cd191f589d12b0582a99808cf19851e468e6b500020000000000000000000a",
             "poolType": "Weighted",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -125,6 +129,7 @@
             "id": "0x072f14b85add63488ddad88f855fda4a99d6ac9b00020000000000000000002b",
             "poolType": "Weighted",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -152,6 +157,7 @@
             "id": "0x09804caea2400035b18e2173fdd10ec8b670ca09000200000000000000000036",
             "poolType": "Weighted",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8186e1d916774ab8004cb84d7adc945953ee966d",
@@ -179,6 +185,7 @@
             "id": "0x0a9e96988e21c9a03b8dc011826a00259e02c46e000100000000000000000048",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -213,6 +220,7 @@
             "id": "0x0b09dea16768f0799065c475be02919503cb2a3500020000000000000000001e",
             "poolType": "Weighted",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -240,6 +248,7 @@
             "id": "0x148ce9b50be946a96e94a4f5479b771bab9b1c59000100000000000000000047",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -274,6 +283,7 @@
             "id": "0x14bf727f67aa294ec36347bd95aba1a2c136fe7a00020000000000000000002f",
             "poolType": "Weighted",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -301,6 +311,7 @@
             "id": "0x15432ba000e58e3c0ae52a5dec0579215ebc75d000010000000000000000005b",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -335,6 +346,7 @@
             "id": "0x16faf9f73748013155b7bc116a3008b57332d1e6000200000000000000000020",
             "poolType": "Weighted",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -362,6 +374,7 @@
             "id": "0x186084ff790c65088ba694df11758fae4943ee9e000200000000000000000017",
             "poolType": "Weighted",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -389,6 +402,7 @@
             "id": "0x231e687c9961d3a27e6e266ac5c433ce4f8253e4000200000000000000000027",
             "poolType": "Weighted",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -416,6 +430,7 @@
             "id": "0x2d6e3515c8b47192ca3913770fa741d3c4dac35400010000000000000000005f",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -450,6 +465,7 @@
             "id": "0x32fc95287b14eaef3afa92cccc48c285ee3a280a000100000000000000000005",
             "poolType": "Weighted",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -484,6 +500,7 @@
             "id": "0x344e8f99a55da2ba6b4b5158df2143374e400df200010000000000000000005d",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -518,6 +535,7 @@
             "id": "0x36128d5436d2d70cab39c9af9cce146c38554ff0000200000000000000000008",
             "poolType": "Weighted",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -545,6 +563,7 @@
             "id": "0x38a01c45d86b61a70044fb2a76eac8e75b1ac78e00020000000000000000003c",
             "poolType": "Weighted",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02822e968856186a20fec2c824d4b174d0b70502",
@@ -572,6 +591,7 @@
             "id": "0x39cd55ff7e7d7c66d7d2736f1d5d4791cdab895b000100000000000000000057",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -606,6 +626,7 @@
             "id": "0x3a19030ed746bd1c3f2b0f996ff9479af04c5f0a000200000000000000000004",
             "poolType": "Weighted",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc2569dd7d0fd715b054fbf16e75b001e5c0c1115",
@@ -633,6 +654,7 @@
             "id": "0x3ebf48cd7586d7a4521ce59e53d9a907ebf1480f00020000000000000000002c",
             "poolType": "Weighted",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -660,6 +682,7 @@
             "id": "0x41175c3ee2dd49fca9b263f49525c069095b87c700010000000000000000005a",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -694,6 +717,7 @@
             "id": "0x4212be3c7b255ba4b29705573abd023cdce2154200020000000000000000006d",
             "poolType": "Weighted",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc2569dd7d0fd715b054fbf16e75b001e5c0c1115",
@@ -721,6 +745,7 @@
             "id": "0x45910faff3cbf990fdb204682e93055506682d17000200000000000000000011",
             "poolType": "Weighted",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -748,6 +773,7 @@
             "id": "0x4626d81b3a1711beb79f4cecff2413886d461677000200000000000000000015",
             "poolType": "Weighted",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -775,6 +801,7 @@
             "id": "0x494b26d4aee801cb1fabf498ee24f0af20238743000100000000000000000063",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -809,6 +836,7 @@
             "id": "0x4e7f40cd37cee710f5e87ad72959d30ef8a01a5d00020000000000000000000b",
             "poolType": "Weighted",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -836,6 +864,7 @@
             "id": "0x503717b3dc137e230afc7c772520d7974474fb70000100000000000000000061",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -870,6 +899,7 @@
             "id": "0x571046eae58c783f29f95adba17dd561af8a8712000200000000000000000010",
             "poolType": "Weighted",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -897,6 +927,7 @@
             "id": "0x58af920d9dc0bc4e8f771ff013d79215cabcaa9e00010000000000000000004e",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -931,6 +962,7 @@
             "id": "0x59e2563c08029f13f80cba9eb610bfd0367ed266000100000000000000000062",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -965,6 +997,7 @@
             "id": "0x5aa90c7362ea46b3cbfbd7f01ea5ca69c98fef1c000200000000000000000024",
             "poolType": "Weighted",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -992,6 +1025,7 @@
             "id": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000018",
             "poolType": "Weighted",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1019,6 +1053,7 @@
             "id": "0x5d563ca1e2daaae3402c36097b934630ab53702c000200000000000000000028",
             "poolType": "Weighted",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1046,6 +1081,7 @@
             "id": "0x606e3ccc8c51cbbb1ff07ad03c6f95a84672ab16000100000000000000000051",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1080,6 +1116,7 @@
             "id": "0x614b5038611729ed49e0ded154d8a5d3af9d1d9e000100000000000000000043",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1114,6 +1151,7 @@
             "id": "0x61d5dc44849c9c87b0856a2a311536205c96c7fd000200000000000000000000",
             "poolType": "Weighted",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1141,6 +1179,7 @@
             "id": "0x647c1fd457b95b75d0972ff08fe01d7d7bda05df000200000000000000000001",
             "poolType": "Weighted",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1168,6 +1207,7 @@
             "id": "0x67f8fcb9d3c463da05de1392efdbb2a87f8599ea00010000000000000000004f",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1202,6 +1242,7 @@
             "id": "0x6ae82385f76e3742f89cb46343b169f6ee49de1b00020000000000000000001a",
             "poolType": "Weighted",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1229,6 +1270,7 @@
             "id": "0x72ab6ff76554f90532e2809cee019ade724e029a000100000000000000000045",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1263,6 +1305,7 @@
             "id": "0x7320d680ca9bce8048a286f00a79a2c9f8dcd7b3000100000000000000000064",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1297,6 +1340,7 @@
             "id": "0x7bf521b4f4c1543a622e11ee347efb1a2374332200010000000000000000004c",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1331,6 +1375,7 @@
             "id": "0x7eb878107af0440f9e776f999ce053d277c8aca8000200000000000000000016",
             "poolType": "Weighted",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1358,6 +1403,7 @@
             "id": "0x80be0c303d8ad2a280878b50a39b1ee8e54dbd22000200000000000000000013",
             "poolType": "Weighted",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1385,6 +1431,7 @@
             "id": "0x8339e311265a025fd5792db800daa8eda4264e2c00020000000000000000002d",
             "poolType": "Weighted",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1412,6 +1459,7 @@
             "id": "0x87165b659ba7746907a48763063efa3b323c2b07000200000000000000000030",
             "poolType": "Weighted",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1439,6 +1487,7 @@
             "id": "0x89ea4363bd541d27d9811e4df1209daa73154472000200000000000000000037",
             "poolType": "Weighted",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1466,6 +1515,7 @@
             "id": "0x8a92c3afabab59101b4e2426c82a7ddbb66b5450000200000000000000000023",
             "poolType": "Weighted",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1493,6 +1543,7 @@
             "id": "0x8bda1ab5eead21547ba0f33c07c86c5dc48d9baa00010000000000000000004b",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1527,6 +1578,7 @@
             "id": "0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f800020000000000000000001d",
             "poolType": "Weighted",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1554,6 +1606,7 @@
             "id": "0x991aeafbe1b1c7ac8348dc623ae350768d0c65b3000200000000000000000007",
             "poolType": "Weighted",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -1581,6 +1634,7 @@
             "id": "0x9c08c7a7a89cfd671c79eacdc6f07c1996277ed5000200000000000000000029",
             "poolType": "Weighted",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1608,6 +1662,7 @@
             "id": "0x9e030b67a8384cbba09d5927533aa98010c87d91000100000000000000000066",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1642,6 +1697,7 @@
             "id": "0x9e7fd25ad9d97f1e6716fa5bb04749a4621e892d00020000000000000000003b",
             "poolType": "Weighted",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02822e968856186a20fec2c824d4b174d0b70502",
@@ -1669,6 +1725,7 @@
             "id": "0x9f1f16b025f703ee985b58ced48daf93dad2f7ef000200000000000000000022",
             "poolType": "Weighted",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1696,6 +1753,7 @@
             "id": "0xa0488d89fb8d3085d83ad2426b94b9715cf02869000200000000000000000032",
             "poolType": "Weighted",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1723,6 +1781,7 @@
             "id": "0xa660ba113f9aabaeb4bcd28a4a1705f4997d5432000200000000000000000026",
             "poolType": "Weighted",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1750,6 +1809,7 @@
             "id": "0xa6f548df93de924d73be7d25dc02554c6bd66db5000200000000000000000012",
             "poolType": "Weighted",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1777,6 +1837,7 @@
             "id": "0xaac98ee71d4f8a156b6abaa6844cdb7789d086ce00020000000000000000001f",
             "poolType": "Weighted",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1804,6 +1865,7 @@
             "id": "0xb0fba102a03703fe2c1dd6300e7b431eac60e4b6000200000000000000000034",
             "poolType": "Weighted",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1831,6 +1893,7 @@
             "id": "0xb2634e2bfab9664f603626afc3d270be63c09ade000100000000000000000046",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1865,6 +1928,7 @@
             "id": "0xb6b9b165c4ac3f5233a0cf413126c72be28b468a00010000000000000000004a",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1899,6 +1963,7 @@
             "id": "0xb82a45ea7c6d7c90bd95e9e2af13242538f2e26900010000000000000000005e",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1933,6 +1998,7 @@
             "id": "0xbb31b8eebb9c71001562ae56aa5751af313e6d89000200000000000000000031",
             "poolType": "Weighted",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1960,6 +2026,7 @@
             "id": "0xc6a5032dc4bf638e15b4a66bc718ba7ba474ff73000200000000000000000003",
             "poolType": "Weighted",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -1987,6 +2054,7 @@
             "id": "0xce66904b68f1f070332cbc631de7ee98b650b499000200000000000000000009",
             "poolType": "Weighted",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -2014,6 +2082,7 @@
             "id": "0xd0e43c99c05271fa9fdf82281d4d1831a47be81f00020000000000000000003a",
             "poolType": "Weighted",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x071af828464def6979fadaa34703deaacd3ac71d",
@@ -2041,6 +2110,7 @@
             "id": "0xd16847480d6bc218048cd31ad98b63cc34e5c2bf000100000000000000000060",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2075,6 +2145,7 @@
             "id": "0xd208168d2a512240eb82582205d94a0710bce4e7000100000000000000000058",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2109,6 +2180,7 @@
             "id": "0xd47c0734a0b5feff3bb2fc8542cd5b9751afeefb00010000000000000000000e",
             "poolType": "Weighted",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32fc95287b14eaef3afa92cccc48c285ee3a280a",
@@ -2150,6 +2222,7 @@
             "id": "0xd57b0ee9e080e3f6aa0c30bae98234359e97ea9800010000000000000000000d",
             "poolType": "Weighted",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2191,6 +2264,7 @@
             "id": "0xd5d7bc115b32ad1449c6d0083e43c87be95f2809000100000000000000000054",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2225,6 +2299,7 @@
             "id": "0xdb1db6e248d7bb4175f6e5a382d0a03fe3dcc813000100000000000000000055",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2259,6 +2334,7 @@
             "id": "0xdb3e5cf969c05625db344dea9c8b12515e235df3000100000000000000000052",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2293,6 +2369,7 @@
             "id": "0xde148e6cc3f6047eed6e97238d341a2b8589e19e00020000000000000000001b",
             "poolType": "Weighted",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2320,6 +2397,7 @@
             "id": "0xde620bb8be43ee54d7aa73f8e99a7409fe51108400010000000000000000004d",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2354,6 +2432,7 @@
             "id": "0xe0947a0d847f9662a6a22ca2eff9d7e6352a123e000100000000000000000059",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2388,6 +2467,7 @@
             "id": "0xe2cd73cfeb471f9f2b08a18afbc87ff2324ef24e000100000000000000000049",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2422,6 +2502,7 @@
             "id": "0xe54b3f5c444a801e61becdca93e74cdc1c4c1f9000010000000000000000005c",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2456,6 +2537,7 @@
             "id": "0xe8075304a388f2f9b2af61f502741a88ff21d9a4000100000000000000000053",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2490,6 +2572,7 @@
             "id": "0xe99481dc77691d8e2456e5f3f61c1810adfc150300020000000000000000001c",
             "poolType": "Weighted",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2517,6 +2600,7 @@
             "id": "0xea0b9c466e6c8d344f75ece6c69d99e7e4f8660000020000000000000000003f",
             "poolType": "Weighted",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x071af828464def6979fadaa34703deaacd3ac71d",
@@ -2544,6 +2628,7 @@
             "id": "0xea39581977325c0833694d51656316ef8a926a62000200000000000000000039",
             "poolType": "Weighted",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x071af828464def6979fadaa34703deaacd3ac71d",
@@ -2571,6 +2656,7 @@
             "id": "0xea8886a24b6e01fba88a9e98d794e8d1f29ed863000200000000000000000014",
             "poolType": "Weighted",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2598,6 +2684,7 @@
             "id": "0xeb58be542e77195355d90100beb07105b9bd295e000100000000000000000042",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2632,6 +2719,7 @@
             "id": "0xec60a5fef79a92c741cb74fdd6bfc340c0279b01000200000000000000000019",
             "poolType": "Weighted",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2659,6 +2747,7 @@
             "id": "0xef123b9e0485d837281342af27012c54bbc0d26100020000000000000000003d",
             "poolType": "Weighted",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e84056760c8d8c3dd2c1980585acdf42183fc61",
@@ -2686,6 +2775,7 @@
             "id": "0xefaa1604e82e1b3af8430b90192c1b9e8197e377000200000000000000000025",
             "poolType": "Weighted",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2713,6 +2803,7 @@
             "id": "0xf099b7c3bd5a221aa34cb83004a50d66b0189ad0000100000000000000000056",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2747,6 +2838,7 @@
             "id": "0xf3a605da753e9de545841de10ea8bffbd1da9c75000200000000000000000038",
             "poolType": "Weighted",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2774,6 +2866,7 @@
             "id": "0xf461f2240b66d55dcf9059e26c022160c06863bf000200000000000000000006",
             "poolType": "Weighted",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -2801,6 +2894,7 @@
             "id": "0xf4c0dd9b82da36c07605df83c8a416f11724d88b00020000000000000000002a",
             "poolType": "Weighted",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2828,6 +2922,7 @@
             "id": "0xf7cd489c2b7e199e2d3e8a982eb6fd51d71c1ce4000100000000000000000044",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2862,6 +2957,7 @@
             "id": "0xf8a0623ab66f985effc1c69d05f1af4badb01b00000200000000000000000021",
             "poolType": "Weighted",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2889,6 +2985,7 @@
             "id": "0xf93e20844fd084b657d5e71342157b36c5f3032d000100000000000000000041",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2923,6 +3020,7 @@
             "id": "0xf94a7df264a2ec8bceef2cfe54d7ca3f6c6dfc7a000100000000000000000050",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2957,6 +3055,7 @@
             "id": "0xfa1575c57d887e93f37a3c267a548ede008458b3000100000000000000000065",
             "poolType": "Weighted",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2991,6 +3090,7 @@
             "id": "0xfa22ec1c02f121083bf04fbbcaad019f490d7a3000020000000000000000002e",
             "poolType": "Weighted",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -3018,6 +3118,7 @@
             "id": "0xff083f57a556bfb3bbe46ea1b4fa154b2b1fbe88000200000000000000000033",
             "poolType": "Weighted",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",

--- a/test/testData/testPools/elementFinanceTest_multihop_1path.json
+++ b/test/testData/testPools/elementFinanceTest_multihop_1path.json
@@ -1110,6 +1110,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1137,6 +1138,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1408,6 +1410,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -1578,6 +1581,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -1605,6 +1609,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -1816,6 +1821,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2177,6 +2183,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2381,6 +2388,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2815,6 +2823,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2910,6 +2919,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2944,6 +2954,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -3020,6 +3031,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3122,6 +3134,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3395,6 +3408,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -3422,6 +3436,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3483,6 +3498,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3625,6 +3641,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3991,6 +4008,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -4351,6 +4369,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -5036,6 +5055,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -5206,6 +5226,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5308,6 +5329,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5389,6 +5411,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5728,6 +5751,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5946,6 +5970,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6015,6 +6040,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6069,6 +6095,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6238,6 +6265,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6319,6 +6347,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6455,6 +6484,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6624,6 +6654,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6875,6 +6906,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -7344,6 +7376,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7889,6 +7922,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7970,6 +8004,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8146,6 +8181,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8309,6 +8345,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8444,6 +8481,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8567,6 +8605,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8608,6 +8647,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8777,6 +8817,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -9150,6 +9191,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9463,6 +9505,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9613,6 +9656,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9878,6 +9922,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10163,6 +10208,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10258,6 +10304,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11351,6 +11398,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11480,6 +11528,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11588,6 +11637,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11669,6 +11719,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11942,6 +11993,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11969,6 +12021,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12630,6 +12683,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12968,6 +13022,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13253,6 +13308,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13497,6 +13553,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13708,6 +13765,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13735,6 +13793,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13783,6 +13842,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13851,6 +13911,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14171,6 +14232,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14342,6 +14404,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14410,6 +14473,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14471,6 +14535,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14512,6 +14577,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14608,6 +14674,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14987,6 +15054,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15157,6 +15225,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15184,6 +15253,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15253,6 +15323,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15510,6 +15581,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15660,6 +15732,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15768,6 +15841,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15849,6 +15923,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16045,6 +16120,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16344,6 +16420,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16413,6 +16490,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16812,6 +16890,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17443,6 +17522,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17633,6 +17713,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17870,6 +17951,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17939,6 +18021,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18142,6 +18225,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18427,6 +18511,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18828,6 +18913,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19011,6 +19097,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -19065,6 +19152,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19269,6 +19357,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -20111,6 +20200,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20192,6 +20282,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20219,6 +20310,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20307,6 +20399,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20557,6 +20650,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21194,6 +21288,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21807,6 +21902,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22305,6 +22401,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22704,6 +22801,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23253,6 +23351,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -23280,6 +23379,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -23321,6 +23421,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -23491,6 +23592,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -24102,6 +24204,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24238,6 +24341,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -24394,6 +24498,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24807,6 +24912,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24915,6 +25021,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25566,6 +25673,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25607,6 +25715,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26240,6 +26349,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26701,6 +26811,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -27047,6 +27158,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -27074,6 +27186,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27578,6 +27691,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27767,6 +27881,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27848,6 +27963,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27910,6 +28026,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27979,6 +28096,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -28175,6 +28293,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28386,6 +28505,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -28413,6 +28533,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28825,6 +28946,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28852,6 +28974,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28927,6 +29050,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29116,6 +29240,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -29258,6 +29383,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29624,6 +29750,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29908,6 +30035,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30128,6 +30256,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30277,6 +30406,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30873,6 +31003,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31253,6 +31384,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31469,6 +31601,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -32113,6 +32246,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32370,6 +32504,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32425,6 +32560,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32560,6 +32696,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32867,6 +33004,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32962,6 +33100,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33105,6 +33244,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33463,6 +33603,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33679,6 +33820,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33938,6 +34080,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -34175,6 +34318,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34256,6 +34400,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34352,6 +34497,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34427,6 +34573,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34502,6 +34649,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34529,6 +34677,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34672,6 +34821,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34814,6 +34964,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34841,6 +34992,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35370,6 +35522,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35690,6 +35843,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35717,6 +35871,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35771,6 +35926,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -36008,6 +36164,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36035,6 +36192,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36083,6 +36241,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36788,6 +36947,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37347,6 +37507,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37374,6 +37535,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37503,6 +37665,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37957,6 +38120,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38548,6 +38712,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38738,6 +38903,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -39030,6 +39196,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39071,6 +39238,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39139,6 +39307,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39309,6 +39478,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39390,6 +39560,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39586,6 +39757,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39796,6 +39968,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -40054,6 +40227,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40590,6 +40764,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40767,6 +40942,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40909,6 +41085,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/elementFinanceTest_multihop_1path_swapExactOut.json
+++ b/test/testData/testPools/elementFinanceTest_multihop_1path_swapExactOut.json
@@ -1110,6 +1110,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1137,6 +1138,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1408,6 +1410,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -1578,6 +1581,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -1605,6 +1609,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -1816,6 +1821,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2177,6 +2183,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2381,6 +2388,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2815,6 +2823,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2910,6 +2919,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2944,6 +2954,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -3020,6 +3031,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3122,6 +3134,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3395,6 +3408,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -3422,6 +3436,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3483,6 +3498,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3625,6 +3641,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3991,6 +4008,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -4351,6 +4369,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -5036,6 +5055,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -5206,6 +5226,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5308,6 +5329,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5389,6 +5411,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5728,6 +5751,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5946,6 +5970,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6015,6 +6040,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6069,6 +6095,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6238,6 +6265,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6319,6 +6347,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6455,6 +6484,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6624,6 +6654,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6875,6 +6906,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -7344,6 +7376,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7889,6 +7922,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7970,6 +8004,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8146,6 +8181,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8309,6 +8345,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8444,6 +8481,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8567,6 +8605,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8608,6 +8647,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8777,6 +8817,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -9150,6 +9191,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9463,6 +9505,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9613,6 +9656,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9878,6 +9922,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10163,6 +10208,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10258,6 +10304,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11351,6 +11398,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11480,6 +11528,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11588,6 +11637,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11669,6 +11719,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11942,6 +11993,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11969,6 +12021,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12630,6 +12683,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12968,6 +13022,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13253,6 +13308,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13497,6 +13553,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13708,6 +13765,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13735,6 +13793,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13783,6 +13842,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13851,6 +13911,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14171,6 +14232,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14342,6 +14404,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14410,6 +14473,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14471,6 +14535,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14512,6 +14577,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14608,6 +14674,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14987,6 +15054,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15157,6 +15225,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15184,6 +15253,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15253,6 +15323,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15510,6 +15581,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15660,6 +15732,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15768,6 +15841,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15849,6 +15923,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16045,6 +16120,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16344,6 +16420,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16413,6 +16490,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16812,6 +16890,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17443,6 +17522,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17633,6 +17713,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17870,6 +17951,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17939,6 +18021,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18142,6 +18225,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18427,6 +18511,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18828,6 +18913,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19011,6 +19097,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -19065,6 +19152,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19269,6 +19357,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -20111,6 +20200,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20192,6 +20282,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20219,6 +20310,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20307,6 +20399,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20557,6 +20650,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21194,6 +21288,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21807,6 +21902,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22305,6 +22401,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22704,6 +22801,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23253,6 +23351,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -23280,6 +23379,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -23321,6 +23421,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -23491,6 +23592,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -24102,6 +24204,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24238,6 +24341,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -24394,6 +24498,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24807,6 +24912,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24915,6 +25021,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25566,6 +25673,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25607,6 +25715,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26240,6 +26349,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26701,6 +26811,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -27047,6 +27158,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -27074,6 +27186,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27578,6 +27691,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27767,6 +27881,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27848,6 +27963,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27910,6 +28026,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27979,6 +28096,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -28175,6 +28293,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28386,6 +28505,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -28413,6 +28533,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28825,6 +28946,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28852,6 +28974,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28927,6 +29050,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29116,6 +29240,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -29258,6 +29383,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29624,6 +29750,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29908,6 +30035,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30128,6 +30256,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30277,6 +30406,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30873,6 +31003,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31253,6 +31384,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31469,6 +31601,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -32113,6 +32246,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32370,6 +32504,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32425,6 +32560,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32560,6 +32696,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32867,6 +33004,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32962,6 +33100,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33105,6 +33244,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33463,6 +33603,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33679,6 +33820,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33938,6 +34080,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -34175,6 +34318,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34256,6 +34400,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34352,6 +34497,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34427,6 +34573,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34502,6 +34649,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34529,6 +34677,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34672,6 +34821,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34814,6 +34964,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34841,6 +34992,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35370,6 +35522,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35690,6 +35843,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35717,6 +35871,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35771,6 +35926,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -36008,6 +36164,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36035,6 +36192,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -36083,6 +36241,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36788,6 +36947,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37347,6 +37507,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37374,6 +37535,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37503,6 +37665,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37957,6 +38120,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38548,6 +38712,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38738,6 +38903,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -39030,6 +39196,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -39071,6 +39238,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39139,6 +39307,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39309,6 +39478,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39390,6 +39560,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39586,6 +39757,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39796,6 +39968,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -40054,6 +40227,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40590,6 +40764,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40767,6 +40942,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40909,6 +41085,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/elementFinanceTest_multihop_2paths.json
+++ b/test/testData/testPools/elementFinanceTest_multihop_2paths.json
@@ -1110,6 +1110,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1137,6 +1138,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",

--- a/test/testData/testPools/elementFinanceTest_multihop_2paths_swapExactOut.json
+++ b/test/testData/testPools/elementFinanceTest_multihop_2paths_swapExactOut.json
@@ -1110,6 +1110,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1137,6 +1138,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",

--- a/test/testData/testPools/fleek-11-03-21.json
+++ b/test/testData/testPools/fleek-11-03-21.json
@@ -84,6 +84,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -111,6 +112,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -409,6 +411,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -579,6 +582,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -606,6 +610,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -844,6 +849,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -1178,6 +1184,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1409,6 +1416,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1843,6 +1851,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -1938,6 +1947,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -1972,6 +1982,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2047,6 +2058,7 @@
         {
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2361,6 +2373,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2388,6 +2401,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2449,6 +2463,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2591,6 +2606,7 @@
         {
             "id": "0x10e5b0ef142cb28c2b53305f1a22db55fc23c72a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0e2a28fd7b1e4e7e5cced5c5bb00f7d24a5c282",
@@ -2632,6 +2648,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2998,6 +3015,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -3358,6 +3376,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4043,6 +4062,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -4213,6 +4233,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4315,6 +4336,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4396,6 +4418,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -4762,6 +4785,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5007,6 +5031,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5076,6 +5101,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5130,6 +5156,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5299,6 +5326,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5380,6 +5408,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5516,6 +5545,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5685,6 +5715,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -5936,6 +5967,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -6446,6 +6478,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -6964,6 +6997,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7045,6 +7079,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -7221,6 +7256,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7384,6 +7420,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -7519,6 +7556,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -7642,6 +7680,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7683,6 +7722,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7852,6 +7892,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8225,6 +8266,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -8565,6 +8607,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -8715,6 +8758,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8980,6 +9024,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9265,6 +9310,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -9360,6 +9406,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -10487,6 +10534,7 @@
         {
             "id": "0x444eaa82580eab5533217a0e9cfad58b6ea9d09d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -10541,6 +10589,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10718,6 +10767,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -10799,6 +10849,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11126,6 +11177,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11153,6 +11205,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -11826,6 +11879,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12164,6 +12218,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -12449,6 +12504,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12693,6 +12749,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -12904,6 +12961,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -12931,6 +12989,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12979,6 +13038,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13047,6 +13107,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13333,6 +13394,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -13504,6 +13566,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -13572,6 +13635,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13633,6 +13697,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -13674,6 +13739,7 @@
         {
             "id": "0x566cac9e77744c5a037b6d805a78516eddc9cd91",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -13715,6 +13781,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -13811,6 +13878,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14217,6 +14285,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14387,6 +14456,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14414,6 +14484,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -14483,6 +14554,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -14740,6 +14812,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -14890,6 +14963,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15032,6 +15106,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15113,6 +15188,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15309,6 +15385,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -15608,6 +15685,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15677,6 +15755,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16110,6 +16189,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -16741,6 +16821,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16931,6 +17012,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17168,6 +17250,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17237,6 +17320,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -17440,6 +17524,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17752,6 +17837,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -17970,6 +18056,7 @@
         {
             "id": "0x6f1a5cdf95a81c9c5fbf825c4a09b5ad94c47318",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f",
@@ -18188,6 +18275,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18371,6 +18459,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18425,6 +18514,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -18629,6 +18719,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19471,6 +19562,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -19552,6 +19644,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19579,6 +19672,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -19667,6 +19761,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -19917,6 +20012,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -20581,6 +20677,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -20848,6 +20945,7 @@
         {
             "id": "0x8012cf225535c377f47781ff8937b1901be4da71",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -21255,6 +21353,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -21753,6 +21852,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22152,6 +22252,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -22728,6 +22829,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -22769,6 +22871,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -22939,6 +23042,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23327,6 +23431,7 @@
         {
             "id": "0x91f31e08f4dac97c07e8c01e54694629ab94c574",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992d6ef73506a28d084dd092722f686fb5570e38",
@@ -23375,6 +23480,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23598,6 +23704,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -23734,6 +23841,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -23863,6 +23971,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24276,6 +24385,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24384,6 +24494,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25008,6 +25119,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25049,6 +25161,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -25682,6 +25795,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26170,6 +26284,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26516,6 +26631,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26543,6 +26659,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27047,6 +27164,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27236,6 +27354,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27317,6 +27436,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27379,6 +27499,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27448,6 +27569,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -27644,6 +27766,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -27855,6 +27978,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -27882,6 +28006,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28294,6 +28419,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28321,6 +28447,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28396,6 +28523,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28585,6 +28713,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -28727,6 +28856,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29120,6 +29250,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29431,6 +29562,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29651,6 +29783,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29800,6 +29933,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30085,6 +30219,7 @@
         {
             "id": "0xbcbaa95dba4c31283bbc4454c6aa137e26eab009",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -30450,6 +30585,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30830,6 +30966,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31073,6 +31210,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31744,6 +31882,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32001,6 +32140,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32056,6 +32196,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32191,6 +32332,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32498,6 +32640,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32593,6 +32736,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32736,6 +32880,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33094,6 +33239,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33310,6 +33456,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33569,6 +33716,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -33765,6 +33913,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33846,6 +33995,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33942,6 +34092,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34017,6 +34168,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34092,6 +34244,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34119,6 +34272,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34262,6 +34416,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34521,6 +34676,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34548,6 +34704,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35050,6 +35207,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35397,6 +35555,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35424,6 +35583,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35478,6 +35638,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35715,6 +35876,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35742,6 +35904,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35790,6 +35953,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36494,6 +36658,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37053,6 +37218,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37080,6 +37246,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37209,6 +37376,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37690,6 +37858,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38281,6 +38450,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38444,6 +38614,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38736,6 +38907,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38777,6 +38949,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38845,6 +39018,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39015,6 +39189,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39096,6 +39271,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39292,6 +39468,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39448,6 +39625,7 @@
         {
             "id": "0xf5f7939d8afbccfe840621f09ca702f9113ee339",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e15361fd6b4bb609fa63c81a2be19d873717870",
@@ -39536,6 +39714,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39794,6 +39973,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40378,6 +40558,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40555,6 +40736,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40670,6 +40852,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/gusdBug.json
+++ b/test/testData/testPools/gusdBug.json
@@ -1406,6 +1406,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2262,6 +2263,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -3474,6 +3476,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -4930,6 +4933,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",

--- a/test/testData/testPools/gusdBug.json
+++ b/test/testData/testPools/gusdBug.json
@@ -19,6 +19,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e84056760c8d8c3dd2c1980585acdf42183fc61",
@@ -50,6 +51,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -81,6 +83,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -112,6 +115,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -143,6 +147,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -181,6 +186,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -219,6 +225,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -250,6 +257,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8186e1d916774ab8004cb84d7adc945953ee966d",
@@ -281,6 +289,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -319,6 +328,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -350,6 +360,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -388,6 +399,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb0a8608f84dbfff504f12dbded6eac04473a0305",
@@ -419,6 +431,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -457,6 +470,7 @@
             "poolType": "Stable",
             "principalToken": null,
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -488,6 +502,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -526,6 +541,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -564,6 +580,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -595,6 +612,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -633,6 +651,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -664,6 +683,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -702,6 +722,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -740,6 +761,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -771,6 +793,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -809,6 +832,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -847,6 +871,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -885,6 +910,7 @@
             "poolType": "Stable",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -923,6 +949,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -954,6 +981,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -992,6 +1020,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -1030,6 +1059,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x071af828464def6979fadaa34703deaacd3ac71d",
@@ -1061,6 +1091,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -1092,6 +1123,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1130,6 +1162,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1168,6 +1201,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1206,6 +1240,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -1237,6 +1272,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02822e968856186a20fec2c824d4b174d0b70502",
@@ -1268,6 +1304,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1306,6 +1343,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc2569dd7d0fd715b054fbf16e75b001e5c0c1115",
@@ -1337,6 +1375,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb0a8608f84dbfff504f12dbded6eac04473a0305",
@@ -1368,6 +1407,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -1438,6 +1478,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -1476,6 +1517,7 @@
             "poolType": "Stable",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -1528,6 +1570,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -1559,6 +1602,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1597,6 +1641,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -1635,6 +1680,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc2569dd7d0fd715b054fbf16e75b001e5c0c1115",
@@ -1666,6 +1712,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -1704,6 +1751,7 @@
             "poolType": "Stable",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -1742,6 +1790,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1773,6 +1822,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1804,6 +1854,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -1842,6 +1893,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -1880,6 +1932,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -1918,6 +1971,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -1949,6 +2003,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -1980,6 +2035,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2018,6 +2074,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -2056,6 +2113,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -2087,6 +2145,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -2125,6 +2184,7 @@
             "poolType": "Stable",
             "principalToken": null,
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc2569dd7d0fd715b054fbf16e75b001e5c0c1115",
@@ -2156,6 +2216,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2187,6 +2248,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2225,6 +2287,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2295,6 +2358,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb0a8608f84dbfff504f12dbded6eac04473a0305",
@@ -2326,6 +2390,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2357,6 +2422,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -2395,6 +2461,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2426,6 +2493,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -2464,6 +2532,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaff4481d10270f50f203e0763e2597776068cbc5",
@@ -2495,6 +2564,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -2533,6 +2603,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -2571,6 +2642,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -2609,6 +2681,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2647,6 +2720,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -2678,6 +2752,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2716,6 +2791,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2747,6 +2823,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -2785,6 +2862,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2816,6 +2894,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -2847,6 +2926,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -2885,6 +2965,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -2916,6 +2997,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -2954,6 +3036,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -2992,6 +3075,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -3030,6 +3114,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -3096,6 +3181,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -3134,6 +3220,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -3172,6 +3259,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -3210,6 +3298,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -3248,6 +3337,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -3286,6 +3376,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -3324,6 +3415,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -3362,6 +3454,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -3400,6 +3493,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -3438,6 +3532,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -3508,6 +3603,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -3546,6 +3642,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -3577,6 +3674,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -3615,6 +3713,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -3646,6 +3745,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -3684,6 +3784,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -3715,6 +3816,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -3746,6 +3848,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -3784,6 +3887,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -3815,6 +3919,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -3853,6 +3958,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -3891,6 +3997,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -3922,6 +4029,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -3960,6 +4068,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -3998,6 +4107,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -4036,6 +4146,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -4074,6 +4185,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -4112,6 +4224,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -4143,6 +4256,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -4181,6 +4295,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -4212,6 +4327,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -4243,6 +4359,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -4281,6 +4398,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02822e968856186a20fec2c824d4b174d0b70502",
@@ -4312,6 +4430,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -4343,6 +4462,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -4374,6 +4494,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb0a8608f84dbfff504f12dbded6eac04473a0305",
@@ -4405,6 +4526,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -4436,6 +4558,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -4474,6 +4597,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -4505,6 +4629,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -4536,6 +4661,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -4574,6 +4700,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -4605,6 +4732,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -4636,6 +4764,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -4674,6 +4803,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -4705,6 +4835,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -4743,6 +4874,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -4781,6 +4913,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -4819,6 +4952,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -4857,6 +4991,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -4895,6 +5030,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -4965,6 +5101,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -5003,6 +5140,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -5041,6 +5179,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -5072,6 +5211,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -5110,6 +5250,7 @@
             "poolType": "Stable",
             "principalToken": null,
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15e76fc74c6ab1c3141d61219883d1c59f716e21",
@@ -5141,6 +5282,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -5172,6 +5314,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -5210,6 +5353,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x071af828464def6979fadaa34703deaacd3ac71d",
@@ -5241,6 +5385,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -5279,6 +5424,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -5317,6 +5463,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32fc95287b14eaef3afa92cccc48c285ee3a280a",
@@ -5362,6 +5509,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -5407,6 +5555,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -5445,6 +5594,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -5483,6 +5633,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -5521,6 +5672,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -5559,6 +5711,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -5597,6 +5750,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -5628,6 +5782,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -5666,6 +5821,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -5704,6 +5860,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -5742,6 +5899,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -5780,6 +5938,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -5818,6 +5977,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -5856,6 +6016,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -5894,6 +6055,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -5925,6 +6087,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x071af828464def6979fadaa34703deaacd3ac71d",
@@ -5956,6 +6119,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x071af828464def6979fadaa34703deaacd3ac71d",
@@ -5987,6 +6151,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -6018,6 +6183,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -6056,6 +6222,7 @@
             "poolType": "Stable",
             "principalToken": null,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",
@@ -6094,6 +6261,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -6125,6 +6293,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -6163,6 +6332,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e84056760c8d8c3dd2c1980585acdf42183fc61",
@@ -6194,6 +6364,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -6225,6 +6396,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -6263,6 +6435,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -6301,6 +6474,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -6332,6 +6506,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468c26d86c614cc3d8eb8cfd89d5607f79d46289",
@@ -6363,6 +6538,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -6394,6 +6570,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -6432,6 +6609,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -6470,6 +6648,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -6501,6 +6680,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -6539,6 +6719,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -6577,6 +6758,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -6615,6 +6797,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c8e3bcb3378a443cc591f154c5ce0ebb4da9648",
@@ -6653,6 +6836,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -6684,6 +6868,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x22ee6c3b011facc530dd01fe94c58919344d6db5",
@@ -6722,6 +6907,7 @@
             "poolType": "Weighted",
             "principalToken": null,
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41286bb1d3e870f3f750eb7e1c25d7e48c8a1ac7",
@@ -6753,6 +6939,7 @@
             "poolType": "Stable",
             "principalToken": null,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04df6e4121c27713ed22341e7c7df330f56f289b",

--- a/test/testData/testPools/stable-and-weighted-gas-price-zero.json
+++ b/test/testData/testPools/stable-and-weighted-gas-price-zero.json
@@ -990,6 +990,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1017,6 +1018,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1288,6 +1290,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -1458,6 +1461,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -1485,6 +1489,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -1696,6 +1701,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2057,6 +2063,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2261,6 +2268,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2695,6 +2703,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2790,6 +2799,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2824,6 +2834,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2900,6 +2911,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3002,6 +3014,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3275,6 +3288,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -3302,6 +3316,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3363,6 +3378,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3505,6 +3521,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3871,6 +3888,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -4231,6 +4249,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4916,6 +4935,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -5086,6 +5106,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5188,6 +5209,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5269,6 +5291,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5608,6 +5631,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5826,6 +5850,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5895,6 +5920,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5949,6 +5975,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6118,6 +6145,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6199,6 +6227,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6335,6 +6364,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6504,6 +6534,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6755,6 +6786,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -7224,6 +7256,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7769,6 +7802,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7850,6 +7884,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8026,6 +8061,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8189,6 +8225,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8324,6 +8361,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8447,6 +8485,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8488,6 +8527,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8657,6 +8697,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -9030,6 +9071,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9343,6 +9385,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9493,6 +9536,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9758,6 +9802,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10043,6 +10088,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10138,6 +10184,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11231,6 +11278,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11360,6 +11408,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11468,6 +11517,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11549,6 +11599,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11822,6 +11873,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11849,6 +11901,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12510,6 +12563,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12848,6 +12902,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13133,6 +13188,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13377,6 +13433,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13588,6 +13645,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13615,6 +13673,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13663,6 +13722,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13731,6 +13791,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14051,6 +14112,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14222,6 +14284,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14290,6 +14353,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14351,6 +14415,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14392,6 +14457,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14488,6 +14554,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14867,6 +14934,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15037,6 +15105,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15064,6 +15133,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15133,6 +15203,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15390,6 +15461,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15540,6 +15612,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15648,6 +15721,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15729,6 +15803,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15925,6 +16000,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16224,6 +16300,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16293,6 +16370,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16692,6 +16770,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17323,6 +17402,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17513,6 +17593,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17750,6 +17831,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17819,6 +17901,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18022,6 +18105,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18307,6 +18391,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18708,6 +18793,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18891,6 +18977,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18945,6 +19032,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19149,6 +19237,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19991,6 +20080,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20072,6 +20162,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20099,6 +20190,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20187,6 +20279,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20437,6 +20530,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21074,6 +21168,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21687,6 +21782,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22185,6 +22281,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22584,6 +22681,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23133,6 +23231,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -23160,6 +23259,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -23201,6 +23301,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -23371,6 +23472,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23982,6 +24084,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24118,6 +24221,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -24274,6 +24378,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24687,6 +24792,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24795,6 +24901,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25446,6 +25553,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25487,6 +25595,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26120,6 +26229,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26581,6 +26691,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26927,6 +27038,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26954,6 +27066,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +27571,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27647,6 +27761,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27728,6 +27843,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27790,6 +27906,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27859,6 +27976,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -28055,6 +28173,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28266,6 +28385,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -28293,6 +28413,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28705,6 +28826,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28732,6 +28854,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28807,6 +28930,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28996,6 +29120,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -29138,6 +29263,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29504,6 +29630,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29788,6 +29915,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30008,6 +30136,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30157,6 +30286,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30753,6 +30883,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31133,6 +31264,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31349,6 +31481,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31993,6 +32126,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32250,6 +32384,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32305,6 +32440,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32440,6 +32576,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32747,6 +32884,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32842,6 +32980,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32985,6 +33124,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33343,6 +33483,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33559,6 +33700,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33818,6 +33960,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -34055,6 +34198,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34136,6 +34280,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34232,6 +34377,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34307,6 +34453,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34382,6 +34529,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34409,6 +34557,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34552,6 +34701,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34694,6 +34844,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34721,6 +34872,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35250,6 +35402,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35570,6 +35723,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35597,6 +35751,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35651,6 +35806,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35888,6 +36044,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35915,6 +36072,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35963,6 +36121,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36668,6 +36827,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37227,6 +37387,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37254,6 +37415,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37383,6 +37545,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37837,6 +38000,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38428,6 +38592,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38618,6 +38783,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38910,6 +39076,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38951,6 +39118,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39019,6 +39187,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39189,6 +39358,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39270,6 +39440,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39466,6 +39637,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39676,6 +39848,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39934,6 +40107,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40470,6 +40644,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40647,6 +40822,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40789,6 +40965,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/stable-and-weighted-gas-price-zero.json
+++ b/test/testData/testPools/stable-and-weighted-gas-price-zero.json
@@ -13,6 +13,7 @@
         {
             "id": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "588",
             "tokens": [
                 {
@@ -48,6 +49,7 @@
         {
             "id": "0x3B3Ac5386837Dc563660FB6a0937DFAa5924333B",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "500",
             "tokens": [
                 {
@@ -90,6 +92,7 @@
         {
             "id": "0x845838DF265Dcd2c412A1Dc9e959c7d08537f8a2",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "450",
             "tokens": [
                 {
@@ -118,6 +121,7 @@
         {
             "id": "0xD2967f45c4f384DEEa880F807Be904762a3DeA07",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -146,6 +150,7 @@
         {
             "id": "0xb19059ebb43466C323583928285a49f558E572Fd",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "300",
             "tokens": [
                 {
@@ -174,6 +179,7 @@
         {
             "id": "0x5B5CFE992AdAC0C9D48E05854B2d91C73a003858",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -202,6 +208,7 @@
         {
             "id": "0x6D65b498cb23deAba52db31c93Da9BFFb340FB8F",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "5",
             "tokens": [
                 {
@@ -230,6 +237,7 @@
         {
             "id": "0x1AEf73d49Dedc4b1778d0706583995958Dc862e6",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -258,6 +266,7 @@
         {
             "id": "0xD905e2eaeBe188fc92179b6350807D8bd91Db0D8",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -300,6 +309,7 @@
         {
             "id": "0x49849C98ae39Fff122806C06791Fa73784FB3675",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -328,6 +338,7 @@
         {
             "id": "0xC2Ee6b0334C261ED60C72f6054450b61B8f18E35",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -356,6 +367,7 @@
         {
             "id": "0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -391,6 +403,7 @@
         {
             "id": "0xC25a3A3b969415c80451098fa907EC722572917F",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -433,6 +446,7 @@
         {
             "id": "0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "150",
             "tokens": [
                 {
@@ -461,6 +475,7 @@
         {
             "id": "0x97E2768e8E73511cA874545DC5Ff8067eB19B787",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -489,6 +504,7 @@
         {
             "id": "0x4f3E8F405CF5aFC05D68142F3783bDfE13811522",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "51",
             "tokens": [
                 {
@@ -517,6 +533,7 @@
         {
             "id": "0x9fC689CCaDa600B6DF723D9E47D84d76664a1F23",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "2000",
             "tokens": [
                 {
@@ -552,6 +569,7 @@
         {
             "id": "0xdF5e0e81Dff6FAF3A7e52BA697820c5e32D806A8",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "1000",
             "tokens": [
                 {
@@ -594,6 +612,7 @@
         {
             "id": "0x3a664Ab939FD8482048609f652f9a0B0677337B9",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -622,6 +641,7 @@
         {
             "id": "0x410e3E86ef427e30B9235497143881f717d93c2A",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -650,6 +670,7 @@
         {
             "id": "0x2fE94ea3d5d4a175184081439753DE15AeF9d614",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -678,6 +699,7 @@
         {
             "id": "0xDE5331AC4B3630f94853Ff322B66407e0D6331E8",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "200",
             "tokens": [
                 {
@@ -706,6 +728,7 @@
         {
             "id": "0x94e131324b6054c0D789b190b2dAC504e4361b53",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -734,6 +757,7 @@
         {
             "id": "0x194eBd173F6cDacE046C53eACcE9B953F28411d1",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -762,6 +786,7 @@
         {
             "id": "0xA3D87FffcE63B53E0d54fAa1cc983B7eB0b74A9c",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -790,6 +815,7 @@
         {
             "id": "0x06325440D014e39736583c165C2963BA99fAf14E",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "9",
             "tokens": [
                 {
@@ -818,6 +844,7 @@
         {
             "id": "0xaA17A236F2bAdc98DDc0Cf999AbB47D47Fc0A6Cf",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "10",
             "tokens": [
                 {
@@ -846,6 +873,7 @@
         {
             "id": "0x5282a4eF67D9C33135340fB3289cc1711c13638C",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "600",
             "tokens": [
                 {
@@ -881,6 +909,7 @@
         {
             "id": "0xcee60cFa923170e4f8204AE08B4fA6A3F5656F3a",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "100",
             "tokens": [
                 {
@@ -909,6 +938,7 @@
         {
             "id": "0x003a70265a3662342010823bea15dc84c6f7ed54",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -936,6 +966,7 @@
         {
             "id": "0x004e74ff81239c8f2ec0e2815defb970f3754d86",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -963,6 +994,7 @@
         {
             "id": "0x0077732357ac0f29e26ea629b79ab3b266ddb796",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1067,6 +1099,7 @@
         {
             "id": "0x0126cfa7ec6b6d4a960b5979943c06a9742af55e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -1094,6 +1127,7 @@
         {
             "id": "0x016259c630ee0b06ef56e2e6ba7908efbabfe731",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4467e8d621105312a914f1d42f10770c0ffe3c8",
@@ -1128,6 +1162,7 @@
         {
             "id": "0x0189c1f3181e4de8e2825a3aa85e40135b607dd4",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7866e48c74cbfb8183cd1a929cd9b95a7a5cb4f4",
@@ -1155,6 +1190,7 @@
         {
             "id": "0x01c0075b25579229b374dd375afd1982b3fddd0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -1182,6 +1218,7 @@
         {
             "id": "0x01c1adb4ad6678d2bf2b772301f111d257b7b109",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xeca82185adce47f39c684352b0439f030f860318",
@@ -1209,6 +1246,7 @@
         {
             "id": "0x01d7e6a79f6e6dc6f0884743078f76ac1239520a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -1236,6 +1274,7 @@
         {
             "id": "0x020da2cabb4c8ff5637c8180d2755943f442071c",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -1263,6 +1302,7 @@
         {
             "id": "0x02b77ad79e27ad80a0a0868cc7528520e8442c9b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1318,6 +1358,7 @@
         {
             "id": "0x02c6aed29690d50cd625739efda526c298540181",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x35a18000230da775cac24873d00ff85bccded550",
@@ -1366,6 +1407,7 @@
         {
             "id": "0x032d9bc3f3c1042b431f29df63aaa547f5ed6ee6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -1407,6 +1449,7 @@
         {
             "id": "0x0395e4a17ff11d36dac9959f2d7c8eca10fe89c9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -1434,6 +1477,7 @@
         {
             "id": "0x03e971000df6c356d8a68bd843cc58b5f272a99e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -1517,6 +1561,7 @@
         {
             "id": "0x04ab9fe4ca8d814c2dec3af13909d152d53891f4",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -1544,6 +1589,7 @@
         {
             "id": "0x04df4fbb6a003d1db3dd83d6d3b9951455837fff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -1592,6 +1638,7 @@
         {
             "id": "0x055db9aff4311788264798356bbf3a733ae181c6",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -1619,6 +1666,7 @@
         {
             "id": "0x05c04d16da1a7efd6d6768a3f0e609c09f99710b",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1646,6 +1694,7 @@
         {
             "id": "0x05c6961c6a903d7b8e064ac759ce0172a44c38f7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1750,6 +1799,7 @@
         {
             "id": "0x05f661a1bd2da5e59c8e06b92acdcde2706110e5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1777,6 +1827,7 @@
         {
             "id": "0x05f9a126bb07d74f53a41a70bc7619c95b9a6c93",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -1804,6 +1855,7 @@
         {
             "id": "0x060feb082a4aa0424b8ff4fdb769faf9e06e1fb9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x625ae63000f46200499120b906716420bd059240",
@@ -1831,6 +1883,7 @@
         {
             "id": "0x0690dd1266f739727d2f1c04905a0db2ccd80c3e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -1858,6 +1911,7 @@
         {
             "id": "0x0727e2d2c233795af0a80f3b7144b523341bec1f",
             "swapFee": "0.0345",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -1899,6 +1953,7 @@
         {
             "id": "0x0744faa646ad31e6f78f2c1714d72c3ff4777ad9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1926,6 +1981,7 @@
         {
             "id": "0x075b5b7cbc3addb9d8ce86629ceb066da8617bb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1967,6 +2023,7 @@
         {
             "id": "0x076a61995653c2a4b95bc13da80c6eb1aedef23d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1678c45c65530b33571e1968e21ca9d2f8d9c006",
@@ -1994,6 +2051,7 @@
         {
             "id": "0x07b18c2686f3d1ba0fa8c51edc856819f2b1100a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -2133,6 +2191,7 @@
         {
             "id": "0x0838861817c6e4af8b5ee51db6632c3fdec815f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -2160,6 +2219,7 @@
         {
             "id": "0x08ac64ec9902635d18204a1a75df0173aea00057",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -2187,6 +2247,7 @@
         {
             "id": "0x09b8de949282c7f73355b8285f131c447694f95d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -2214,6 +2275,7 @@
         {
             "id": "0x09bc559189d309695804cfe0ed64d8fa23128206",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2241,6 +2303,7 @@
         {
             "id": "0x09c5d39e789962776c4c0a0cbbd8106f8034823b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2296,6 +2359,7 @@
         {
             "id": "0x0a52d6aeac2e06cf12e168784eaa2afbda62a17a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
@@ -2323,6 +2387,7 @@
         {
             "id": "0x0a5712d6f5ac59405935e11ed05d4b07ed56a498",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -2371,6 +2436,7 @@
         {
             "id": "0x0ad2c8d5a578e7b787513a52295761232acb035f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eceb2e4f909602de1a8a30b51feba46e75b3eb1",
@@ -2398,6 +2464,7 @@
         {
             "id": "0x0af1b241ee25b6d6a8c9c8a2ac0e86ff33a44db7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2446,6 +2513,7 @@
         {
             "id": "0x0b0448ee12653b2ddd12b2c4b858e98de30b4eb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2473,6 +2541,7 @@
         {
             "id": "0x0b0da4e85b6ee526ad5314f0a13c8402057558c5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2500,6 +2569,7 @@
         {
             "id": "0x0b0dea284a07d60d026691476b130f160e48bd0a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2527,6 +2597,7 @@
         {
             "id": "0x0b74f2ae01b9cc9cfd0de08fdbbeeac5894f38ba",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2568,6 +2639,7 @@
         {
             "id": "0x0b75f370a7efabdb8a5a92615f141005831cd1cd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -2595,6 +2667,7 @@
         {
             "id": "0x0ba1d7092ad70aaf175924ab39412d5528ef3311",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -2622,6 +2695,7 @@
         {
             "id": "0x0badc63d5cc7a25007f7c35acc23369c00df6ee7",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2649,6 +2723,7 @@
         {
             "id": "0x0bdf7efef728308b6f55b1dd8d0c714f0d5d233f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -2676,6 +2751,7 @@
         {
             "id": "0x0ce374be0d5d403e5204dd5be6bfbbb18cc28747",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -2731,6 +2807,7 @@
         {
             "id": "0x0cf1f359b78d18b2923e4f0f11475172125f229f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -2772,6 +2849,7 @@
         {
             "id": "0x0d167d8cbbfc00ffa239640134d780a808e8fba0",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -2883,6 +2961,7 @@
         {
             "id": "0x0e4383eb32d32f8a23476cb4910a6af89c91ef70",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -2959,6 +3038,7 @@
         {
             "id": "0x0e552307659e70bf61f918f96aa880cdec40d7e2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3077,6 +3157,7 @@
         {
             "id": "0x0e7f8c907ea3583f859c13b5a35cbbb290e0c78e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -3125,6 +3206,7 @@
         {
             "id": "0x0e93c05a0c51c98b7d14130d1cc705b4fb60d97d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3152,6 +3234,7 @@
         {
             "id": "0x0f24b5730e0aedf61d22aabbf0079d517203d48e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52e6caccb7affc30a3ceee544428692fa2120e7b",
@@ -3179,6 +3262,7 @@
         {
             "id": "0x0f67e34aed6c6c4334523568c2acb750c18541f7",
             "swapFee": "0.007777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -3234,6 +3318,7 @@
         {
             "id": "0x0fc96c922fd2b457a7d6507b61b7af7d9f7c95e5",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
@@ -3261,6 +3346,7 @@
         {
             "id": "0x0fd6fa6cb1e7cb78e6ad5f6d32e56d524f6a092e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -3351,6 +3437,7 @@
         {
             "id": "0x10432575da20157e242a3489decbc0f2122c23fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3597bfd533a99c9aa083587b074434e61eb0a258",
@@ -3406,6 +3493,7 @@
         {
             "id": "0x10996ec4f3e7a1b314ebd966fa8b1ad0fe0f8307",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3440,6 +3528,7 @@
         {
             "id": "0x10a39605ae49bf6bee84dcd09551e3ede7401b63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3467,6 +3556,7 @@
         {
             "id": "0x10d9b57f769fbb355cdc2f3c076a65a288ddc78e",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -3494,6 +3584,7 @@
         {
             "id": "0x10dd17ecfc86101eab956e0a443cab3e9c62d9b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -3570,6 +3661,7 @@
         {
             "id": "0x117d7d0247d5a0b52097a9884e4e9caea1134174",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
@@ -3597,6 +3689,7 @@
         {
             "id": "0x119ed29ff7209ae155ca695c6f29640157690a25",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -3631,6 +3724,7 @@
         {
             "id": "0x123a01ae560f7b39f5f649ea40bb13186b72df69",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3658,6 +3752,7 @@
         {
             "id": "0x1294bc499779314777498d3c485b83e013c52fcf",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -3685,6 +3780,7 @@
         {
             "id": "0x12a4395d92971c4f7bbf5f6c9b9ae1257b0a0e63",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3712,6 +3808,7 @@
         {
             "id": "0x12d165dc02ef89fff66b53e165a532507e51b2c7",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26607ac599266b21d13c7acf7942c7701a8b699c",
@@ -3739,6 +3836,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3773,6 +3871,7 @@
         {
             "id": "0x12fb15ff6b7420d85f5fe3f9b5ddcfe88aac63c0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -3800,6 +3899,7 @@
         {
             "id": "0x12ff2b8269e93016e8350c6641b1208b0d70afb8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57b482dfe9adf5b33c4f7329fcc33369660658fa",
@@ -3827,6 +3927,7 @@
         {
             "id": "0x1304e7ac1e6305393cf9ed568d1d5f1b3613198e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -3854,6 +3955,7 @@
         {
             "id": "0x1369f8b1f9746422408c659df4da0ed8707dfe50",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c405acf8688afb61b3197421cdeec1a266c6839",
@@ -3958,6 +4060,7 @@
         {
             "id": "0x13f33189945858153b216e8e622bf118439c35a9",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3992,6 +4095,7 @@
         {
             "id": "0x14b4e45e0bb92a8c5928710611956ca4a963496b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -4019,6 +4123,7 @@
         {
             "id": "0x14c6f9f0ccbb990c6517b17e3e79a39e0a27f27e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -4046,6 +4151,7 @@
         {
             "id": "0x156d75ea60db947870fc25635886c5e78e651090",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -4073,6 +4179,7 @@
         {
             "id": "0x156d96eac6fe0e403428379c2d891c17a24c77f9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4114,6 +4221,7 @@
         {
             "id": "0x15ac360ddf2f4dbf6a7150497b7eb8cbdbb657f9",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -4141,6 +4249,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4168,6 +4277,7 @@
         {
             "id": "0x16ca6feb48043201c9fc87ce7f5d78bb2d3cb1d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -4195,6 +4305,7 @@
         {
             "id": "0x16cac1403377978644e78769daa49d8f6b6cf565",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4222,6 +4333,7 @@
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4291,6 +4403,7 @@
         {
             "id": "0x178509d5ff75a357fabb4479d2b33e4fafe5212a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -4339,6 +4452,7 @@
         {
             "id": "0x17996cbddd23c2a912de8477c37d43a1b79770b8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4366,6 +4480,7 @@
         {
             "id": "0x17c8a445edee2fa43b44da1adea0d01c81f9c63a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3558d0a29ece12861af228df1970ff3d15a19519",
@@ -4393,6 +4508,7 @@
         {
             "id": "0x17fcd786091e3108047e91d8de132e0cce813b1f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x236bd65c92e1076c54ec7d4c31e980a30c3cb8d9",
@@ -4420,6 +4536,7 @@
         {
             "id": "0x17fee7f451c045498541f89949bfc76c7bfa3f1c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4447,6 +4564,7 @@
         {
             "id": "0x1811a719a05d20b6447ca556a54f00f9c14578be",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -4516,6 +4634,7 @@
         {
             "id": "0x18b5cb6b881edede9b7773e6a0c9bef45ac92168",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4543,6 +4662,7 @@
         {
             "id": "0x19192aba85eb665f3272d848ecf30beced68eb58",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -4570,6 +4690,7 @@
         {
             "id": "0x191f7e8e5b8a3b8b2e5b20313be8355cdc33c11a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4597,6 +4718,7 @@
         {
             "id": "0x1938211251036c44346b71c86f71fab5f54db596",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbeab55a2032b5a8fbc641bb3dcd98e1006c23e4",
@@ -4624,6 +4746,7 @@
         {
             "id": "0x196bfb322cc8d249c3476835a86bc609477bacfa",
             "swapFee": "0.036",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -4651,6 +4774,7 @@
         {
             "id": "0x198059d85defcd671cc1ee1919979a934bc039be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5732046a883704404f284ce41ffadd5b007fd668",
@@ -4678,6 +4802,7 @@
         {
             "id": "0x19b04c7264563791d54e449f965548b8a9e2fc3a",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -4705,6 +4830,7 @@
         {
             "id": "0x19b50750b3a72da1075380fd0447ff533d99a728",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -4739,6 +4865,7 @@
         {
             "id": "0x19bb24cfbbd87bf3add4b2caba5077d0b8da6d99",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -4766,6 +4893,7 @@
         {
             "id": "0x19db8e1a8553955757e87bc2620b76cca4262577",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4793,6 +4921,7 @@
         {
             "id": "0x19f4611c61e2ee6d2fadfccbde1e95cfcfd1e210",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
@@ -4820,6 +4949,7 @@
         {
             "id": "0x1a2ebf505cb83dffb31ca86e8ebd8b7978f2f305",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4854,6 +4984,7 @@
         {
             "id": "0x1a38ea1ca878cd2734aef22f6615e7c6e28de859",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -4881,6 +5012,7 @@
         {
             "id": "0x1af23b311f203844108137d6ee399109e4981401",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -4908,6 +5040,7 @@
         {
             "id": "0x1b481b706b571839aa095ad11b82d7057370ee98",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -4963,6 +5096,7 @@
         {
             "id": "0x1b8874baceaafba9ea194a625d12e8b270d77016",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -5004,6 +5138,7 @@
         {
             "id": "0x1bbaf53bab7893345b65976e8f67d64f7d3e3a33",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5031,6 +5166,7 @@
         {
             "id": "0x1be21dd1fa2aced16656b7d765b88afa6853cc98",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -5079,6 +5215,7 @@
         {
             "id": "0x1be4c2afd3705cbe6dbbe45b1f87a637616683f5",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -5155,6 +5292,7 @@
         {
             "id": "0x1ca5a381dc900554a5c0ce97a874a7b3518d12e7",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5182,6 +5320,7 @@
         {
             "id": "0x1cea175ae937f195e2c4ff7d2fc4893fa215d339",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x222b631c42977ed8724cdf8d6fcf7d66385a2da3",
@@ -5237,6 +5376,7 @@
         {
             "id": "0x1d19a4209d78fe94c99f104fafcc1e3457039a8f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -5264,6 +5404,7 @@
         {
             "id": "0x1d261ec7ab834fedb01602c5b7ffc6fc68362bbf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5347,6 +5488,7 @@
         {
             "id": "0x1dd2cb1745aaf061380a46d5dd3b1ee2f5d5e8ad",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -5388,6 +5530,7 @@
         {
             "id": "0x1ddf0976ac842c696d01a86b39d25b067ed8c7ff",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -5415,6 +5558,7 @@
         {
             "id": "0x1def952d49cb7e122bbef0c643b87995d874ce3d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
@@ -5442,6 +5586,7 @@
         {
             "id": "0x1df8f3aad2353e087ec0296ed5c504f6d622ca18",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739",
@@ -5469,6 +5614,7 @@
         {
             "id": "0x1e01123b8333205e9c254922c3365c7d94061ca0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -5496,6 +5642,7 @@
         {
             "id": "0x1e2da0aa71155726c5c0e39af76ac0c2e8f74bef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -5523,6 +5670,7 @@
         {
             "id": "0x1e63fd8f5c2b7d4498f72f09016c0893e382e1f8",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5550,6 +5698,7 @@
         {
             "id": "0x1eff8af5d577060ba4ac8a29a13525bb0ee2a3d5",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5577,6 +5726,7 @@
         {
             "id": "0x1f069e458127c7a19f68747cbee1d420f0d0d1fb",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -5604,6 +5754,7 @@
         {
             "id": "0x1f187fa8d99803a0c1d7bb66ba619aa92a3ec34a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -5659,6 +5810,7 @@
         {
             "id": "0x2108f1d1328fce8c2cb92b2fac720a79195eff23",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -5728,6 +5880,7 @@
         {
             "id": "0x21a4021f4794715827fb534161305ea532becf83",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d762f76b9e91f71cc4f94391bdfe6333db8519c",
@@ -5755,6 +5908,7 @@
         {
             "id": "0x221bf20c2ad9e5d7ec8a9d1991d8e2edcfcb9d6c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5782,6 +5936,7 @@
         {
             "id": "0x22356b87082c59be4fc8c81b3e037b0a3b47d0a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5809,6 +5964,7 @@
         {
             "id": "0x2257aaac34bcb27900291f7b84ee2565a6cbac57",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -5948,6 +6104,7 @@
         {
             "id": "0x2360a9f7198532cfdede04fca1a51ebe2fa68672",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5299d6f7472dcc137d7f3c4bcfbbb514babf341a",
@@ -6003,6 +6160,7 @@
         {
             "id": "0x239c53350be2b399fe104f0e207e26dfb24164f3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f49ed43c90a540d1cf12f6170ace8d0b88a14e6",
@@ -6037,6 +6195,7 @@
         {
             "id": "0x23acc850b30a07dcd9fb87e36da111b9b301b3e5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59fec83ec709c893aedd1a144cf1828eb04127cd",
@@ -6064,6 +6223,7 @@
         {
             "id": "0x23c1f4caaab3d3c978d3a1b8bbda22bef0320f84",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -6091,6 +6251,7 @@
         {
             "id": "0x2417f25de6d1688324e0de5c6a4ae34a733147ed",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -6118,6 +6279,7 @@
         {
             "id": "0x2471de1547296aadb02cc1af84afe369b6f67c87",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6173,6 +6335,7 @@
         {
             "id": "0x249dda6b483f3fde86cd1937e825f0901c1151f3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6200,6 +6363,7 @@
         {
             "id": "0x24d97eed6e171e70c82bc60afd37c7d1e549a0ad",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -6255,6 +6419,7 @@
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6282,6 +6447,7 @@
         {
             "id": "0x251d79f54e481efc2c7755b226d238225dd8be62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -6337,6 +6503,7 @@
         {
             "id": "0x252b17eb53f8baeae583cfed1665a5483632829f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8104c9f13118320eefe5fbea8a44d600b85981ef",
@@ -6399,6 +6566,7 @@
         {
             "id": "0x2617cb704b1e5b6c4fe28399f2031cc2d2b99cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6426,6 +6594,7 @@
         {
             "id": "0x2617eb71ae6932009ec915bf032ddc66d55755fc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -6453,6 +6622,7 @@
         {
             "id": "0x26545fd70c44e6d7025a554d5bbcffdb3e457cf7",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbabc2015dab61008f5e248dd3511fd46a4103418",
@@ -6480,6 +6650,7 @@
         {
             "id": "0x26939bb6d0b993a2bf991141edd7d48d0b9a39c9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -6507,6 +6678,7 @@
         {
             "id": "0x26bd10af71ea2c262cad5961fb71c24a7a4a2ccf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4d807509aece24c0fa5a102b6a3b059ec6e14392",
@@ -6562,6 +6734,7 @@
         {
             "id": "0x276715628b9863a94037a03b79ef9374ea773053",
             "swapFee": "0.0011",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -6596,6 +6769,7 @@
         {
             "id": "0x27fdccd1a9ee46b46b3d4547cbf4c57bc10c0508",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -6623,6 +6797,7 @@
         {
             "id": "0x280267901c175565c64acbd9a3c8f60705a72639",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -6650,6 +6825,7 @@
         {
             "id": "0x2814dec8b21031f310e57829f942906c40318230",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -6705,6 +6881,7 @@
         {
             "id": "0x2835bfa92f7ce41f17759ea8895172a94a610fef",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aed65101dde0c7760c7ce226d911c43c862eb21",
@@ -6732,6 +6909,7 @@
         {
             "id": "0x285d6228ca5234edcb127077cd46b492c879760c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -6759,6 +6937,7 @@
         {
             "id": "0x285f2e1495c9c9f883b36331ee54bb1d7d0542c5",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -6814,6 +6993,7 @@
         {
             "id": "0x28e598846febb750effc384853fbce82988eaaa2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -6841,6 +7021,7 @@
         {
             "id": "0x292515d1ebf861ca5c1e0edfd45ffa87bee3644e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -6868,6 +7049,7 @@
         {
             "id": "0x294de1cde8b04bf6d25f98f1d547052f8080a177",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6895,6 +7077,7 @@
         {
             "id": "0x2961c01eb89d9af84c3859ce9e00e78effcab32f",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6922,6 +7105,7 @@
         {
             "id": "0x29d2e5957249e5c8c2b22a9101002183f7d35382",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -6949,6 +7133,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -6997,6 +7182,7 @@
         {
             "id": "0x2a8d66fbd0efb5f72e9b1d0dc9912d4456ac6b55",
             "swapFee": "0.0999",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -7024,6 +7210,7 @@
         {
             "id": "0x2aa3041fe813cfe572969216c6843c33f14f9194",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -7065,6 +7252,7 @@
         {
             "id": "0x2aaba2a54b72bc8a93521c2dd9c6b4354906b764",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -7113,6 +7301,7 @@
         {
             "id": "0x2abacbc859cf66efdcb69f7bc7116f42183f0109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -7140,6 +7329,7 @@
         {
             "id": "0x2aeb22cd755fa598b493e4b69ce99effb64e676e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -7167,6 +7357,7 @@
         {
             "id": "0x2b0d0fc5892b929c9f8b1283add68cad65ce0e45",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -7222,6 +7413,7 @@
         {
             "id": "0x2b2d9a11b6d4f1f010c47166d15b3dee90fee1c8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -7298,6 +7490,7 @@
         {
             "id": "0x2bb0ceed9083ab2bb1ff5270608d642835ddf864",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -7367,6 +7560,7 @@
         {
             "id": "0x2c1cb70cccf250b35ca2cb021e2f624aba76e3e8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7394,6 +7588,7 @@
         {
             "id": "0x2c317515ae16d61ccea43f18e4687d956ee4831f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -7428,6 +7623,7 @@
         {
             "id": "0x2c70ea56c08ba4279d62f83ca14952ed28944072",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaaaf91d9b90df800df4f55c205fd6989c977e73a",
@@ -7455,6 +7651,7 @@
         {
             "id": "0x2cbb8dfe7ccd4f33cd243ea6a6d02c9f3118450f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8daebade922df735c38c80c7ebd708af50815faa",
@@ -7482,6 +7679,7 @@
         {
             "id": "0x2cc8677176499d5af8f3f125d9e6303b56d57e1b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7509,6 +7707,7 @@
         {
             "id": "0x2cd2cae99a6667ff81aa60f759d65b4e50bcf4d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7536,6 +7735,7 @@
         {
             "id": "0x2cdfd9e12e482d0238a2e1db8d1ae11cb47c4515",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -7563,6 +7763,7 @@
         {
             "id": "0x2cf9106faf2c5c8713035d40df655fb1b9b0f9b9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -7590,6 +7791,7 @@
         {
             "id": "0x2d18e16138196f4a1fd93af24db4b9cbc9f5e938",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7617,6 +7819,7 @@
         {
             "id": "0x2d2bd6715244bbaa81b61b190116e7564108a3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x06af07097c9eeb7fd685c692751d5c66db49c215",
@@ -7679,6 +7882,7 @@
         {
             "id": "0x2d4d246d8f46d3a2a9cf6160bcabbf164c15b36f",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -7748,6 +7952,7 @@
         {
             "id": "0x2d65efefb43bec376b920cddbd5eb19e59f59ca8",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -7775,6 +7980,7 @@
         {
             "id": "0x2dd7255b487a62d738110bd10f8bc4b4ea989778",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -7830,6 +8036,7 @@
         {
             "id": "0x2e41132dab88a9bad80740a1392d322bf023d494",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7857,6 +8064,7 @@
         {
             "id": "0x2e46d8d54b606ebe1e8f653a265ef8b1638e64cb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -7919,6 +8127,7 @@
         {
             "id": "0x2e933a4612c4fa03b258c2fd183c299d099975be",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7946,6 +8155,7 @@
         {
             "id": "0x2eb6cfbffc8785cd0d9f2d233d0a617bf4269eef",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7973,6 +8183,7 @@
         {
             "id": "0x2ed22a483eafa494f13b03c8d99bfcefda7689ff",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8000,6 +8211,7 @@
         {
             "id": "0x2ee268541b96b2b8129a06b006fd247b467f6118",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -8034,6 +8246,7 @@
         {
             "id": "0x2eefe2d42ccecd9980349c2189ddbfa9a47935af",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -8089,6 +8302,7 @@
         {
             "id": "0x2f49eea1efc1b04e9ecd3b81321060e29db26a19",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8116,6 +8330,7 @@
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -8171,6 +8386,7 @@
         {
             "id": "0x3003ba4f03d823fef98e5887bdb292a80d7ba3e3",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c1ec5587303d7f16f2370d21942d57b0a48223d",
@@ -8198,6 +8414,7 @@
         {
             "id": "0x302b1e2eb889e3dcf813f55bd93dc8455b150649",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaba53e2d526c2b37eeb97da4e60da82bdcc0a7a7",
@@ -8253,6 +8470,7 @@
         {
             "id": "0x30bb2bd0ae5b018014d8356a16d665a4c9d69134",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8280,6 +8498,7 @@
         {
             "id": "0x30cb859317e171832b064c97cc03ccb081954d1b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -8307,6 +8526,7 @@
         {
             "id": "0x3138c04d53654325880d1a19b85b0d04d14c8a0e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb47ac409fd451f89eadaefc4cf1e76daf7ae0650",
@@ -8334,6 +8554,7 @@
         {
             "id": "0x3144c5a74672aa509db2ea02d252d8af2dcca488",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -8389,6 +8610,7 @@
         {
             "id": "0x315e6a6687c7a31a1d9cc931c8dc8e7a7a72b2cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -8416,6 +8638,7 @@
         {
             "id": "0x3169673fe57e87960afc14d0714346273be019b4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -8555,6 +8778,7 @@
         {
             "id": "0x3217bee1f4a2f6140e551c8d32bfc4ad8d9f621e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7890cbe646dcf9f1f9a00c64ed2b8d8585e09a02",
@@ -8582,6 +8806,7 @@
         {
             "id": "0x32751c04b865e0143ac0ed53c8fa9b7c7b0afb4a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75b81f13401e7312bdb3dea8abd18e9e05950e26",
@@ -8609,6 +8834,7 @@
         {
             "id": "0x330416c863f2acce7af9c9314b422d24c672534a",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -8636,6 +8862,7 @@
         {
             "id": "0x336eb7fb7f53a287d384ad12826a32f82c5e4d78",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8663,6 +8890,7 @@
         {
             "id": "0x33812e984d49ed5b44d75a008c12060e5076238c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -8725,6 +8953,7 @@
         {
             "id": "0x33bb46f1d83b22e4b4ef235da7dda0fe3451a61a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -8759,6 +8988,7 @@
         {
             "id": "0x33bc3abfabde8fceb0ced58e16184fb4cfc163ef",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8786,6 +9016,7 @@
         {
             "id": "0x33f7cc013041082477452ec0bdaa61d99bf3113d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93dfaf57d986b9ca77df9376c50878e013d9c7c8",
@@ -8813,6 +9044,7 @@
         {
             "id": "0x33f97949fc88a225681b553894db51064085e69a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -8861,6 +9093,7 @@
         {
             "id": "0x33fa3468251f1066d1a85f35c06ec04d78b4d0c5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -8888,6 +9121,7 @@
         {
             "id": "0x343aed64144ed1940360e25917fc781bbb98b899",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -8915,6 +9149,7 @@
         {
             "id": "0x349388dafb463ba2bc5cedc8ebc55c25d70f61bb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -8942,6 +9177,7 @@
         {
             "id": "0x34ed04c89a63ac06d136e46e657a9451722f22a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
@@ -8969,6 +9205,7 @@
         {
             "id": "0x35333cf3db8e334384ec6d2ea446da6e445701df",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c",
@@ -8996,6 +9233,7 @@
         {
             "id": "0x35381c233fbddaa2853581ec7cda95f4ca86b1d8",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9023,6 +9261,7 @@
         {
             "id": "0x354594ab5018fed842146c0b2062c82ea8834292",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x419d0d8bdd9af5e606ae2232ed285aff190e711b",
@@ -9099,6 +9338,7 @@
         {
             "id": "0x35f6d69f83773d92bbfa326dae2f4e337ca577a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02eca910cb3a7d43ebc7e8028652ed5c6b70259b",
@@ -9126,6 +9366,7 @@
         {
             "id": "0x3694b26c6b67677b663a905cea4d325019eace9a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9160,6 +9401,7 @@
         {
             "id": "0x36a57f5ea6cceb75523639aba3224036e5f8231d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9187,6 +9429,7 @@
         {
             "id": "0x36d6498157007b9a8b359f7db9910529e7ff5917",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -9214,6 +9457,7 @@
         {
             "id": "0x371a47394006224e38c9da28c17738e4f9a7900e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9255,6 +9499,7 @@
         {
             "id": "0x37958087165359e0ff4224c7cc77bdc9be77dbda",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -9282,6 +9527,7 @@
         {
             "id": "0x3895bd6a41c914111c8e1bbbd0c351e43190bd7f",
             "swapFee": "0.0195",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9316,6 +9562,7 @@
         {
             "id": "0x39376719cd74a5eec8b5f726ebfc1be858455088",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -9413,6 +9660,7 @@
         {
             "id": "0x3a0ddb5f674b5ecb590d6b1d204d9b382cc1cb8d",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9440,6 +9688,7 @@
         {
             "id": "0x3a17f93ef0baee1b9903449c92a350fe6b47bd2c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9467,6 +9716,7 @@
         {
             "id": "0x3a2038254394b78dc8bff9f5f19bde0e8b1ef022",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -9564,6 +9814,7 @@
         {
             "id": "0x3a7a90ac4064c55abedfc919a773b54189ea25dc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d8d9f5b96f4438195be9b99eee6118ed4304286",
@@ -9591,6 +9842,7 @@
         {
             "id": "0x3a7f3019a295cff0de44eff749987e0d1d5f6424",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04abeda201850ac0124161f037efd70c74ddc74c",
@@ -9618,6 +9870,7 @@
         {
             "id": "0x3a96c7833809a14bebc86df3cd6a17b56c2c537c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -9652,6 +9905,7 @@
         {
             "id": "0x3b188b0c813a8d34bb401c9a6630477025823e7d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -9679,6 +9933,7 @@
         {
             "id": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -9727,6 +9982,7 @@
         {
             "id": "0x3b6c3600b6350eb34da0eaf26204fbed8953a14e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -9775,6 +10031,7 @@
         {
             "id": "0x3b9648062c21e3ea44c522c575be15a0e635966b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -9830,6 +10087,7 @@
         {
             "id": "0x3c035c3f8e271e12df1bed648024e60249f507c3",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -9857,6 +10115,7 @@
         {
             "id": "0x3c0bf8e626d4c6371c3d32593653b69e0a2ae263",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -9884,6 +10143,7 @@
         {
             "id": "0x3c71fad2a1fc9ea1c5f7b87491daae7f1669d21a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -9911,6 +10171,7 @@
         {
             "id": "0x3cf393b95a4fbf9b2bdfc2011fd6675cf51d3e5d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9938,6 +10199,7 @@
         {
             "id": "0x3d27dcc521d0c2cfadbbdcb03ae38dde17bff772",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10007,6 +10269,7 @@
         {
             "id": "0x3d5519aa20d855cc13cbcf0084230d76310959fd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10034,6 +10297,7 @@
         {
             "id": "0x3d67f5fa074f39d946b29fe86bd2539709771e1c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -10061,6 +10325,7 @@
         {
             "id": "0x3d7173d89d50a5797614cb7e0324ad6370851909",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -10116,6 +10381,7 @@
         {
             "id": "0x3da908c4d1f5d240139b619f68a37329bc199110",
             "swapFee": "0.00618",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -10157,6 +10423,7 @@
         {
             "id": "0x3e148f928f03ef53004b4d6dd2c8375c84ad5cf9",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -10254,6 +10521,7 @@
         {
             "id": "0x3e413cbe7ea087706e57ad4e53994f36c173e521",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -10302,6 +10570,7 @@
         {
             "id": "0x3e47520b419165c53bb26dee8a6c02e60f9320b1",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -10329,6 +10598,7 @@
         {
             "id": "0x3e7356c713a9043d0efac4d9b4e2d993d2e62a79",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -10398,6 +10668,7 @@
         {
             "id": "0x3ebeaed4dad56dea4fe8a272d0fc79e129bdd53b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -10446,6 +10717,7 @@
         {
             "id": "0x3efa059a667b52d1583bd2d0828783b15d290fa6",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -10473,6 +10745,7 @@
         {
             "id": "0x3f4f22b2f3741d3d7adef18d3d9faeeb1fb86e56",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x23f62df9756786f993eb7a49af1afbba73c23d84",
@@ -10500,6 +10773,7 @@
         {
             "id": "0x3f69d8cc0be18a01972203bbe4d74f7d6148f40c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x02285acaafeb533e03a7306c55ec031297df9224",
@@ -10527,6 +10801,7 @@
         {
             "id": "0x4019ba88158daa468a063ac48171a3bfe8cd9f3b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -10554,6 +10829,7 @@
         {
             "id": "0x405906bf12452ec996757d9997144ee0042aafec",
             "swapFee": "0.075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -10581,6 +10857,7 @@
         {
             "id": "0x406472d6643627e4cfcd15e7018caa80abe37b64",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10608,6 +10885,7 @@
         {
             "id": "0x406ffef38af87a170babc5b9b853d2ecef3e596e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -10635,6 +10913,7 @@
         {
             "id": "0x408287a8469b234448f882fcea8ed52e469cf4ae",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -10662,6 +10941,7 @@
         {
             "id": "0x40c78299dd82fb8fa5473fcffff95203464757f9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -10689,6 +10969,7 @@
         {
             "id": "0x4118f3935231c517a71e154ab945249e5b9ed684",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -10716,6 +10997,7 @@
         {
             "id": "0x41262f83ccba8e7f902e86f34e762af6c7d2772e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa31b1767e09f842ecfd4bc471fe44f830e3891aa",
@@ -10743,6 +11025,7 @@
         {
             "id": "0x41284a88d970d3552a26fae680692ed40b34010c",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -10770,6 +11053,7 @@
         {
             "id": "0x413beaf25a73db58acd7b661dac0d4fbb1c1bbac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53352e7d6620cc931c0c9318166ae2a92c1a4666",
@@ -10797,6 +11081,7 @@
         {
             "id": "0x41523be0ab764a2aef588b2d49eb424b71bcb9b0",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10824,6 +11109,7 @@
         {
             "id": "0x415900c6e18b89531e3e24c902b05c031c71a925",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5dbcf33d8c2e976c6b560249878e6f1491bca25c",
@@ -10851,6 +11137,7 @@
         {
             "id": "0x417f2c87f72236eec4ebee1ef9240024595df4d7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x488e0369f9bc5c40c002ea7c1fe4fd01a198801c",
@@ -10878,6 +11165,7 @@
         {
             "id": "0x418d3dfca5099923cd57e0bf9ed1e9994f515152",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -10905,6 +11193,7 @@
         {
             "id": "0x421ea8ebd0b4709a71d741b0cbceba2dffd54978",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10946,6 +11235,7 @@
         {
             "id": "0x4246f1f495cdc07e309bd667666438c7ccd86220",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -10973,6 +11263,7 @@
         {
             "id": "0x42aebc0ad3e2a2c630d4097c16916d32a738e067",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11000,6 +11291,7 @@
         {
             "id": "0x42bec8082f3d5a9db6cddd781ea873957a3711bf",
             "swapFee": "0.0225",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11055,6 +11347,7 @@
         {
             "id": "0x4304ae5fd14cec2299caee4e9a4afbedd046d612",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -11082,6 +11375,7 @@
         {
             "id": "0x430bb168b724058024859422bcddcece3f1ef8ca",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8202346458f32ec51e96d7e214ce98fe749e182c",
@@ -11109,6 +11403,7 @@
         {
             "id": "0x432081ef9aa1b8503f8c7be37e4bb158a0543da9",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c19596f5aaff459fa38b0f7ed92f11ae6543784",
@@ -11143,6 +11438,7 @@
         {
             "id": "0x432947be1975a437180133a65f3937318dfc0a1a",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -11170,6 +11466,7 @@
         {
             "id": "0x433d0c33288b985cf232a7e312bcfafd372460a8",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11197,6 +11494,7 @@
         {
             "id": "0x434f06eca376067b4d6739ea09097929767480be",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11224,6 +11522,7 @@
         {
             "id": "0x4376410559078e813a6e52b4544608c1e20b15e6",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2baecdf43734f22fd5c152db08e3c27233f0c7d2",
@@ -11251,6 +11550,7 @@
         {
             "id": "0x4384590e20bd905b0b5a72cb760d68b183766109",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5458cad9efe6069df308d59cf204ddf16a5b4939",
@@ -11306,6 +11606,7 @@
         {
             "id": "0x43d335dc1749fd22cfdd26ba3540140b802fa7e0",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11333,6 +11634,7 @@
         {
             "id": "0x43fd7c3427a274fa96a76289dbb7bdd37ba8ec57",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11381,6 +11683,7 @@
         {
             "id": "0x44624f0cff9651773721a1396a175e6ef5f8c2b4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11436,6 +11739,7 @@
         {
             "id": "0x44b02fe8be307c7452a57b40c3ed54b364e26590",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -11463,6 +11767,7 @@
         {
             "id": "0x44b57179b2351e427b6cd9009d6db04702451139",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3eab7b78ca39ca1c9f371290308428b7975f8747",
@@ -11490,6 +11795,7 @@
         {
             "id": "0x452aadf9d02cfe3a22e0ba1faa991673e8fdb39c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x212dd60d4bf0da8372fe8116474602d429e5735f",
@@ -11545,6 +11851,7 @@
         {
             "id": "0x454c1d458f9082252750ba42d60fae0887868a3b",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -11572,6 +11879,7 @@
         {
             "id": "0x457c97d44d198349178715c60f3d5bdf05025fbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -11662,6 +11970,7 @@
         {
             "id": "0x461e474e594b211d41bb2ff855aa43e455d93888",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x59d4ccc94a9c4c3d3b4ba2aa343a9bdf95145dd1",
@@ -11689,6 +11998,7 @@
         {
             "id": "0x470c5541aaf245c8394fae7e904212f19a13a8a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e0989b1f9b8a38983c2ba8053269ca62ec9b195",
@@ -11716,6 +12026,7 @@
         {
             "id": "0x471eb7dcf6647abaf838a5aad94940ce6932198c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -11743,6 +12054,7 @@
         {
             "id": "0x47477cd00da54a3ee74e595e125a5dca76286648",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -11812,6 +12124,7 @@
         {
             "id": "0x476821016b300ed6ec0d30ef95d5a4409c50bb55",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -11846,6 +12159,7 @@
         {
             "id": "0x4777de3bcb5ca91d37c8cc2ee571d6460ad3b9c7",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f7f961648ae6db43c75663ac7e5414eb79b5704",
@@ -11929,6 +12243,7 @@
         {
             "id": "0x482475fd014d2c176a0bbcf78b70cc7ae4d8eea8",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -11956,6 +12271,7 @@
         {
             "id": "0x4833e8b56fc8e8a777fcc5e37cb6035c504c9478",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x793786e2dd4cc492ed366a94b88a3ff9ba5e7546",
@@ -12004,6 +12320,7 @@
         {
             "id": "0x483b4a2d55565f946df12824c9b33bfa85be95f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
@@ -12031,6 +12348,7 @@
         {
             "id": "0x4939e1557613b6e84b92bf4c5d2db4061bd1a7c7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12079,6 +12397,7 @@
         {
             "id": "0x4974b3c2c5ac0143fd4a70aed5a262ea075b833d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12106,6 +12425,7 @@
         {
             "id": "0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12133,6 +12453,7 @@
         {
             "id": "0x49ff149d649769033d43783e7456f626862cd160",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -12195,6 +12516,7 @@
         {
             "id": "0x4a22ec018f1f72ebba9620001b992ac86c40d1ad",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -12236,6 +12558,7 @@
         {
             "id": "0x4a77b41ec5708bfa5ca0dccead8a4145e31c85a0",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -12263,6 +12586,7 @@
         {
             "id": "0x4a85d283bcd7038cc43b6a8d8c50749dd4eb08e3",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69746c719e59674b147df25f50e7cfa0673cb625",
@@ -12290,6 +12614,7 @@
         {
             "id": "0x4b0b0bf60abbf79a2fd028e4d52ac393982488ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -12317,6 +12642,7 @@
         {
             "id": "0x4b2a6951cf2c9b1f391c219a977e4cd2f8987cba",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12344,6 +12670,7 @@
         {
             "id": "0x4b3fa856cef9aa85ed9bbfa8992d6138c5f150e6",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -12413,6 +12740,7 @@
         {
             "id": "0x4b51e86848fa2fb0f30375bf88d2e56249fb9479",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -12482,6 +12810,7 @@
         {
             "id": "0x4b6b06de9a52e8a3fb91df2d1615e17705371f86",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12509,6 +12838,7 @@
         {
             "id": "0x4bc3a95dcc417aa9856fb50c93d0f73aa477dfb6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12536,6 +12866,7 @@
         {
             "id": "0x4bcbc51fbabe5ed04b4cd93d361674fc3fb519b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b09a0371c1da44a8e24d36bf5deb1141a84d875",
@@ -12598,6 +12929,7 @@
         {
             "id": "0x4c321a9487128b84679d375acd967a6b8b8559fb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -12632,6 +12964,7 @@
         {
             "id": "0x4c34a687906092ec11cc04ddf30b71e29747ed76",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27702a26126e0b3702af63ee09ac4d1a084ef628",
@@ -12659,6 +12992,7 @@
         {
             "id": "0x4c709be5dfce030a7719af9ec8e472d57803e569",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12686,6 +13020,7 @@
         {
             "id": "0x4c9207e26c1036c41a4d080d69b9f61300ced7ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -12713,6 +13048,7 @@
         {
             "id": "0x4cc6b0c72f863aaa8b522ea989be33aaf621d415",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -12740,6 +13076,7 @@
         {
             "id": "0x4cc983986933b512b90c4448cb2f90bdfacb96de",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -12767,6 +13104,7 @@
         {
             "id": "0x4cfa6c06b29a5d3e802b99ea747bc52d79f30942",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d",
@@ -12794,6 +13132,7 @@
         {
             "id": "0x4d2e7d81d4da0fe8ac831344d54c027f3eea324c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -12821,6 +13160,7 @@
         {
             "id": "0x4d5bc7ea9f73503869c0997212e2a937d77796f1",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5eaefb33f7ed63656cf8fb1aea15fbe797c7900b",
@@ -12848,6 +13188,7 @@
         {
             "id": "0x4d6c17259332b3a1229bc4938894a7d295f90aeb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -12875,6 +13216,7 @@
         {
             "id": "0x4dd3274fd9baf289de0794a18ca5c174648318b4",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -12930,6 +13272,7 @@
         {
             "id": "0x4e21db79ff71cb4ea8f948dbb9a2ee8cf43e4c4f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc7e5f0ab8b2e10d2d0a3f21739fce62459aef3",
@@ -12957,6 +13300,7 @@
         {
             "id": "0x4e82d7ac3fe0b3550144f12e91a5a9819fe92a33",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -12984,6 +13328,7 @@
         {
             "id": "0x4e985fafb0d4cc9a9d34f160167763c4b78d6296",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -13011,6 +13356,7 @@
         {
             "id": "0x4ea237942e52c7095db7acf244e55decf3ad7371",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13073,6 +13419,7 @@
         {
             "id": "0x4ef3f7c240ffc48a149a27a0947bd09b5fa81ffd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13107,6 +13454,7 @@
         {
             "id": "0x4f0f422874e1525d88551d6a755116b9b7dcea7c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
@@ -13134,6 +13482,7 @@
         {
             "id": "0x4f2a40654a2d17992d299bcce9877de79df97a70",
             "swapFee": "0.0023",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13161,6 +13510,7 @@
         {
             "id": "0x4f9dde745bf54f207dfc1fe34896d6752c63ad07",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13216,6 +13566,7 @@
         {
             "id": "0x4fd974aee9c45a043d3e10efc3caa7de9ddfb0b3",
             "swapFee": "0.007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -13271,6 +13622,7 @@
         {
             "id": "0x504b37b251cc15f4852cede69206bca5ca66a635",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13298,6 +13650,7 @@
         {
             "id": "0x50a6af8d1b16e9fb18c912562239d65c0ff6724a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x21634b64a6915b879ad13d96418a82b2a48fcbe9",
@@ -13325,6 +13678,7 @@
         {
             "id": "0x50ca3590c65d8a50fb00de468615e5ce6219d5ff",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -13352,6 +13706,7 @@
         {
             "id": "0x50d3cac90d890ba0cc48c957bb9412b85794edb6",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -13379,6 +13734,7 @@
         {
             "id": "0x51478f6917a3e1928b53e3a584cc9684ad7878ab",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13406,6 +13762,7 @@
         {
             "id": "0x516bd93d659a8e3b6028022bb07e49b435a1e74a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -13461,6 +13818,7 @@
         {
             "id": "0x51a5d2c9e91df18af3cbbdc7715f0df609260815",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -13530,6 +13888,7 @@
         {
             "id": "0x51c562ba0a46f0066b28d6dbc0a62416bb855a2d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41b3f18c6384dc9a39c33afeca60d9b8e61eaa9f",
@@ -13557,6 +13916,7 @@
         {
             "id": "0x52086ef7800bb9779be98e6f5e635842486b4528",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -13584,6 +13944,7 @@
         {
             "id": "0x522c5c985736e01cc61a4a46b76088c364f8e3e3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8dbf4f5603a698d669596662aea790c0f5d867",
@@ -13618,6 +13979,7 @@
         {
             "id": "0x5277a42ef95eca7637ffa9e69b65a12a089fe12b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c972b70c533e2e045f333ee28b9ffb8d717be69",
@@ -13750,6 +14112,7 @@
         {
             "id": "0x5353e4294fcf069a5e8db9b8109d8f23dcd25f35",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13847,6 +14210,7 @@
         {
             "id": "0x537397a15ff68f949c600a34915744cffcdcc286",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -13881,6 +14245,7 @@
         {
             "id": "0x5385e9b6c3200d639171f257282ca139bbd5573e",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -13950,6 +14315,7 @@
         {
             "id": "0x5390f43ef8b8fe0b103e89f1ca74bfb985669f7b",
             "swapFee": "0.0375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fad7d44640c5cd0120deec0301e8cf850becb68",
@@ -13977,6 +14343,7 @@
         {
             "id": "0x53b0a526e67aec8f151297f8b6b20d0d8a7b9129",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -14004,6 +14371,7 @@
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14031,6 +14399,7 @@
         {
             "id": "0x53c455dc20195890063ec2a4772263f63d120048",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d967bb0134f2d07f7cfb6e246680c53927dd30",
@@ -14058,6 +14427,7 @@
         {
             "id": "0x53e6728366d8518e69867ee15fa990708c0d8cd6",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14085,6 +14455,7 @@
         {
             "id": "0x53f160490d7e48ba2c31be4790f3d87a2f4dc662",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -14140,6 +14511,7 @@
         {
             "id": "0x54a2d158c110ad1f1f2287558684e43c114420e7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -14167,6 +14539,7 @@
         {
             "id": "0x55353cbadda8fd525f0e6f307b3527d518416700",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -14215,6 +14588,7 @@
         {
             "id": "0x555dee5f67db53c66ca62442477624ebb0ebfbb9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14312,6 +14686,7 @@
         {
             "id": "0x55f06ed45606c78370edddcb85ef7141ad2033d1",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14381,6 +14756,7 @@
         {
             "id": "0x564f10f2e5deb8d475c20b418c5b6ed071855f2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -14527,6 +14903,7 @@
         {
             "id": "0x56bdd64b468f259689ea421e155ccb8f6facf799",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa8e7ad77c60ee6f30bac54e2e7c0617bd7b5a03e",
@@ -14582,6 +14959,7 @@
         {
             "id": "0x572bd1ba3571c8edb88106dbf4492d2d41f32dd8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14609,6 +14987,7 @@
         {
             "id": "0x5750a44a59f05badf3817296b2656ca0e9badaf3",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -14636,6 +15015,7 @@
         {
             "id": "0x576f2ce03f9dec176fc2a6cd5b2cfd9bda146a35",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x34612903db071e888a4dadcaa416d3ee263a87b9",
@@ -14691,6 +15071,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14718,6 +15099,7 @@
         {
             "id": "0x57bab7b6c4669f69c5792c282b4078e5706a5f71",
             "swapFee": "0.0399",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3505f494c3f0fed0b594e01fa41dd3967645ca39",
@@ -14745,6 +15127,7 @@
         {
             "id": "0x57c7bf29ecd4ffe50cbb93694f74c157b239ba8f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
@@ -14772,6 +15155,7 @@
         {
             "id": "0x57c9821179a4d94657161eeaad9dfdf5280f86db",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -14799,6 +15183,7 @@
         {
             "id": "0x57d365c82f5c1c659f3e76af324e5e34239e03ed",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -14826,6 +15211,7 @@
         {
             "id": "0x57f07147a30927eb1d9aa1c7f89ac3c806fd0525",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -14853,6 +15239,7 @@
         {
             "id": "0x57f1835f0bcfb4b3e913c6474b4ad02c33812196",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14880,6 +15267,7 @@
         {
             "id": "0x57f604e1be07f2db3e19b58ea00d0005156889d2",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8762db106b2c2a0bccb3a80d1ed41273552616e8",
@@ -14907,6 +15295,7 @@
         {
             "id": "0x5848da89e6a9a9154defa654c656c72bba4239ce",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x75231f58b43240c9718dd58b4967c5114342a86c",
@@ -14997,6 +15386,7 @@
         {
             "id": "0x58e808e472e5113860339bcd2b5266a47c04305f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14c4d8e57751e083bcd1edcca5b435720166f5e9",
@@ -15024,6 +15414,7 @@
         {
             "id": "0x58ef3abab72c6c365d4d0d8a70039752b9f32bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x81ab848898b5ffd3354dbbefb333d5d183eedcb5",
@@ -15051,6 +15442,7 @@
         {
             "id": "0x5905092a363d5de79a2e3cf4449854d7253254fe",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -15078,6 +15470,7 @@
         {
             "id": "0x590c656293452d3c37e586e595ee7849253f5f92",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9c78ee466d6cb57a4d01fd887d2b5dfb2d46288f",
@@ -15231,6 +15624,7 @@
         {
             "id": "0x59a19d8c652fa0284f44113d0ff9aba70bd46fb4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -15258,6 +15652,7 @@
         {
             "id": "0x59c0190823276c5ab9d8d41b291efd1defce168a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x41764099426529966df42c4010a3863cc87aeb07",
@@ -15285,6 +15680,7 @@
         {
             "id": "0x5a0d85166a20f9cd27be2cb293e4d10188f0c97d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -15312,6 +15708,7 @@
         {
             "id": "0x5a21e141ca90e46a2ee54f93b54a1bec608c307b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15353,6 +15750,7 @@
         {
             "id": "0x5a5d4a1fe3114ef5635ce740ff4a9c4d1ba8b463",
             "swapFee": "0.0045",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
@@ -15380,6 +15778,7 @@
         {
             "id": "0x5a82503652d05b21780f33178fdf53d31c29b916",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -15407,6 +15806,7 @@
         {
             "id": "0x5a8844290f44465c71878fef9827a475ab86ebcf",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -15434,6 +15834,7 @@
         {
             "id": "0x5a9d6f1d52f7b969974229fd8e15340d7314dcff",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94c6dc2bc44a0384a80d0e34f0afb030480f659c",
@@ -15489,6 +15890,7 @@
         {
             "id": "0x5aec4cff7fc3880ade1582e5e37cf89152e70ace",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15516,6 +15918,7 @@
         {
             "id": "0x5b18df96d3c8b9f1d1b9e38752498f92d1e2d490",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -15543,6 +15946,7 @@
         {
             "id": "0x5b2dc8c02728e8fb6aea03a622c3849875a48801",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
@@ -15640,6 +16044,7 @@
         {
             "id": "0x5b662ff89380c72bd4a8c9e24448313539786eda",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15667,6 +16072,7 @@
         {
             "id": "0x5b84174e567d141d9029a5e369c3dbc415bfecb0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -15694,6 +16100,7 @@
         {
             "id": "0x5bae310507a963c31771c412493d43c66757c97d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -15749,6 +16156,7 @@
         {
             "id": "0x5c07465b7062e1bc56e66cc8649d6e986d6e0979",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7afebbb46fdb47ed17b22ed075cde2447694fb9e",
@@ -15776,6 +16184,7 @@
         {
             "id": "0x5c0f17b1cfb6225628204e2b8e44239a9cc0ef9f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15838,6 +16247,7 @@
         {
             "id": "0x5c689f76e155bd69d148f2f66b5968f35cdce798",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77c6e4a580c0dce4e5c7a17d0bc077188a83a059",
@@ -15865,6 +16275,7 @@
         {
             "id": "0x5cac4d8f47baf46102400c003b0f01adf3d58315",
             "swapFee": "0.000123",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -15892,6 +16303,7 @@
         {
             "id": "0x5ccfa3b5f56efcc7ce03eba0352806b7e1766fb8",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -15919,6 +16331,7 @@
         {
             "id": "0x5cf95fa2d491599d954c106b7152137002dacc9f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15946,6 +16359,7 @@
         {
             "id": "0x5d1f2d1002bd0b3a23e0d7b4828c128a6ae4964d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b6d9eac7f64c1d98054cf1389ad43e44704d9ba",
@@ -15973,6 +16387,7 @@
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -16028,6 +16443,7 @@
         {
             "id": "0x5df340aee23aee3feedeead6890fa1aaa94c19ed",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -16097,6 +16513,7 @@
         {
             "id": "0x5e065d534d1daaf9e6222afa1d09e7dac6cbd0f7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90f802c7e8fb5d40b0de583e34c065a3bd2020d8",
@@ -16124,6 +16541,7 @@
         {
             "id": "0x5e37910cfb8de1b14ec4e4bac0bec27c35dc07d5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb",
@@ -16151,6 +16569,7 @@
         {
             "id": "0x5e7967eecd8828f5c50b5d1892da091fb797ecb6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16178,6 +16597,7 @@
         {
             "id": "0x5ed0f2d7602c9940a5063634942c66e5613c7582",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xab9c92a9337a1494c6d545e48187fa37144403c8",
@@ -16205,6 +16625,7 @@
         {
             "id": "0x5f67f02092921b5cbad775ab22df110827b7ad4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -16232,6 +16653,7 @@
         {
             "id": "0x5f6ef509e65676134bd73baf85e0cf2744d8e254",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -16259,6 +16681,7 @@
         {
             "id": "0x5f752aa9e748ffc007a15b7ca0fad8f2127f186c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -16398,6 +16821,7 @@
         {
             "id": "0x60626db611a9957c1ae4ac5b7ede69e24a3b76c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -16425,6 +16849,7 @@
         {
             "id": "0x60d7e353ff384c90be139399506fabc4fccfd15e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -16452,6 +16877,7 @@
         {
             "id": "0x61329a6e99d6d12aa762412fee0fc7bc39d50b5a",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -16479,6 +16905,7 @@
         {
             "id": "0x615339b4b8939f245510cec937756f895f8ec1fa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16506,6 +16933,7 @@
         {
             "id": "0x61bd6f3e39c0059d9b3d45f7099f71411794ef65",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -16547,6 +16975,7 @@
         {
             "id": "0x61e35bf99095a4844b3b2edac397e738c34b43c3",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -16574,6 +17003,7 @@
         {
             "id": "0x61f16a989eb552ff03d451807d0389466d415d94",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed1406873c9eb91f6f9a67ac4e152387c1132e7",
@@ -16601,6 +17031,7 @@
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -16628,6 +17059,7 @@
         {
             "id": "0x6250fd2b909981561292d9b807531d25a0c7cf4d",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -16655,6 +17087,7 @@
         {
             "id": "0x62713503753e179cde1066d9efc854088a4debf0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -16689,6 +17122,7 @@
         {
             "id": "0x62bc642e8fe96703589518c909eb8a48ab573fe7",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -16716,6 +17150,7 @@
         {
             "id": "0x6320bacd752eb602fecff80d75b8a3be57b7f282",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -16743,6 +17178,7 @@
         {
             "id": "0x6339f81d166b074c661f837df4560ca267ef05fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -16840,6 +17276,7 @@
         {
             "id": "0x63b642819845f3edacedd4cf614a4ac0a7950cb0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -16867,6 +17304,7 @@
         {
             "id": "0x641c5e9b5c6f5372959ace58efee4665670b4d0a",
             "swapFee": "0.0499",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -16894,6 +17332,7 @@
         {
             "id": "0x6439256186d2fa69a4fb2561c4648e541065c76f",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -16921,6 +17360,7 @@
         {
             "id": "0x64bd63cc9d697a58c307791b43a34a08c722491d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e",
@@ -16948,6 +17388,7 @@
         {
             "id": "0x64dd4573297dd5ce7199a5d31a5be185e8d8c80d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x617758ec94e90ef81431d6a209174fbc90fab870",
@@ -16975,6 +17416,7 @@
         {
             "id": "0x650191c1d862ed6ee0634431a8ef619a99137581",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -17002,6 +17444,7 @@
         {
             "id": "0x650c9f5b5fc57a106722be806c180e433b2f4424",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe75d3b39d017985caf20fac7134ed55b8b47cc26",
@@ -17029,6 +17472,7 @@
         {
             "id": "0x653911da49db4cdb0b7c3e4d929cfb56024cd4e6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -17056,6 +17500,7 @@
         {
             "id": "0x6545773483142fd781023ec74ee008d93ad5466b",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
@@ -17083,6 +17528,7 @@
         {
             "id": "0x654d9f45199d9195dd01a36e0810f6bd8bd75e5d",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -17110,6 +17556,7 @@
         {
             "id": "0x65a61353639eca7236d2fb12f6812c6eaf976fe3",
             "swapFee": "0.0024",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17151,6 +17598,7 @@
         {
             "id": "0x65bdb4b10b381378050a4c0bf910930e82421946",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -17178,6 +17626,7 @@
         {
             "id": "0x660d4b02ec91aca859239d3e1292c01fdfcb7ba2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -17205,6 +17654,7 @@
         {
             "id": "0x660f30293df5e2506b6a2e09ce64c1454eebd9a4",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -17267,6 +17717,7 @@
         {
             "id": "0x662f8d6783170ec4231e18a79fa7e255c5fb64e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -17294,6 +17745,7 @@
         {
             "id": "0x66535bf069a8b57273066c6f249b16e4e2ae5984",
             "swapFee": "0.0699",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -17321,6 +17773,7 @@
         {
             "id": "0x66840d5c7b99a0b133ea982915ad24e5ee78bd64",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17348,6 +17801,7 @@
         {
             "id": "0x66adc23726809d5a16d71184265bc4e286ece3b8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x654eebac62240e6c56bab5f6adf7cfa74a894510",
@@ -17375,6 +17829,7 @@
         {
             "id": "0x66f106d7f604cc6df77172166e74bb4705238657",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -17430,6 +17885,7 @@
         {
             "id": "0x68198e4ed6975204b3467dc217166d9ff1cbb57a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -17457,6 +17913,7 @@
         {
             "id": "0x68582481d5872d530669e3f08504fa8444a025ee",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -17484,6 +17941,7 @@
         {
             "id": "0x687a13a016f038ed9b40ad518766619f6f4de8f5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -17511,6 +17969,7 @@
         {
             "id": "0x6899ceba285070122f545005c196b248fec4c0d3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fd570033a745e85026795a261453f8630610271",
@@ -17538,6 +17997,7 @@
         {
             "id": "0x68a241796628ecf44e48f0533fb00d07dd3419d2",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -17628,6 +18088,7 @@
         {
             "id": "0x691aed5ccda49cb734c375aeb58c7b7e2fa4f6ed",
             "swapFee": "0.0888",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44",
@@ -17655,6 +18116,7 @@
         {
             "id": "0x6928f625e448cc4480378938d9e98439d7baf1b9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17682,6 +18144,7 @@
         {
             "id": "0x6a1544d5569d6b5e0c576444a4375b585688c4c4",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17709,6 +18172,7 @@
         {
             "id": "0x6a19aa086cb9d803b4d843f9997d6f263326c3ce",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -17736,6 +18200,7 @@
         {
             "id": "0x6ac89a0b82767b75d244904b1fb1e68091246cb3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17763,6 +18228,7 @@
         {
             "id": "0x6ad69f29454114a2b883cda1e4cdb34f9d4f0023",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -17790,6 +18256,7 @@
         {
             "id": "0x6afc9b1ed3a30c5236fbde1790dbde02a8c457a5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -17936,6 +18403,7 @@
         {
             "id": "0x6b9887422e2a4ae11577f59ea9c01a6c998752e2",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -17963,6 +18431,7 @@
         {
             "id": "0x6ba1c79fb5cf34c9fab3944bf15f15bd796223bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -17990,6 +18459,7 @@
         {
             "id": "0x6bd73b07d48626aa4915709c57087cb098546ae6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -18017,6 +18487,7 @@
         {
             "id": "0x6be6258fe363288b397882c071531b3623fd5fd9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x002f0b1a71c5730cf2f4da1970a889207bdb6d0d",
@@ -18044,6 +18515,7 @@
         {
             "id": "0x6c305fbb4bd2e3b8d130694beb16f1561443203d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -18078,6 +18550,7 @@
         {
             "id": "0x6c323c144a8d1748c6ca517b6c386561bfd599e3",
             "swapFee": "0.0455",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -18133,6 +18606,7 @@
         {
             "id": "0x6c9223ac56c6a808ff6b0c706e5c009c2dd2aea4",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -18202,6 +18676,7 @@
         {
             "id": "0x6ca8c49ddc74a070fa02daebd067dab8b7828d86",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -18229,6 +18704,7 @@
         {
             "id": "0x6cb5c5cb789fae62ce5ce280e1fbc5dd3bbdad81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
@@ -18256,6 +18732,7 @@
         {
             "id": "0x6cceb04f626fb4cfcf62669805b535e36e1c70ce",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18283,6 +18760,7 @@
         {
             "id": "0x6cd4eaae3b61a04002e5543382f2b4b1a364871d",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18310,6 +18788,7 @@
         {
             "id": "0x6cf9d531cd62428665195742438e06de990ebdcd",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x14073498cda09bfce04fdf269cb56828d67861e2",
@@ -18337,6 +18816,7 @@
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -18364,6 +18844,7 @@
         {
             "id": "0x6d42692518c8b09c883e7c1e69c97518107f2185",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18454,6 +18935,7 @@
         {
             "id": "0x6d60867e7da9c4caa8f905fc8ca915e826d57557",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -18481,6 +18963,7 @@
         {
             "id": "0x6d74eb17986ffd8cce421a965e696f1128958170",
             "swapFee": "0.06",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78a685e0762096ed0f98107212e98f8c35a9d1d8",
@@ -18508,6 +18991,7 @@
         {
             "id": "0x6da34875d905bc4ef0880bdd04bc5c57137a4931",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49706a576bb823cde3180c930f9947d59e2ded4d",
@@ -18535,6 +19019,7 @@
         {
             "id": "0x6dc407583173f2622ff3d9372739e0a1d6eb489e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92cca15553f244196970eefcd45e13d459418539",
@@ -18562,6 +19047,7 @@
         {
             "id": "0x6e352003c12f491f56c11459cd20596d3866b321",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -18610,6 +19096,7 @@
         {
             "id": "0x6f1c8742ba79d9bc1dfcb01fefdd54c38f99f9ca",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18651,6 +19138,7 @@
         {
             "id": "0x6f831f26444100e592afb5d0d9b723c3e475df73",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -18678,6 +19166,7 @@
         {
             "id": "0x6f8ac853e442e94d8b3f8b0b781ca8409ae4e38c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -18705,6 +19194,7 @@
         {
             "id": "0x6fc73b0ac200924f94677e1994453ab1a37ab93b",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -18739,6 +19229,7 @@
         {
             "id": "0x6fe4ffec00c96274ed2381c9861bc0cc82f21435",
             "swapFee": "0.0299",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
@@ -18766,6 +19257,7 @@
         {
             "id": "0x70633cdd5261ff89263277bd24772f5fd0d1a9ca",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -18835,6 +19327,7 @@
         {
             "id": "0x70d684ac589e797a01fe4aace76a2bdfe2909d67",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -18862,6 +19355,7 @@
         {
             "id": "0x70de15ccae66882dfa8e35a0ad2fc22c4dea1dc7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -18896,6 +19390,7 @@
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -18923,6 +19418,7 @@
         {
             "id": "0x70f6eb3dcf017b4765a53679b70dafbaff6098b3",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3166c570935a7d8554c8f4ea792ff965d2efe1f2",
@@ -18950,6 +19446,7 @@
         {
             "id": "0x726496deb01afbbe23e314841818ccf0aaddae0c",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -19005,6 +19502,7 @@
         {
             "id": "0x729133418c49b315ee6cae15e61d0a6a408fea53",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x244f054c35b64d2545c5f468d79db42526256681",
@@ -19060,6 +19558,7 @@
         {
             "id": "0x72a8f00913226b49e63cb7f27bc31ee5cfd09646",
             "swapFee": "0.018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -19129,6 +19628,7 @@
         {
             "id": "0x72b1ab41e82c75008dd752af1783a60b962037ae",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19156,6 +19656,7 @@
         {
             "id": "0x72bc698d85481198ea10b1bee141b8dca910e0d1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4282aa3a84de99c9d6fea1ddfc2ea6cc2e685875",
@@ -19183,6 +19684,7 @@
         {
             "id": "0x72cd8f4504941bf8c5a21d1fd83a96499fd71d2c",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19210,6 +19712,7 @@
         {
             "id": "0x730469dfce617e4f185885f3a97ae98416c2d161",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -19265,6 +19768,7 @@
         {
             "id": "0x73476c0fa25017b1b7390a56f401d7f32eec3310",
             "swapFee": "0.0028777",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -19334,6 +19838,7 @@
         {
             "id": "0x7398a9d32aa24f5d65cf045d8f9e1334f45b60e4",
             "swapFee": "0.0028",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -19361,6 +19866,7 @@
         {
             "id": "0x73a775b6e3c9b3ae2a4b06db369c9d4ff79b8c40",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -19430,6 +19936,7 @@
         {
             "id": "0x73eba399fbbea50852359ff8b8d0e3eba1f22500",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa117000000f279d81a1d3cc75430faa017fa5a2e",
@@ -19457,6 +19964,7 @@
         {
             "id": "0x742569fd5266486fd2a50171dbdc88b8ee893ee9",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -19484,6 +19992,7 @@
         {
             "id": "0x7439016d882ded793b2d108f3a1f51ac23cff834",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19511,6 +20020,7 @@
         {
             "id": "0x74512c70c1411d9ad193d495dd48ca97e92b8534",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x949265f0fd98e9a7dc4b259503bbe51c3f6de6fe",
@@ -19538,6 +20048,7 @@
         {
             "id": "0x7470452303ce12947659818e1d44942899e37032",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -19565,6 +20076,7 @@
         {
             "id": "0x74a5d106b18c86dc37be5c817093a873cdcff216",
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -19592,6 +20104,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -19626,6 +20139,7 @@
         {
             "id": "0x753f64a1447228bb800336569d98e11e94b0d0d2",
             "swapFee": "0.09",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -19660,6 +20174,7 @@
         {
             "id": "0x75a6a230865e4fc7c278ea924e053d52f42408e9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19687,6 +20202,7 @@
         {
             "id": "0x75e3198907f7346ca1662694b22ab26ec6232690",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19714,6 +20230,7 @@
         {
             "id": "0x75e751509ef6aa0325452a8c039003565b630f89",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -19769,6 +20286,7 @@
         {
             "id": "0x767174538ce622c6ca19a8c7b10911469d1f43ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -19796,6 +20314,7 @@
         {
             "id": "0x76730720bc5ef699e8e6f691065948be2fb3632e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19823,6 +20342,7 @@
         {
             "id": "0x768b54469a1bcf43bb226fc4dfe4678c4700dec5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -19850,6 +20370,7 @@
         {
             "id": "0x76958fa640ca66e8f4337a0d874b2d8a6c408f95",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158e55b4b14c4f49da5599ed3b26c0c8773095b2",
@@ -19884,6 +20405,7 @@
         {
             "id": "0x7699aa381d4df02213ac1421b7b8cfbaaf8290eb",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5e8b19aca3ac1690fe6a646d74567219f90e7fa3",
@@ -19911,6 +20433,7 @@
         {
             "id": "0x77a76bc4ee798b541e9f1495ceef4d3ada9dee73",
             "swapFee": "0.0675",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3435001a9d5dce254036d1159aa7dbbc3d6a2c22",
@@ -19938,6 +20461,7 @@
         {
             "id": "0x77e8560bc23fdf3c7a93c6f8e6c295d6088a9889",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -19965,6 +20489,7 @@
         {
             "id": "0x77f5f3dfd95d0b061c9ef47c4f4ca4681d807776",
             "swapFee": "0.0019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -19992,6 +20517,7 @@
         {
             "id": "0x7842792a8471d0f5ae645f513cc5999b1bb6b182",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -20026,6 +20552,7 @@
         {
             "id": "0x7860e28ebfb8ae052bfe279c07ac5d94c9cd2937",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20053,6 +20580,7 @@
         {
             "id": "0x789f2a5ebbade9b7b5bbc2fa1bd1ebd489d69c3c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ba6dcc667d3ff64c1a2123ce72ff5f0199e5315",
@@ -20108,6 +20636,7 @@
         {
             "id": "0x78c281090399ebc2d720595654b908ed31cd8bcb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70e8de73ce538da2beed35d14187f6959a8eca96",
@@ -20135,6 +20664,7 @@
         {
             "id": "0x78cea5ef876187e44ace4d8c3bbeb4bd45e91355",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -20218,6 +20748,7 @@
         {
             "id": "0x7941def033b4039fd2957c86d425fc75c0775dea",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -20252,6 +20783,7 @@
         {
             "id": "0x795dfdfd413c4a9492cef5b58723f9fb3c8af624",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -20307,6 +20839,7 @@
         {
             "id": "0x7965bf79dfe19ccc2d445cbc0800912ec1401816",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -20334,6 +20867,7 @@
         {
             "id": "0x79c44cd4291a72aa26a2f04a3559daf67e3ff761",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20361,6 +20895,7 @@
         {
             "id": "0x79f57815d3a68d03d963a88a456013c23942cb2a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -20388,6 +20923,7 @@
         {
             "id": "0x7a5185014d685dde6ec605fd56965969e272205f",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -20422,6 +20958,7 @@
         {
             "id": "0x7aa7305838d858f7089f86fc136d0816baacb0d8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x208d174775dc39fe18b1b374972f77ddec6c0f73",
@@ -20449,6 +20986,7 @@
         {
             "id": "0x7ac8b26032df15028d1aa2029f6854777e464441",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28441ed6ebaad179a2c10a0a5d46bf3f3ace17de",
@@ -20476,6 +21014,7 @@
         {
             "id": "0x7ae275fafdbcded0a4cdc6e25884b849f00efc48",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0202be363b8a4820f3f4de7faf5224ff05943ab1",
@@ -20503,6 +21042,7 @@
         {
             "id": "0x7afe74ae3c19f070c109a38c286684256adc656c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20558,6 +21098,7 @@
         {
             "id": "0x7bee47379c01a8a2f73c6506d980ac628388ee00",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20585,6 +21126,7 @@
         {
             "id": "0x7bfd1ddb7307d52afdf095537bb183c358007d53",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -20612,6 +21154,7 @@
         {
             "id": "0x7c1460e627d64febe9294c9b6aabd5bb801d7ab6",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -20660,6 +21203,7 @@
         {
             "id": "0x7c5fc4339dc4291052149c30f3118b7f32c3ba39",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20687,6 +21231,7 @@
         {
             "id": "0x7c63735de8de092cab2d2e1092af64b5ecf600fd",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x368b3a58b5f49392e5c9e4c998cb0bb966752e51",
@@ -20714,6 +21259,7 @@
         {
             "id": "0x7c90a3cd7ec80dd2f633ed562480abbeed3be546",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -20741,6 +21287,7 @@
         {
             "id": "0x7c9ba7c47314c9129e66403d93012445ec5f4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def16f9b486faed0293eb623dc8395dfe46a",
@@ -20768,6 +21315,7 @@
         {
             "id": "0x7cd40497c8284df1018673e6b29c3d97ef811685",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -20795,6 +21343,7 @@
         {
             "id": "0x7d014a7464c91f20da99a3e6f77bc5506ddf3c5e",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0a913bead80f321e7ac35285ee10d9d922659cb7",
@@ -20822,6 +21371,7 @@
         {
             "id": "0x7d2f4bcb767eb190aed0f10713fe4d9c07079ee8",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -20849,6 +21399,7 @@
         {
             "id": "0x7da51d06c07f37498c6d98345eb0f7a55980673a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
@@ -20876,6 +21427,7 @@
         {
             "id": "0x7dfe2931d2677a3ae9eb92642ac538dee90146f4",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0abdace70d3790235af448c88547603b945604ea",
@@ -20945,6 +21497,7 @@
         {
             "id": "0x7dfeef1b3acff3e2fdfa14b21de82601d96cf3a8",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20972,6 +21525,7 @@
         {
             "id": "0x7e2105a44c1e316a87591c99bb8d65f9ecd64791",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -20999,6 +21553,7 @@
         {
             "id": "0x7e7fec34fb6c0585dc6e2a9b06e7dcb6e60b033e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21026,6 +21581,7 @@
         {
             "id": "0x7ef02eec9dab2410eaf638afac04bad4703076c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -21060,6 +21616,7 @@
         {
             "id": "0x7ef2c76430b2e450ba0b7c56b7fd5ca32530753e",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21087,6 +21644,7 @@
         {
             "id": "0x7f0059b7eac988be65e0391b4d49a09bee232788",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -21114,6 +21672,7 @@
         {
             "id": "0x7f032763009b53c7dbbc72697724ca83c1c239b1",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -21141,6 +21700,7 @@
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21210,6 +21770,7 @@
         {
             "id": "0x7f8616a9f6916376f2ef066e79ddd93bea6b475b",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21237,6 +21798,7 @@
         {
             "id": "0x7f8ec02007ea664b3cac5694f8f57ad020a921db",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -21278,6 +21840,7 @@
         {
             "id": "0x7fc95945eaa14e7a2954052a4c9bfbaa79d170ae",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21305,6 +21868,7 @@
         {
             "id": "0x7ff9b3d39ba655128985266b9037428396cd1065",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -21374,6 +21938,7 @@
         {
             "id": "0x80027377c7133c91cb461a46c8d12386c290fc36",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -21436,6 +22001,7 @@
         {
             "id": "0x8026c3b9ecf3369f617a068862677b22a13ebe14",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2298e3b3390e3b945a5456fbf59ecc3f55da16",
@@ -21463,6 +22029,7 @@
         {
             "id": "0x80cba5ba9259c08851d94d6bf45e248541fb3e86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21532,6 +22099,7 @@
         {
             "id": "0x814c01ecb99b090cae15adfe662d949b3244c51c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21559,6 +22127,7 @@
         {
             "id": "0x815f8ef4863451f4faf34fbc860034812e7377d9",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -21586,6 +22155,7 @@
         {
             "id": "0x8194efab90a290b987616f687bc380b041a2cc25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -21613,6 +22183,7 @@
         {
             "id": "0x81d258af4f640021a73cea2a45849d4dfb3222ec",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26b3038a7fc10b36c426846a9086ef87328da702",
@@ -21640,6 +22211,7 @@
         {
             "id": "0x82342f983c177b00a746d8a383eca1de996f6775",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -21667,6 +22239,7 @@
         {
             "id": "0x82374bf03dbfe35845cb5b90b6c9a660a49f69aa",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf58006b2400ebec3eb8c05b73170138a340563",
@@ -21694,6 +22267,7 @@
         {
             "id": "0x824063cf83aab15ef7bff055547d454d2cb4b8cd",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b4f7cb9e60362a49dd04eb0091a374d340e3efd",
@@ -21721,6 +22295,7 @@
         {
             "id": "0x824b4dea11656d5bec9d0184e331ab724bcf6fbb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -21755,6 +22330,7 @@
         {
             "id": "0x826f313076afae1b86ad211ef79d0616451a9045",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -21845,6 +22421,7 @@
         {
             "id": "0x82991e0d4671275600359d06c6c81d71161d8b34",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -21872,6 +22449,7 @@
         {
             "id": "0x82d838ccfb252c501a970a00827653acfc17f846",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x66fd97a78d8854fec445cd1c80a07896b0b4851f",
@@ -21899,6 +22477,7 @@
         {
             "id": "0x8302efa4e838fd15cf09a39f4ca5bff2a3a78443",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -21933,6 +22512,7 @@
         {
             "id": "0x8309dc6b6bdaafd693d58f8b969d97fffef244a5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -21967,6 +22547,7 @@
         {
             "id": "0x83218d02abb6acdfd4c972e9c8b13754bc2e23d0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -22008,6 +22589,7 @@
         {
             "id": "0x833e88ddab6cabda936dcb58a2ed351b006adf7a",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -22063,6 +22645,7 @@
         {
             "id": "0x834fb8276b4e8a24010e2108fdd7f8417c8922bd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -22090,6 +22673,7 @@
         {
             "id": "0x8372b43a3d2d39d00d8f66d7f98e51e6d0d7da25",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ee0f7bb50a54ab5253da0667b0dc2ee526c30a8",
@@ -22117,6 +22701,7 @@
         {
             "id": "0x838d504010d83a343db2462256180ca311d29d90",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -22186,6 +22771,7 @@
         {
             "id": "0x8434019a3ac641d10f93f20efdf5a56456adf8af",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e9bc21c9b189c09df3ef1b824798658d5011937",
@@ -22213,6 +22799,7 @@
         {
             "id": "0x84e393cdffd89250f136598036eef066eed8f8da",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -22254,6 +22841,7 @@
         {
             "id": "0x854123b3c1ea19242d3a1a3510703f8f01635372",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22309,6 +22897,7 @@
         {
             "id": "0x855bc78f3dfa40a6642cf3a0ecb0570a1fcd7025",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22336,6 +22925,7 @@
         {
             "id": "0x85c06b1b3498266578aacb57b1fc9884742d725d",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22363,6 +22953,7 @@
         {
             "id": "0x868e68549418e9dcf92f2bf8611a2578f0f1fe88",
             "swapFee": "0.08",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2",
@@ -22397,6 +22988,7 @@
         {
             "id": "0x86ab9b94a4b4657c9ec32edb8596a1a26924c1ba",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -22424,6 +23016,7 @@
         {
             "id": "0x877d2a28ba931964b3479c23191c72a63993c2e7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -22451,6 +23044,7 @@
         {
             "id": "0x879d459f84431880f446d5ab7e7867d53706ae06",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -22478,6 +23072,7 @@
         {
             "id": "0x87d0f666f9aeea538e3c5d40928e58675f992707",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5016c464595870fa23a839aa6b78f48433178f53",
@@ -22505,6 +23100,7 @@
         {
             "id": "0x88daa4e6c2525b126c977c7d0da86710d93ed1b2",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -22532,6 +23128,7 @@
         {
             "id": "0x891e306044d19de453ac8c0774c83994e22c0b70",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30bcd71b8d21fe830e493b30e90befba29de9114",
@@ -22573,6 +23170,7 @@
         {
             "id": "0x8982e9bbf7ac6a49c434ad81d2ff8e16895318e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1695936d6a953df699c38ca21c2140d497c08bd9",
@@ -22600,6 +23198,7 @@
         {
             "id": "0x89ada24f8eb0f50485b686103ae8955e6c315fc6",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -22627,6 +23226,7 @@
         {
             "id": "0x89c6562933d4b3bd7083e7b7589331d5a3f78d17",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a9fff453d50d4ac52a6890647b823379ba36b9e",
@@ -22654,6 +23254,7 @@
         {
             "id": "0x89cb414cc57092b99efa1b55fac8bde8bbae5691",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
@@ -22730,6 +23331,7 @@
         {
             "id": "0x89f95c20368b96f878c4124eba063a9e5ed8b791",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22757,6 +23359,7 @@
         {
             "id": "0x8a649274e4d777ffc6851f13d23a86bbfa2f2fbf",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22784,6 +23387,7 @@
         {
             "id": "0x8b2e66c3b277b2086a976d053f1762119a92d280",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x790ace920baf3af2b773d4556a69490e077f6b4a",
@@ -22811,6 +23415,7 @@
         {
             "id": "0x8b6e6e7b5b3801fed2cafd4b22b8a16c2f2db21a",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -22838,6 +23443,7 @@
         {
             "id": "0x8b7333eb8c072523441f5eba8bf7680c0d931ddd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -22865,6 +23471,7 @@
         {
             "id": "0x8b91c432d947ebc8dbac7ea80329bb1cf27c0853",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -22913,6 +23520,7 @@
         {
             "id": "0x8bdbef67b4c9e9970fdb87d335926c0b3d3c0585",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -22947,6 +23555,7 @@
         {
             "id": "0x8bf495304697e420b3b766ca4d2fb6c9051f3b04",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22974,6 +23583,7 @@
         {
             "id": "0x8c551a2f7c12c695894ea1876125da363f13c6c1",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -23001,6 +23611,7 @@
         {
             "id": "0x8c68a087130cc7dbf0a48e6ba13b9618d40f06d6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23028,6 +23639,7 @@
         {
             "id": "0x8c7769f9f1e5042c0809b8702e4b9947b1bcb3f3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23055,6 +23667,7 @@
         {
             "id": "0x8c7fed3d60a63abcebf6808835f6c6552af930a5",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -23082,6 +23695,7 @@
         {
             "id": "0x8ca1b17c69fe04bf31036219d75ad1bab29f88f3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23109,6 +23723,7 @@
         {
             "id": "0x8d5c91324da4c4ef46b623ae62bf5586de0f4507",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -23150,6 +23765,7 @@
         {
             "id": "0x8d7d90a9554ca05c1668ded1a554d1b1d7b34480",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -23177,6 +23793,7 @@
         {
             "id": "0x8d924a1287dfa27ff5f7111b31d7392674a3e928",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -23204,6 +23821,7 @@
         {
             "id": "0x8e066d77080a9903785854e502e2aa9b6b9d099b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x90de74265a416e1393a450752175aed98fe11517",
@@ -23343,6 +23961,7 @@
         {
             "id": "0x8ea198b47a3abd30a10c0df4ccd7036cf96cc4e2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -23384,6 +24003,7 @@
         {
             "id": "0x8ee78e0f644643f943c621341009b0d9e6b173d2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23411,6 +24031,7 @@
         {
             "id": "0x8f2df546a20ba45218b1961ef8f6b6e48daffc05",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b260cf977df1ff8d87960064daee2ce491a1b91",
@@ -23445,6 +24066,7 @@
         {
             "id": "0x8f7867f87b1bc1adb4074136e81b9cf36a465307",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -23500,6 +24122,7 @@
         {
             "id": "0x8fc0324d7a62a47c69e7c186c3a761d2f835aadc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -23527,6 +24150,7 @@
         {
             "id": "0x8fc158523ca4817459e3f84e4f63d80ef057c4b2",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b02059c47c333a81c234a74550ebbc017fae86c",
@@ -23554,6 +24178,7 @@
         {
             "id": "0x9011f62a83c8a43a55e52b555fd3bd93313f4372",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -23602,6 +24227,7 @@
         {
             "id": "0x902d58a84af3ac8d9d384393be6c21449a6fd40b",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -23643,6 +24269,7 @@
         {
             "id": "0x905373b191a418b214b64b324de2b8c3d60bc935",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23670,6 +24297,7 @@
         {
             "id": "0x905c619c121349ca900b274da39ee64ec43b4b4f",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23697,6 +24325,7 @@
         {
             "id": "0x910fa45d3d2e87a71ce73140839cd270b56060cc",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -23766,6 +24395,7 @@
         {
             "id": "0x917fbcdc6e7077c55c9ea1cf9442809dd55fcb91",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x056fd409e1d7a124bd7017459dfea2f387b6d5cd",
@@ -23800,6 +24430,7 @@
         {
             "id": "0x91800a5356b4d2459ac6720a809e61c4f7c0dc8f",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x92e187a03b6cd19cb6af293ba17f2745fd2357d5",
@@ -23827,6 +24458,7 @@
         {
             "id": "0x918b5d94ec11f889ef5a1fe7df799ddfc3397776",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -23861,6 +24493,7 @@
         {
             "id": "0x923c8a19f4c4f9399fb69b46064eaa8db3f562d1",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b2c40eb69bed45143797e64fc104832a8fc51b1",
@@ -23895,6 +24528,7 @@
         {
             "id": "0x92830c6cfabf00a8070a2cc0772cf058e050558b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
@@ -23922,6 +24556,7 @@
         {
             "id": "0x929fb98aa5d597802273fb08f5968c9832b62b7a",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55f044ce437085ca8a0b6eb2bea500c32c0812c1",
@@ -23949,6 +24584,7 @@
         {
             "id": "0x92c83fb9c27c4952947135dc75a130e067b30062",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -23976,6 +24612,7 @@
         {
             "id": "0x92d179ee51a027a254feee0c5d91cc1f7058200b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24003,6 +24640,7 @@
         {
             "id": "0x92e7eb99a38c8eb655b15467774c6d56fb810bc9",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -24030,6 +24668,7 @@
         {
             "id": "0x930ae255053e40f430a4fda533eae0de5b131924",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -24057,6 +24696,7 @@
         {
             "id": "0x939ff8e09f7006bcbada0c41d837a74f77597de1",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24112,6 +24752,7 @@
         {
             "id": "0x9403d141047422fbf43724fcb985b1e96196c84f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -24139,6 +24780,7 @@
         {
             "id": "0x9446625e3090d155fd7c74752edf4e87cf44de05",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -24194,6 +24836,7 @@
         {
             "id": "0x9457facebbe9a8730684f511bdcca760879411f2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -24256,6 +24899,7 @@
         {
             "id": "0x94bcc44db60fca1c6442fa6b0684d54c0a1ada4f",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24283,6 +24927,7 @@
         {
             "id": "0x94fecb4af622a1ab64d11cbb1f01850591cabdf8",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24310,6 +24955,7 @@
         {
             "id": "0x953500397dbd43bf64321c4f54cd7b3f862c1bd6",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -24351,6 +24997,7 @@
         {
             "id": "0x9561c32840c10721c2c99291a63e5732750b7609",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ae055097c6d159879521c384f1d2123d1f195e6",
@@ -24406,6 +25053,7 @@
         {
             "id": "0x9588dcdc8b4fe73f1312469818405f02465bcfbc",
             "swapFee": "0.013",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24433,6 +25081,7 @@
         {
             "id": "0x95c4b6c7cff608c0ca048df8b81a484aa377172b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24460,6 +25109,7 @@
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -24487,6 +25137,7 @@
         {
             "id": "0x9619af84e324c9da4deccd4167b7699878b3184c",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -24521,6 +25172,7 @@
         {
             "id": "0x96248f6305d04c4842df1abba3714036226bf3fb",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -24548,6 +25200,7 @@
         {
             "id": "0x96c41c30fd6749c798b0a6f3c1f11b7b86944e10",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -24582,6 +25235,7 @@
         {
             "id": "0x96d99093f22719dd06fb8db8e93779979a2acab3",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -24609,6 +25263,7 @@
         {
             "id": "0x973123a9d14ecf095fee71bd826492da1a6fb0aa",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24657,6 +25312,7 @@
         {
             "id": "0x973499bb0edc8906db35969adc59b4bb4f59fe64",
             "swapFee": "0.035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26ce25148832c04f3d7f26f32478a9fe55197166",
@@ -24684,6 +25340,7 @@
         {
             "id": "0x9762c600a39bda3359f50a1fb1f90945cead379d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -24711,6 +25368,7 @@
         {
             "id": "0x97cd8e51cd6c888567c6c620188b8fb264ee8e91",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -24738,6 +25396,7 @@
         {
             "id": "0x97f50f649db045b76edebe7a947d101d9b1c5129",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -24765,6 +25424,7 @@
         {
             "id": "0x980efbe727f74e6aadc47452a0bc7c4332de4a33",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x601d244d9fe9434e03ccf7d9cd8f4d4d4f8790a9",
@@ -24820,6 +25480,7 @@
         {
             "id": "0x9866772a9bdb4dc9d2c5a4753e8658b8b0ca1fc3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -24847,6 +25508,7 @@
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -24874,6 +25536,7 @@
         {
             "id": "0x98a48026355cffaacf1dade7928442aa856a5e63",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -24929,6 +25592,7 @@
         {
             "id": "0x98adeb6937ff0a356b0805b89dd7d09b4c221a0d",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -24956,6 +25620,7 @@
         {
             "id": "0x98eb6be84183d46e435f693ca0aee4138d77eafb",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -25004,6 +25669,7 @@
         {
             "id": "0x9936fb81a36303882c8cd696f3d61a4be9ba793b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -25052,6 +25718,7 @@
         {
             "id": "0x9965dfe46ef0edc1557e5d794f67dce62fad22b7",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5eb2247cd16166d86925dccfa5b3d083daa0e5c",
@@ -25079,6 +25746,7 @@
         {
             "id": "0x997c0fc9578a8194efdde2e0cd7aa6a69cfcd7c1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b38210ea11411557c13457d4da7dc6ea731b88a",
@@ -25106,6 +25774,7 @@
         {
             "id": "0x998a8d555f18cdb18bbd18aada2dbe191e19c061",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -25133,6 +25802,7 @@
         {
             "id": "0x99ba95cd5d8781ed8369da8699b0934644e502f3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25160,6 +25830,7 @@
         {
             "id": "0x99d9df67196190e9f12eac7414f02e62c5bf9eab",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x64f0d720ce8b97ba44cd002005d2dfa3186c0580",
@@ -25187,6 +25858,7 @@
         {
             "id": "0x99e582374015c1d2f3c0f98d0763b4b1145772b7",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25214,6 +25886,7 @@
         {
             "id": "0x9a16bddf0e89541d6abea035b706968465241e4f",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -25241,6 +25914,7 @@
         {
             "id": "0x9a2181cf0bc57fc0177517db21d457bdd1b2b32e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ed9e47679422c2f78568af8728ec3c3c8591146",
@@ -25268,6 +25942,7 @@
         {
             "id": "0x9a43e689dbe8f60ec12ba899d58b94a14d852e37",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0721211926c9b07a92d5e6d9043d0291b4b6364a",
@@ -25295,6 +25970,7 @@
         {
             "id": "0x9a7c477709195e1306bd8a154833bf1bdfdfed4a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4946fcea7c692606e8908002e55a582af44ac121",
@@ -25322,6 +25998,7 @@
         {
             "id": "0x9acc9e81e4d1bfeec7f9847b2085b87247e46b4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -25349,6 +26026,7 @@
         {
             "id": "0x9af74a84de5152db4e0e656a8d735b0a3460c227",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -25376,6 +26054,7 @@
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25410,6 +26089,7 @@
         {
             "id": "0x9b6d305147931afc298e08303d03fd16fb583431",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -25472,6 +26152,7 @@
         {
             "id": "0x9bd9523ec4affad7df1ce01a47abf75be180cbeb",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -25499,6 +26180,7 @@
         {
             "id": "0x9c1b855a9cd2d6232a6debd6f8b431c19a54c14e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb6ed7644c69416d67b522e20bc294a9a9b405b31",
@@ -25526,6 +26208,7 @@
         {
             "id": "0x9c32798313ec02029bf105c84ce7a0293ad05a2c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25665,6 +26348,7 @@
         {
             "id": "0x9cfea0a3a08ac6f16e4e1c875f145ac72f726ba2",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
@@ -25734,6 +26418,7 @@
         {
             "id": "0x9dcc2104f25d40db2f455b458fcbe538c6812bbc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -25761,6 +26446,7 @@
         {
             "id": "0x9dde0b1d39d0d2c6589cde1bfed3542d2a3c5b11",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25788,6 +26474,7 @@
         {
             "id": "0x9e04b421149043c04b33865d5ecd8f6c87f174b6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -25857,6 +26544,7 @@
         {
             "id": "0x9e4a4b53e19410ae519be74f92659e5b0ef9489b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -25884,6 +26572,7 @@
         {
             "id": "0x9e7cbc6e96993e7c5abb3ec4cb30aa8275618b2b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -25911,6 +26600,7 @@
         {
             "id": "0x9e844d9115a0af3c1fd31c0e82c682b85da8a8e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -25938,6 +26628,7 @@
         {
             "id": "0x9eb4fa8d451251bec8e2bd9b88646de2c8be9121",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -25972,6 +26663,7 @@
         {
             "id": "0x9ee3abca5692ce38f13956081f09a75ef7a1e255",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26013,6 +26705,7 @@
         {
             "id": "0x9ef88559171f6b335c5708c7f8d93f6c5b0f5510",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26040,6 +26733,7 @@
         {
             "id": "0x9f46bdb33a179556a7676f516f4e5adcaebb5fac",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27bb56cff127de5fb52e382371679195eac9d017",
@@ -26067,6 +26761,7 @@
         {
             "id": "0x9f90a60f38bacd9b27096e27b32fd8acb6b1a8f6",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69d9905b2e5f6f5433212b7f3c954433f23c1572",
@@ -26094,6 +26789,7 @@
         {
             "id": "0x9fa4eb27c2a859a76caa1da9fe4ae2e48c2307c3",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x15822a64c8cb27d7828c45e0aafc3e6c5decd172",
@@ -26121,6 +26817,7 @@
         {
             "id": "0xa00a01369fb2258c99875f440fef57a1dd6c26f6",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26148,6 +26845,7 @@
         {
             "id": "0xa018079c61888ead5e2f2b8af8968f601224c650",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
@@ -26175,6 +26873,7 @@
         {
             "id": "0xa0194f845cc78d1c03c6601ff18cd55594cbb380",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26202,6 +26901,7 @@
         {
             "id": "0xa034a16d28d60a5e3c838268959ebc076eed278c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -26271,6 +26971,7 @@
         {
             "id": "0xa054ba2c35382c0520c66d9c32f00de8bd7330e8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -26298,6 +26999,7 @@
         {
             "id": "0xa09806fd152b9a2467720d46540654c4d06e953a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x46bfa3bb807b5c3b3ce7f7e0e667397020b6dc15",
@@ -26325,6 +27027,7 @@
         {
             "id": "0xa13af6789237ea64de3022ef60a319ff4a098167",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbf4a2ddaa16148a9d0fa2093ffac450adb7cd4aa",
@@ -26359,6 +27062,7 @@
         {
             "id": "0xa169e0c6cea6990e3e89062262d03746d625a19e",
             "swapFee": "0.00005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -26386,6 +27090,7 @@
         {
             "id": "0xa1ec308f05bca8acc84eaf76bc9c92a52ac25415",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -26434,6 +27139,7 @@
         {
             "id": "0xa1eda8392ea716392449d934b0bdef62e8a0cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26468,6 +27174,7 @@
         {
             "id": "0xa23da5ae002c15928d4dcabfc4300d2a1c30209c",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -26495,6 +27202,7 @@
         {
             "id": "0xa286e27457f30bfeb534fc010a01fbf86c8a31ba",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26522,6 +27230,7 @@
         {
             "id": "0xa28979ee7ac9d688e798cc5450da307ca5f51908",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26549,6 +27258,7 @@
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26576,6 +27286,7 @@
         {
             "id": "0xa2c074f406cf674359f51e4efc257cbaff9ad714",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -26603,6 +27314,7 @@
         {
             "id": "0xa2c1db514151bed505f145e22046aa407ffb37c4",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -26630,6 +27342,7 @@
         {
             "id": "0xa2c483ef506bafdf722ceb0ddeadbc45f3a9a545",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x224e13df4b4dbf41820ec848b19bb6f015f8bf7b",
@@ -26657,6 +27370,7 @@
         {
             "id": "0xa2dfeac16d3101328aa6e9b54e85258e4397bd95",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26719,6 +27433,7 @@
         {
             "id": "0xa36c6f854ef17238a6bdef7eec3b5af371006c16",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26746,6 +27461,7 @@
         {
             "id": "0xa374d321771781fda20793bc7dca33aadd4c2ee4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -26780,6 +27496,7 @@
         {
             "id": "0xa3e69ebce417ee0508d6996340126ad60078fcdd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -26807,6 +27524,7 @@
         {
             "id": "0xa47aaa0dcc5e4bd7d861bc6078d3f942a3dc2534",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x150b0b96933b75ce27af8b92441f8fb683bf9739",
@@ -26834,6 +27552,7 @@
         {
             "id": "0xa4824dc4bc118a2611717063ada3628151d95a2e",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -26882,6 +27601,7 @@
         {
             "id": "0xa4c6f71372d716d54b307d3e6e137be9f8a8f7ee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26909,6 +27629,7 @@
         {
             "id": "0xa4cb6b82429b3ffbb4f1aaa315015016408d7624",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52a6ddd08efc86892ce3d9074c4b39a571115655",
@@ -26936,6 +27657,7 @@
         {
             "id": "0xa4d3a50c4acd5fce7da5973fea62387405bbba3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -26963,6 +27685,7 @@
         {
             "id": "0xa516b20aaa2ceaf619004fda6d7d31dcc98f342a",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -26997,6 +27720,7 @@
         {
             "id": "0xa51831e33a1ac245d327ff92def377e5e681c9cc",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -27094,6 +27818,7 @@
         {
             "id": "0xa55a0baaab6741d446986322751b8cc8484c6c81",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27121,6 +27846,7 @@
         {
             "id": "0xa5910940b97b7b8771a01b202583fd9331cb8be3",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -27183,6 +27909,7 @@
         {
             "id": "0xa5af158d9449da9ba12fd7a6cb6eba5e15ac1ab1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9d47894f8becb68b9cf3428d256311affe8b068b",
@@ -27210,6 +27937,7 @@
         {
             "id": "0xa5da8cc7167070b62fdcb332ef097a55a68d8824",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
@@ -27237,6 +27965,7 @@
         {
             "id": "0xa69e2d058d50394cc3b4f1a1aacb41e6809d4be9",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27264,6 +27993,7 @@
         {
             "id": "0xa6cf0a736fbb441b3cd39a476699eeec4737f28e",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -27291,6 +28021,7 @@
         {
             "id": "0xa73d442fc0783e91a5b0c1b557aeea344e0146b6",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -27318,6 +28049,7 @@
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -27345,6 +28077,7 @@
         {
             "id": "0xa751a143f8fe0a108800bfb915585e4255c2fe80",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -27379,6 +28112,7 @@
         {
             "id": "0xa795600590a7da0057469049ab8f1284baed977e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -27406,6 +28140,7 @@
         {
             "id": "0xa7971d5c7793dd1d0fc50957fb59b188bafad6ac",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -27475,6 +28210,7 @@
         {
             "id": "0xa7d7d09484fa6e5f497b6b687f979509373c6530",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -27502,6 +28238,7 @@
         {
             "id": "0xa81798fec662c1a131029b28546cc80ecd11cb61",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x119f22fa21d4ee54c9911e1bf876fcf24a0adfc1",
@@ -27599,6 +28336,7 @@
         {
             "id": "0xa881d926142be2133baee1b7f93c7925f8624a4a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -27626,6 +28364,7 @@
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -27653,6 +28392,7 @@
         {
             "id": "0xa8ec63bf15459600f983e43fffa82deb999a9f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9041fe5b3fdea0f5e4afdc17e75180738d877a01",
@@ -27680,6 +28420,7 @@
         {
             "id": "0xa97a516f59b14fac3420a2ffabf3891945af3a90",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27707,6 +28448,7 @@
         {
             "id": "0xa9d06f185f300c57fa54dc71678b225e4ce89407",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07ab6390bc4f105dd2ac24a7cb1dce9b3ec5c6af",
@@ -27734,6 +28476,7 @@
         {
             "id": "0xaa1a18b1fad3d27b3e56d3c8da8a27d8ec05a405",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4574562e9310a94f9ca962bd23168d8a06875b1a",
@@ -27789,6 +28532,7 @@
         {
             "id": "0xaa8b8ad143bc3d5e779253ed52a4c8fb7cee4133",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0508331c4883dc6a0ffc4e0b239a38a68787e21b",
@@ -27816,6 +28560,7 @@
         {
             "id": "0xaaa117d04aaf533701c9e40cd52113706d95d420",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -28004,6 +28749,7 @@
         {
             "id": "0xabe82d12eaad0a3fa0275d74a58cbaadc11c2f95",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0869faecb4fac0064973647f44a1f6cb22883056",
@@ -28031,6 +28777,7 @@
         {
             "id": "0xac48a86e60911546842e8af4349dedd623bf3083",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ff668ddfdcbb7505f41ed56e626e4d4719dcb26",
@@ -28058,6 +28805,7 @@
         {
             "id": "0xac4dc99050e46d04bf5cc48e36f3897a4ce0512a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
@@ -28085,6 +28833,7 @@
         {
             "id": "0xac5e692689d78269c4cdb07d654ebdb96c1fb30c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -28119,6 +28868,7 @@
         {
             "id": "0xac6bac9dc3de2c14b420e287de8ecb330d96e492",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -28146,6 +28896,7 @@
         {
             "id": "0xad369012c0fc9328a251e98930f17e339e49e21c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da7befc654c45ea53842c3fbb19d1c13f6263f8",
@@ -28222,6 +28973,7 @@
         {
             "id": "0xadd3b473aed491177d87139cc48ff4de22774966",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -28249,6 +29001,7 @@
         {
             "id": "0xaded062426863b6c60ac59217bc956447bd5deef",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -28290,6 +29043,7 @@
         {
             "id": "0xae1019cfc59dc21a2395c8b38a6f6d0df61d2c22",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8207c1ffc5b6804f6024322ccf34f29c3541ae26",
@@ -28317,6 +29071,7 @@
         {
             "id": "0xae952c77282e080cf07316649e3a0e4a975c076f",
             "swapFee": "0.0275",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26e75307fc0c021472feb8f727839531f112f317",
@@ -28358,6 +29113,7 @@
         {
             "id": "0xae95d3198d602acfb18f9188d733d710e14a27dd",
             "swapFee": "0.0087",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
@@ -28448,6 +29204,7 @@
         {
             "id": "0xaf6bf18b139841f26c830b0b56d6478d6e808dd1",
             "swapFee": "0.029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28475,6 +29232,7 @@
         {
             "id": "0xaf71d6c242a00e8364ea0ef3c007f3413e975011",
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -28502,6 +29260,7 @@
         {
             "id": "0xaf9220376e569cbf8b1cdd488dde61fc09a0f575",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28529,6 +29288,7 @@
         {
             "id": "0xafd541e91b5bf792ae36f7ea1213c878e6feb1d3",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -28556,6 +29316,7 @@
         {
             "id": "0xb10ee84a9afb7a7033998efaa6b15835e978068d",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x62529c43017ae1e4694a2d36ca5b37b04e3e7cad",
@@ -28583,6 +29344,7 @@
         {
             "id": "0xb135b31665bd67c4497f6eb3d5964e8897e5feb7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x348f9b40df1d4ec2082371bacb136fc727ccdd8c",
@@ -28610,6 +29372,7 @@
         {
             "id": "0xb189802d50c45515369bc5373d5ca71aa9b70d88",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3ebfa35034c07c22167a64b4c2f089d685951e7d",
@@ -28637,6 +29400,7 @@
         {
             "id": "0xb19f103499e1e397227a11150997bec8bb8b418b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28664,6 +29428,7 @@
         {
             "id": "0xb1b8c56f3bb4915b2c976a457504b80895953faf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb3317914d93a75bfb4d482442bc34b1809a9c9ab",
@@ -28691,6 +29456,7 @@
         {
             "id": "0xb1da44d07b8fe6e0169f0591e8cd9a384e914bca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x249a198d59b57fda5dda90630febc86fd8c7594c",
@@ -28718,6 +29484,7 @@
         {
             "id": "0xb1f7c9c188c1063187bae43f54767c24024d76dd",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44",
@@ -28745,6 +29512,7 @@
         {
             "id": "0xb1f9ec02480dd9e16053b010dfc6e6c4b72ecad5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -28772,6 +29540,7 @@
         {
             "id": "0xb21e53d8bd2c81629dd916eead08d338e7fcc201",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28799,6 +29568,7 @@
         {
             "id": "0xb25f188721c16e742b067dbbb355f01cf2d87c0e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2bf91c18cd4ae9c2f2858ef9fe518180f7b5096d",
@@ -28903,6 +29673,7 @@
         {
             "id": "0xb2ec68ad657ecfd9aa1f61ed8de02c3f5186d925",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
@@ -28958,6 +29729,7 @@
         {
             "id": "0xb38b0c480a451db976837a1a464af95bb0f3f5e2",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x85eee30c52b0b379b046fb0f85f4f3dc3009afec",
@@ -28985,6 +29757,7 @@
         {
             "id": "0xb40f31eb01d13ed5e05f5e349e74af38bbca0154",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -29012,6 +29785,7 @@
         {
             "id": "0xb4297eac15a4ac064f30103dcace12355f3c0b3a",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29039,6 +29813,7 @@
         {
             "id": "0xb43a8e259fde653c2b3c80bd035fcb302ef58fc3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27ffed7e5926fb2795fc85aaab558243f280a8a2",
@@ -29066,6 +29841,7 @@
         {
             "id": "0xb454f3f2b982e56b962392d93d01e5895b532995",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -29093,6 +29869,7 @@
         {
             "id": "0xb457bbbe9072a5801e5efd0a0e66b9f7d2627380",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x79c75e2e8720b39e258f41c37cc4f309e0b0ff80",
@@ -29148,6 +29925,7 @@
         {
             "id": "0xb464544111cef99643407da47f86e9b96cf2b003",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -29175,6 +29953,7 @@
         {
             "id": "0xb485fe9998285f23b86b3b99f41799c367894166",
             "swapFee": "0.095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -29202,6 +29981,7 @@
         {
             "id": "0xb4d31d005ad163943a222dff0f1f7b14ab500c6d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x960b236a07cf122663c4303350609a66a7b288c0",
@@ -29236,6 +30016,7 @@
         {
             "id": "0xb50961e3d6128fb746ffdc6054046d873194376d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -29291,6 +30072,7 @@
         {
             "id": "0xb537ae8eebe8a7bec9ee8720c936fd15c35940fe",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -29318,6 +30100,7 @@
         {
             "id": "0xb53acbbe6db0f80f9dab5b9dc9e95e2e2393f000",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -29345,6 +30128,7 @@
         {
             "id": "0xb5545d43d68c9e8546d7ffd62f9daf97962dd006",
             "swapFee": "0.0085",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -29414,6 +30198,7 @@
         {
             "id": "0xb58f19e17ef9d8cdd1d870164a026f4135bd0cbf",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29441,6 +30226,7 @@
         {
             "id": "0xb62357d2a05f6bc6e4f05078de9f5fc5c9c004cb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbff34e47e559ef680067a6b1c980639eeb64d24",
@@ -29468,6 +30254,7 @@
         {
             "id": "0xb624c7d3b7daddea8825fa39e764f35d02a1b1ca",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -29495,6 +30282,7 @@
         {
             "id": "0xb66fe9834576fc207a6f727aef6dd60af1d299b8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -29522,6 +30310,7 @@
         {
             "id": "0xb6ad5fd2698a68917e39216304d4845625da2f57",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -29549,6 +30338,7 @@
         {
             "id": "0xb6ccab4082be3aeff751d014000f3d70f73816e7",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68a118ef45063051eac49c7e647ce5ace48a68a5",
@@ -29576,6 +30366,7 @@
         {
             "id": "0xb6f8187f0ab2befc264faf37367583ad41cde07e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29603,6 +30394,7 @@
         {
             "id": "0xb6ffbc0f31fd15474c8ebe09193d3dfdeec16f23",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b377c64f0d30c86473b4f3df6075a1ff1d9357b",
@@ -29658,6 +30450,7 @@
         {
             "id": "0xb711ccdfb3609ea144930c9fb5e6a36219b478de",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -29685,6 +30478,7 @@
         {
             "id": "0xb72b8bb10a66473a53087fdf7c835fe0bed1f989",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29712,6 +30506,7 @@
         {
             "id": "0xb739ad71bb7a405534541fda5aa6027647d4621a",
             "swapFee": "0.015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -29746,6 +30541,7 @@
         {
             "id": "0xb78421bbf3ca0295c8b49e65306e56e71e6ecd15",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -29773,6 +30569,7 @@
         {
             "id": "0xb7c10d12eed70bc7b2341ff8ddaeed02237f5d3b",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -29807,6 +30604,7 @@
         {
             "id": "0xb82b6e4d84e7ef74f7c07e2d2c9971315d453929",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c7bbadc81e18f7177a95eb1593e5f5f35861b10",
@@ -29834,6 +30632,7 @@
         {
             "id": "0xb834c329673f752f0e79551ea78baff15adbbc0c",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4b7dfae2567181e54776337c840e142acb42aa1f",
@@ -29861,6 +30660,7 @@
         {
             "id": "0xb8812fb63de381da0190fc4a01e1f723dbd161c8",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -29888,6 +30688,7 @@
         {
             "id": "0xb88a923ed3d46747085ce2684ed7108352eba886",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x49e833337ece7afe375e44f4e3e8481029218e5c",
@@ -29971,6 +30772,7 @@
         {
             "id": "0xb93aa4cdeef1293303f628e16dd06ddd42db19f1",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29998,6 +30800,7 @@
         {
             "id": "0xb93f696e5c46b6772fc2ff65e459cf9685fac782",
             "swapFee": "0.0097",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30067,6 +30870,7 @@
         {
             "id": "0xb9eaf49d9f913bc1314e37bb5482891840c8e3c1",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1985365e9f78359a9b6ad760e32412f4a445e862",
@@ -30164,6 +30968,7 @@
         {
             "id": "0xba20d4f41121b997a1eaca6d938ac40b67dad226",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30191,6 +30996,7 @@
         {
             "id": "0xba46868f49182b521b71bf9894d24da7e969e286",
             "swapFee": "0.0049",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30218,6 +31024,7 @@
         {
             "id": "0xba95fa2b47de4c971209aec5874c8204a3721e98",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -30245,6 +31052,7 @@
         {
             "id": "0xbaa35c7a1f0bdf7ea92fd9ecaa72539c6f0c564c",
             "swapFee": "0.0119",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -30314,6 +31122,7 @@
         {
             "id": "0xbb1577b192b5f0250c2f3e3a4d7e0cff5e814755",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x468ab3b1f63a1c14b361bc367c3cc92277588da1",
@@ -30341,6 +31150,7 @@
         {
             "id": "0xbb18d181293940d2215117e7d3a9fecc12db480e",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x607f4c5bb672230e8672085532f7e901544a7375",
@@ -30396,6 +31206,7 @@
         {
             "id": "0xbbd31abb1e767c2771de21954728d75bc29333d8",
             "swapFee": "0.009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d65e8fb6e87b60feccbc582f7f97804b725521",
@@ -30423,6 +31234,7 @@
         {
             "id": "0xbbe878cdebe453ab9c640620637b215a8a2f7f13",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -30450,6 +31262,7 @@
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -30477,6 +31290,7 @@
         {
             "id": "0xbc3077e614061c9b88699f80e1946d2544e250ac",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -30518,6 +31332,7 @@
         {
             "id": "0xbc8b1f78ff5a0baf9945e145832ad79c494d4cf6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
@@ -30545,6 +31360,7 @@
         {
             "id": "0xbcf29450ac65dbd9e4066c30946b67488d6a9f37",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -30579,6 +31395,7 @@
         {
             "id": "0xbd7a8f648262b6cb29d38b575df9f27e6cdecde1",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
@@ -30606,6 +31423,7 @@
         {
             "id": "0xbe0e4e74897275f5e5a0a184b112b20860ad4fac",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -30633,6 +31451,7 @@
         {
             "id": "0xbe76e5689c255499412aa66dea160d5ee113842e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x177ba0cac51bfc7ea24bad39d81dcefd59d74faa",
@@ -30660,6 +31479,7 @@
         {
             "id": "0xbea563fbc62640a69de45f1cd275b1590bf2ac8a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7529b92ceac18d0050c0bb8caa6de8b825d1bf2c",
@@ -30687,6 +31507,7 @@
         {
             "id": "0xbebcc2e25f72d50f39cf5957600c3b7641db07bb",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -30721,6 +31542,7 @@
         {
             "id": "0xbed340a301b4f07fa7b61ab9e0767faa172f530d",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -30748,6 +31570,7 @@
         {
             "id": "0xbefb01de17ee3c22b7a798f56ad8cf5c43284c12",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -30775,6 +31598,7 @@
         {
             "id": "0xbf04a3cb05e0c23d5998f3e61e1a66213858583c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -30802,6 +31626,7 @@
         {
             "id": "0xbf315abfbdfa8304473f690bebf9d2127f4547db",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -30829,6 +31654,7 @@
         {
             "id": "0xbfdef139103033990082245c24ff4b23dafd88cf",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -30856,6 +31682,7 @@
         {
             "id": "0xbfee82ff0402b1a24f895ccc2545f6187369b4c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24",
@@ -30953,6 +31780,7 @@
         {
             "id": "0xc0bcfbbf29ccee3724df8efb85bf232ee5b4cc35",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0eb7ab7ed946f7deba76f34a8f79a809775bb471",
@@ -30980,6 +31808,7 @@
         {
             "id": "0xc0f0ab9767ec5117cc640127255fad744ddc55b0",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3e780920601d61cedb860fe9c4a90c9ea6a35e78",
@@ -31007,6 +31836,7 @@
         {
             "id": "0xc16bbbe540e6595967035f3a505477e26a38c0c5",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
@@ -31034,6 +31864,7 @@
         {
             "id": "0xc16ede1d32fbacf3b61efaa6d4f16d390fef64bd",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -31061,6 +31892,7 @@
         {
             "id": "0xc18a88999726d6c1daadc841e5cfcb320648301c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -31088,6 +31920,7 @@
         {
             "id": "0xc198a8765a55648bb39ef0179b88c5606a3d0b23",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -31115,6 +31948,7 @@
         {
             "id": "0xc19e3035a4f6f69b981c7dc2f533e862aa3af496",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -31142,6 +31976,7 @@
         {
             "id": "0xc1c70266ef3dc680e55c5a1c451f664446a9849d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -31183,6 +32018,7 @@
         {
             "id": "0xc1fd33ecdcea2c61e3cc808ae12319548dc05027",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x355c665e101b9da58704a8fddb5feef210ef20c0",
@@ -31210,6 +32046,7 @@
         {
             "id": "0xc2a04278ad502349e6aabb748a41abda9dfd18a9",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -31237,6 +32074,7 @@
         {
             "id": "0xc2aa12a61d747d9a7966ec6cec367bdf9e45f4a3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
@@ -31292,6 +32130,7 @@
         {
             "id": "0xc2fccdb698862ceb2d54e22f6d1eb50cbea51960",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -31319,6 +32158,7 @@
         {
             "id": "0xc30fd7f8585c12b8404c424bfc3a3758539452ed",
             "swapFee": "0.042",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -31346,6 +32186,7 @@
         {
             "id": "0xc351648240e9fc9213e8b6016e566f95c5fa7909",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -31373,6 +32214,7 @@
         {
             "id": "0xc39ec90bcd61ad6b490d20d02b3ffde063d3aec2",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7591a309df68bf43ba42dd11b0344220a260020a",
@@ -31400,6 +32242,7 @@
         {
             "id": "0xc3d9183500746d504a1978d80555026ac4719ee6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x697ef32b4a3f5a4c39de1cb7563f24ca7bfc5947",
@@ -31427,6 +32270,7 @@
         {
             "id": "0xc3dc8c499d646e89b83a70d0b35aeae8c2b3a978",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -31454,6 +32298,7 @@
         {
             "id": "0xc3eb65c18902357f0c3577ced27b1fa914cd0e57",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
@@ -31509,6 +32354,7 @@
         {
             "id": "0xc4031959c45597051f4ac7b166673b144f811034",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -31536,6 +32382,7 @@
         {
             "id": "0xc409d34accb279620b1acdc05e408e287d543d17",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31570,6 +32417,7 @@
         {
             "id": "0xc45a95642bc59df699364237b80057eadc8d8a14",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31632,6 +32480,7 @@
         {
             "id": "0xc48b8329d47ae8fd504c0b81cf8435486380e858",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -31659,6 +32508,7 @@
         {
             "id": "0xc4b2c51f405e4e8bc498385240f6fec11969d071",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdf5e0e81dff6faf3a7e52ba697820c5e32d806a8",
@@ -31686,6 +32536,7 @@
         {
             "id": "0xc52139a20a57c9002e9f5188901ef0ffc63c7205",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -31713,6 +32564,7 @@
         {
             "id": "0xc5821896d6d46da0a7049fbfdcef6643aa0fd71b",
             "swapFee": "0.0975",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x84c3b884a9ff37655dc918d70d99ea8ee9b3f0d3",
@@ -31740,6 +32592,7 @@
         {
             "id": "0xc59290d50e3ade07388809983560d00b1a57364b",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
@@ -31767,6 +32620,7 @@
         {
             "id": "0xc5dfd2921b48bf2f9c7ca684cfa904fb878d3338",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -31794,6 +32648,7 @@
         {
             "id": "0xc697051d1c6296c24ae3bcef39aca743861d9a81",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -31821,6 +32676,7 @@
         {
             "id": "0xc6c68cae4681d7b3b3deb54091d7e10d7ec7757d",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89e3ac6dd69c15e9223be7649025d6f68dab1d6a",
@@ -31848,6 +32704,7 @@
         {
             "id": "0xc6d587ab2cd555462f8feda36d6fb36c115052ed",
             "swapFee": "0.0075",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -31903,6 +32760,7 @@
         {
             "id": "0xc6da2f0c51c624173c013063c88f8070561a5baf",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -31930,6 +32788,7 @@
         {
             "id": "0xc6ecc714b8e50a34314244a8165a4aa0f7d16308",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x80fb784b7ed66730e8b1dbd9820afd29931aab03",
@@ -31957,6 +32816,7 @@
         {
             "id": "0xc7062d899dd24b10bfed5adaab21231a1e7708fe",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31984,6 +32844,7 @@
         {
             "id": "0xc72b359e77698dafabdcf7460d53e72a7cc861e6",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc3dd23a0a854b4f9ae80670f528094e9eb607ccb",
@@ -32011,6 +32872,7 @@
         {
             "id": "0xc75713777b8e47ad640f309b00aa2fd119891e0a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -32038,6 +32900,7 @@
         {
             "id": "0xc78f7d828844517803ca2a447889dfd983e85533",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -32072,6 +32935,7 @@
         {
             "id": "0xc7b51b2660c3340abb0caae77116a15b0bbdd6ec",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x346b31b2720faa1089e5a002ce5383bb7425511f",
@@ -32099,6 +32963,7 @@
         {
             "id": "0xc7b764ed433d51a2851d47db29dc484b0eccf5dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -32154,6 +33019,7 @@
         {
             "id": "0xc81d50c17754b379f1088574cf723be4fb00307d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -32181,6 +33047,7 @@
         {
             "id": "0xc840f401304cdd1ecae3067855ce527b7726376e",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
@@ -32208,6 +33075,7 @@
         {
             "id": "0xc855f1572c8128add6f0503084ba23930b7461f8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xcee1d3c3a02267e37e6b373060f79d5d7b9e1669",
@@ -32235,6 +33103,7 @@
         {
             "id": "0xc85d251711fec21333548b660f5c73a4e484aec1",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32262,6 +33131,7 @@
         {
             "id": "0xc894be8c8444add74517e924c3b44c7884c27476",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -32289,6 +33159,7 @@
         {
             "id": "0xc931fea2b59aaf97a72b68afcf637f41601bbe6f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -32316,6 +33187,7 @@
         {
             "id": "0xc9630cbf7e1559ca84d060e158f3890e431d8f1b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -32343,6 +33215,7 @@
         {
             "id": "0xc99d7688a4e0e9ba6a3491e7d175c9abcd914f93",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3a3a65aab0dd2a17e3f1947ba16138cd37d08c04",
@@ -32468,6 +33341,7 @@
         {
             "id": "0xca2cfb57df10e86315bd7d51ae433d3e2563f3a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32495,6 +33369,7 @@
         {
             "id": "0xca31dc75aa718d30c23c674b2f4f313475c5c597",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -32522,6 +33397,7 @@
         {
             "id": "0xca4b0521d219543be08ea0e743f12ab3620a3c99",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -32549,6 +33425,7 @@
         {
             "id": "0xca54c398195fce98856888b0fd97a9470a140f71",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -32604,6 +33481,7 @@
         {
             "id": "0xcaf467dfe064a1f54e4ece8515ddf326b9be801e",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
@@ -32631,6 +33509,7 @@
         {
             "id": "0xcb5cde8da12555bf770e185e8e323290e5c443d4",
             "swapFee": "0.0095",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -32686,6 +33565,7 @@
         {
             "id": "0xcb8ec8236aff8e112517f4e9a9ffb413a237e6b7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2515db4e378b0bae961d056c5b9012d6d12d5e67",
@@ -32713,6 +33593,7 @@
         {
             "id": "0xcba435408f3b3a7ad231e0083d7ee2e9ec03764f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32740,6 +33621,7 @@
         {
             "id": "0xcbcf7be78c33b513e95d8708ee422b217aec90f1",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32795,6 +33677,7 @@
         {
             "id": "0xcbdc3bdf78c1df509f94f1f52cc5c5c093d4322b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -32829,6 +33712,7 @@
         {
             "id": "0xcbfc115040becb50d2d0d95dd5e931e2defb6bbf",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -32919,6 +33803,7 @@
         {
             "id": "0xcce41676a4624f4a1e33a787a59d6bf96e5067bc",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -32946,6 +33831,7 @@
         {
             "id": "0xcd2e397d4561d06c878e1a9155662722e22dc232",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x469eda64aed3a3ad6f868c44564291aa415cb1d9",
@@ -33029,6 +33915,7 @@
         {
             "id": "0xcd958268208c820a91f2f1a061917967a783194f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x022057c3ef9166433750165bfda21d52988e0756",
@@ -33070,6 +33957,7 @@
         {
             "id": "0xcd9a7dfcf68bee45c9c946af244fff4c23ebd97a",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb8baa0e4287890a5f79863ab62b7f175cecbd433",
@@ -33097,6 +33985,7 @@
         {
             "id": "0xcdc714a8c718709f069f5d4b668015ea44435871",
             "swapFee": "0.00141",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -33152,6 +34041,7 @@
         {
             "id": "0xce339986489f0eb81fc65b4b19f7025a1b6a5c09",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb24f135c954b71b75dd413b288835b5a8d4afa74",
@@ -33179,6 +34069,7 @@
         {
             "id": "0xce46dd186160c81b06433f9f501b06cd36d19d50",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xdaff85b6f5787b2d9ee11ccdf5e852816063326a",
@@ -33206,6 +34097,7 @@
         {
             "id": "0xce6e68d39d3c7c233be493e3bbc60c6660964ed1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -33240,6 +34132,7 @@
         {
             "id": "0xcec5a9d418a3f447e22b57a79f2feaa14d756022",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2a5eb6b5371836d126b753137c9e8f0e2a133ae7",
@@ -33267,6 +34160,7 @@
         {
             "id": "0xcf19a7c81fcf0e01c927f28a2b551405e58c77e5",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0954906da0bf32d5479e25f46056d22f08464cab",
@@ -33294,6 +34188,7 @@
         {
             "id": "0xcf2e274fc7d55d3d2b1c50d5b937ec76cfb8d253",
             "swapFee": "0.0088",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaf1250fa68d7decd34fd75de8742bc03b29bd58e",
@@ -33321,6 +34216,7 @@
         {
             "id": "0xcf2fc6761eeeceb070422d2e5df481b25c2800bf",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1453dbb8a29551ade11d89825ca812e05317eaeb",
@@ -33348,6 +34244,7 @@
         {
             "id": "0xcf4f1243a71749eb15d2630d3aac03c6dcd53bbf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -33375,6 +34272,7 @@
         {
             "id": "0xcfcdb690bdc88f43f7cac7d968d0d66d2118ad20",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33402,6 +34300,7 @@
         {
             "id": "0xd036ab041f8ea4955ee7932deab856725e2f8aba",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -33429,6 +34328,7 @@
         {
             "id": "0xd06726afe91a423afec003fbb2f075ef3adc3cd7",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5",
@@ -33456,6 +34356,7 @@
         {
             "id": "0xd16383a30f652609597cd725b0a5c9439330119b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8eb24319393716668d768dcec29356ae9cffe285",
@@ -33511,6 +34412,7 @@
         {
             "id": "0xd19e1b2f35a17c0f65bba7824b2a73678b30a530",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33538,6 +34440,7 @@
         {
             "id": "0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8a9c67fee641579deba04928c4bc45f66e26343a",
@@ -33565,6 +34468,7 @@
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -33592,6 +34496,7 @@
         {
             "id": "0xd2bbac179784e875bde9cbbdcd3fd578c4d0851c",
             "swapFee": "0.0012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9b53e429b0badd98ef7f01f03702986c516a5715",
@@ -33619,6 +34524,7 @@
         {
             "id": "0xd2e4acdfe12aa8714f6c5208781a47894aeeb979",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xf291ae28e95f2e3ed45e77cf9aa824f4ece68509",
@@ -33646,6 +34552,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33673,6 +34580,7 @@
         {
             "id": "0xd31572a673360ae2e6ee423ccc612cc467eb47e2",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -33728,6 +34636,7 @@
         {
             "id": "0xd386bb106e6fb44f91e180228edeca24ef73c812",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -33776,6 +34685,7 @@
         {
             "id": "0xd39621fb695cda8d2da042696cb1002e3d4f0b1a",
             "swapFee": "0.0154",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33817,6 +34727,7 @@
         {
             "id": "0xd3a38eaeae085b04d4da3614c870c3b985067c40",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33844,6 +34755,7 @@
         {
             "id": "0xd3c8dcfcf2a5203f6a3210591dabea14e181db2d",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
@@ -33871,6 +34783,7 @@
         {
             "id": "0xd3d14de568990854705c40221f75efbad8c0c981",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4fe5851c9af07df9e5ad8217afae1ea72737ebda",
@@ -33898,6 +34811,7 @@
         {
             "id": "0xd44082f25f8002c5d03165c5d74b520fbc6d342d",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -33988,6 +34902,7 @@
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34015,6 +34930,7 @@
         {
             "id": "0xd50985725dbacfb8cf688b58ea90a39fe5090191",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34042,6 +34958,7 @@
         {
             "id": "0xd51cdcdfd2a75c9b163d73abe94984ef1eadfbd7",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -34076,6 +34993,7 @@
         {
             "id": "0xd546604b12c721e6bf964b9b39647adaa68b54a4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bebe99fac607dc7ef2d99d352ca18999f51b709",
@@ -34103,6 +35021,7 @@
         {
             "id": "0xd58eef5b3741919d62d68c14958d0418166edb2b",
             "swapFee": "0.0035",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -34130,6 +35049,7 @@
         {
             "id": "0xd5a4c345cf728e3eb075eb66aafa27662dae283b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -34171,6 +35091,7 @@
         {
             "id": "0xd5b58830b159d86ddf229a0429817fc7d446b45c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x091d2ccf3a03cc1753dd0d62325ac5319213cb00",
@@ -34226,6 +35147,7 @@
         {
             "id": "0xd667b6eeaee0da058143fcb98d7c2543545fdd46",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x69bbe2fa02b4d90a944ff328663667dc32786385",
@@ -34253,6 +35175,7 @@
         {
             "id": "0xd6a12600ea045da17bc681fa042e8d78c3f4c927",
             "swapFee": "0.0055",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x86fadb80d8d2cff3c3680819e4da99c10232ba0f",
@@ -34350,6 +35273,7 @@
         {
             "id": "0xd6afd8e317c85c794683304baa99de78049387c5",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -34426,6 +35350,7 @@
         {
             "id": "0xd6e4520eba3f884b700a3a6c2a88aa5ccd0fe83e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d287cc25dad7ccaf76a26bc660c5f7c8e2a05bd",
@@ -34502,6 +35427,7 @@
         {
             "id": "0xd7067192df19c415ee35cc86708020eaf924cd75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34592,6 +35518,7 @@
         {
             "id": "0xd79d825c3022e641368e77b3883c14d86694dd69",
             "swapFee": "0.0333",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x01ac08e821185b6d87e68c67f9dc79a8988688eb",
@@ -34633,6 +35560,7 @@
         {
             "id": "0xd7b6d14b76595ab7938c2c781079d787ef3bd5ee",
             "swapFee": "0.00125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34674,6 +35602,7 @@
         {
             "id": "0xd82945aa0a6514a3141e92c476da956af4e13db1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1c5857e110cd8411054660f60b5de6a6958cfae2",
@@ -34729,6 +35658,7 @@
         {
             "id": "0xd8e9690eff99e21a2de25e0b148ffaf47f47c972",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20c36f062a31865bed8a5b1e512d9a1a20aa333a",
@@ -34756,6 +35686,7 @@
         {
             "id": "0xd9346ab5a2ed5e32f5fc69a5cccf45211307ffc5",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x704de5696df237c5b9ba0de9ba7e0c63da8ea0df",
@@ -34790,6 +35721,7 @@
         {
             "id": "0xd961daa343c8bf4c945c4fc66fc4eebe9c6a8472",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -34817,6 +35749,7 @@
         {
             "id": "0xd9646c5173f2f4381da50f0b3efa85f9529f485b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3f382dbd960e3a9bbceae22651e88158d2791550",
@@ -34900,6 +35833,7 @@
         {
             "id": "0xda4b031b5ece42abb394a9d2130eaa958c2a8b38",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
@@ -34927,6 +35861,7 @@
         {
             "id": "0xda522be7bdff2207b8c3afb3786cae165b19cb4d",
             "swapFee": "0.033",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39c0edef530d284b8f7820061114157c5bd78093",
@@ -34954,6 +35889,7 @@
         {
             "id": "0xda5c6df410a556ace07a4bc8a7b1eba9ec2db441",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34981,6 +35917,7 @@
         {
             "id": "0xda6500ffdd9f3ffd9cedb57e88028568bb770ea9",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35008,6 +35945,7 @@
         {
             "id": "0xda9bb62dfca058a28c17ca435894a24e97b79828",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0c37bcf456bc661c14d596683325623076d7e283",
@@ -35035,6 +35973,7 @@
         {
             "id": "0xdac256378fa61bacec37a18a15fd7e5c03f48c86",
             "swapFee": "0.0018",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3b3ac5386837dc563660fb6a0937dfaa5924333b",
@@ -35076,6 +36015,7 @@
         {
             "id": "0xdb56e9035972117d532b5ab0e261ba0abf8dab4b",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35103,6 +36043,7 @@
         {
             "id": "0xdb82e3095408d29b59c1b9ce47299f4e784a2187",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35172,6 +36113,7 @@
         {
             "id": "0xdb942c0851774bd817e6f4813f1fa64cce6fe25f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1337def18c680af1f9f45cbcab6309562975b1dd",
@@ -35199,6 +36141,7 @@
         {
             "id": "0xdba7372b38513bb08363ca8287238475bcdd2290",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35226,6 +36169,7 @@
         {
             "id": "0xdbdb92203674123b06dd8501713db2190c80a567",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35253,6 +36197,7 @@
         {
             "id": "0xdbe06999a11f6bae2fb1f77bb83ec8a1676595e2",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35280,6 +36225,7 @@
         {
             "id": "0xdbe29107464d469c64a02afe631aba2e6fabedce",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -35307,6 +36253,7 @@
         {
             "id": "0xdc2be78817492a8c10664f8d1e67252453f11b27",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44f65f6dbacbc836f052c85ce46012c8b6da95fc",
@@ -35341,6 +36288,7 @@
         {
             "id": "0xdc7d39628855b6013000c9af957e6cd484beda6c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -35375,6 +36323,7 @@
         {
             "id": "0xdd0b69d938c6e98bf8f16f04c4913a0c07e0bb6e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35472,6 +36421,7 @@
         {
             "id": "0xddaa60e584338fa251451d6385f6a2b9bde98b2a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -35499,6 +36449,7 @@
         {
             "id": "0xddce7b2c3f7fbc4f1eab24970c3fd26fee1ff80f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
@@ -35526,6 +36477,7 @@
         {
             "id": "0xddfb973690c5b1aaa4a6685eb1a7871ce7f4b2c5",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -35553,6 +36505,7 @@
         {
             "id": "0xde028e868d9fee3168e3e3a525a75152017ae22f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35580,6 +36533,7 @@
         {
             "id": "0xde0999ee4e4bea6fecb03bf4ebef2626942ec6f5",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -35607,6 +36561,7 @@
         {
             "id": "0xde5921f03ba2ec1a9efbeb6957273b5414193a3b",
             "swapFee": "0.00175",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x297d33e17e61c2ddd812389c2105193f8348188a",
@@ -35662,6 +36617,7 @@
         {
             "id": "0xde7e006a9583a4cdcbdd0e233155d88d80962b31",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35689,6 +36645,7 @@
         {
             "id": "0xde7e1a76d036c4786ed59fe4344e004122746416",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2d80f5f5328fdcb6eceb7cacf5dd8aedaec94e20",
@@ -35779,6 +36736,7 @@
         {
             "id": "0xdfb0ce371d4858d2ea247c1d2e07b40daf4e9298",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x91f79d4a59ce6e410fefb059a6d5679aa55403db",
@@ -35834,6 +36792,7 @@
         {
             "id": "0xdff4f867855fd7db4d240b60fd0a88f6a049427a",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -35861,6 +36820,7 @@
         {
             "id": "0xe00770cbe21933e8040ce1b2d0e2c96fd7e4b63f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -35888,6 +36848,7 @@
         {
             "id": "0xe010fcda8894c16a8acfef7b37741a760faeddc4",
             "swapFee": "0.0008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35915,6 +36876,7 @@
         {
             "id": "0xe02307a412196a533d39f3aab925512ad791ac3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x261efcdd24cea98652b9700800a13dfbca4103ff",
@@ -35963,6 +36925,7 @@
         {
             "id": "0xe036cce08cf4e23d33bc6b18e53caf532afa8513",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -35990,6 +36953,7 @@
         {
             "id": "0xe044bc87a030d370d64a6ca4531a08a4e67444e0",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -36017,6 +36981,7 @@
         {
             "id": "0xe06e1bff85187ab405144268c0055a80ba60c179",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36149,6 +37114,7 @@
         {
             "id": "0xe0e6b25b22173849668c85e06bc2ce1f69baff8c",
             "swapFee": "0.0079",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -36176,6 +37142,7 @@
         {
             "id": "0xe104a1e9ac002218123e19685bc78291d976b954",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00d1793d7c3aae506257ba985b34c76aaf642557",
@@ -36203,6 +37170,7 @@
         {
             "id": "0xe1a4ce53ae27bdac1366f4d97b10e8586105f2c0",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36230,6 +37198,7 @@
         {
             "id": "0xe2025063c1610182af972c91e4c721112c36301e",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36257,6 +37226,7 @@
         {
             "id": "0xe24adb0693ec10c5d65ec0c09d5e9410a70b9f7d",
             "swapFee": "0.019",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36284,6 +37254,7 @@
         {
             "id": "0xe26a220a341eaca116bda64cf9d5638a935ae629",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x56d811088235f11c8920698a204a5010a788f4b3",
@@ -36311,6 +37282,7 @@
         {
             "id": "0xe26e8603ab8c05f62a180b1803a815d0c03080c3",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36338,6 +37310,7 @@
         {
             "id": "0xe27d781350d86798a501fcc46241e37f75bcfe16",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36365,6 +37338,7 @@
         {
             "id": "0xe2b5b962bc312dbf98241120de371ce5e726057c",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -36392,6 +37366,7 @@
         {
             "id": "0xe2c7795afea2a0e7210ce9b4d40460601c575b31",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36454,6 +37429,7 @@
         {
             "id": "0xe2c7b75ae19d1029935e7c4c497fbfca395c936c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36502,6 +37478,7 @@
         {
             "id": "0xe2cefefe6bf96585ee198c65d75c6f70a4d4767b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -36529,6 +37506,7 @@
         {
             "id": "0xe2d0b729034cb2d8dd3881680a43a84a474e9b42",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -36556,6 +37534,7 @@
         {
             "id": "0xe2eb726bce7790e57d978c6a2649186c4d481658",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -36583,6 +37562,7 @@
         {
             "id": "0xe361625f216b79a60665cae0b5c9da53a35ccc0e",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5b14eb6309f65ab5c5e2824ef1ed412be115985b",
@@ -36610,6 +37590,7 @@
         {
             "id": "0xe3f9cf7d44488715361581dd8b3a15379953eb4c",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -36644,6 +37625,7 @@
         {
             "id": "0xe42237f32708bd5c04d69cc77e1e36c8f911a016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -36671,6 +37653,7 @@
         {
             "id": "0xe4caf82f8a84dbee8222a1bd1ac7f3c6964dd716",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -36698,6 +37681,7 @@
         {
             "id": "0xe4eaa46910f3b061b4abfe64b5726fb11167107b",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -36725,6 +37709,7 @@
         {
             "id": "0xe51809ad06a2fedff783622c643c11f5b445b383",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b785a0322126826d8226d77e173d75dafb84d11",
@@ -36752,6 +37737,7 @@
         {
             "id": "0xe52d39ec722a8e556fff5df342df64d7872119f7",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -36800,6 +37786,7 @@
         {
             "id": "0xe52e551141d29e4d08a826ff029059f1fb5f6f52",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x98ad9b32dd10f8d8486927d846d4df8baf39abe2",
@@ -36855,6 +37842,7 @@
         {
             "id": "0xe5b11f98f8a16480cfe33029da27884719d1573b",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x45f24baeef268bb6d63aee5129015d69702bcdfa",
@@ -36882,6 +37870,7 @@
         {
             "id": "0xe5c700572799553f9d65cbe8dfeeb543be584431",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
@@ -36909,6 +37898,7 @@
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -36943,6 +37933,7 @@
         {
             "id": "0xe65607162f091af23cf278442ec333321a8c3320",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -36970,6 +37961,7 @@
         {
             "id": "0xe65de360befdba16426f8d1166b03fce01535a93",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -37039,6 +38031,7 @@
         {
             "id": "0xe6c2e229c763ed3e1d5d57b3648aeb1d4011eacd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -37087,6 +38080,7 @@
         {
             "id": "0xe6cb1c3a212001d02706ef93ea0a87b35b36d016",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37142,6 +38136,7 @@
         {
             "id": "0xe763fdbe8dc96687ba050561f59608ca1e977e5b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37183,6 +38178,7 @@
         {
             "id": "0xe77b04cc44c5ae4227eb9be90d55c5df955e4c74",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37210,6 +38206,7 @@
         {
             "id": "0xe78e458cbc9a57dc831e66c9187b0324b4e8304b",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -37279,6 +38276,7 @@
         {
             "id": "0xe79590c1d8cbf6f3217b734dae7abd1b06b68d48",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaac41ec512808d64625576eddd580e7ea40ef8b2",
@@ -37306,6 +38304,7 @@
         {
             "id": "0xe79bdd1a9baf6b65339f8ae80d89edd9a790f87a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37333,6 +38332,7 @@
         {
             "id": "0xe79ee4b575aca0cf8e88d3fef3ce7243f16417f6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x87aba522529895283bcacb9a2bb840b0908253e2",
@@ -37360,6 +38360,7 @@
         {
             "id": "0xe7eec16a731ab674026b2daf8afb48b48705cdd0",
             "swapFee": "0.0022",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa283d8ab7439ad553e4496c32f102da94ad59db1",
@@ -37464,6 +38465,7 @@
         {
             "id": "0xe842bd9e1ae02bc4ba15ff2c024ef180e245eb71",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
@@ -37491,6 +38493,7 @@
         {
             "id": "0xe85c43477b602f363bebce6bf478480ac1002810",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1d77302ca9a3f0cf07ceaf362383445f1c8897b8",
@@ -37518,6 +38521,7 @@
         {
             "id": "0xe867be952ee17d2d294f2de62b13b9f4af521e9a",
             "swapFee": "0.0014",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37615,6 +38619,7 @@
         {
             "id": "0xe8d754546a60b7204933be8675dd7a7f0080a999",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -37642,6 +38647,7 @@
         {
             "id": "0xe8e2ee74ba84bd2d52c1348132c949e49c826c3b",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255be163c9f9aa6a6127188723463585665ea4c7",
@@ -37669,6 +38675,7 @@
         {
             "id": "0xe8ea65f8b53c4ba348d3d276ba635aa5adafeaad",
             "swapFee": "0.0003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xade5900f0c560dc3aed9ebe93ceff90f69745df5",
@@ -37696,6 +38703,7 @@
         {
             "id": "0xe93e8aa4e88359dacf33c491cf5bd56eb6c110c1",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -37723,6 +38731,7 @@
         {
             "id": "0xe969991ce475bcf817e01e1aad4687da7e1d6f83",
             "swapFee": "0.00009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -37750,6 +38759,7 @@
         {
             "id": "0xe97f5d1d35bcca8dfcd290ccd1aa26c95995b77c",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37777,6 +38787,7 @@
         {
             "id": "0xe9a1d2e12716a820f8b63b51f0668f58416abfc6",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -37804,6 +38815,7 @@
         {
             "id": "0xe9a2c7a19e47bac855fad9c3147ffe95aea8c4c4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -37831,6 +38843,7 @@
         {
             "id": "0xe9ffe183f8a095d21f1b7049e3c76875b0dc745e",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa59b009cd174710d9c79b5b1fe38d7347717cf4e",
@@ -37858,6 +38871,7 @@
         {
             "id": "0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x30cf203b48edaa42c3b4918e955fed26cd012a3f",
@@ -37885,6 +38899,7 @@
         {
             "id": "0xea2097986285fc3006d7490985d9b21bc4484460",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5ade7ae8660293f2ebfcefaba91d141d72d221e8",
@@ -37919,6 +38934,7 @@
         {
             "id": "0xea63de726a757202242b253361a6d5f42f982094",
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd",
@@ -37946,6 +38962,7 @@
         {
             "id": "0xea862ffed19a2e5b8ac1b10fe14c88c1b35d4a2c",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d0bd297350b49ee96d5d4e15a12001928fddb1e",
@@ -37973,6 +38990,7 @@
         {
             "id": "0xeb2b9959c7943eb3c0bdb69ede25247bab4d1c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38028,6 +39046,7 @@
         {
             "id": "0xeb85b2e12320a123d447ca0da26b49e666b799db",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -38055,6 +39074,7 @@
         {
             "id": "0xec1ce403f5214c819ea0d9e7331945c834dec5d0",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b8e12f839bd4e73a47addf76cf7f0097d74c14c",
@@ -38082,6 +39102,7 @@
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -38137,6 +39158,7 @@
         {
             "id": "0xecd6894a1649dcc09bad2caede52928d702d750f",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -38164,6 +39186,7 @@
         {
             "id": "0xecffd9975ad7744832d7f12457dda49cd35f0125",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -38219,6 +39242,7 @@
         {
             "id": "0xed0413d19cdf94759bbe3fe9981c4bd085b430cf",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x44ea84a85616f8e9cd719fc843de31d852ad7240",
@@ -38246,6 +39270,7 @@
         {
             "id": "0xed1e5da50ef80c473eb94885672d610fbcf14e63",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -38273,6 +39298,7 @@
         {
             "id": "0xed201fc1d50a49ecf8b6e99730012dfff4daf8d0",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -38321,6 +39347,7 @@
         {
             "id": "0xed3d99d838ab16e8a0543bb91f254139a0fcb8dd",
             "swapFee": "0.0002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -38348,6 +39375,7 @@
         {
             "id": "0xed5ad5f258eef6a9745042bde7d46e8a5254c183",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831",
@@ -38375,6 +39403,7 @@
         {
             "id": "0xed641d0a5a87d34167990a457c80023d4343dde8",
             "swapFee": "0.0295",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38402,6 +39431,7 @@
         {
             "id": "0xedcbad088e7f6418ecac3bf352f401709b388ca1",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0b747c07da305d75ffbbdaa45aad82c73136b591",
@@ -38443,6 +39473,7 @@
         {
             "id": "0xee11fbe8d835328bcf2588e17276b1375d909f29",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -38470,6 +39501,7 @@
         {
             "id": "0xee4148ff794cf1d0976d2063a32a8f562abe6d75",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -38504,6 +39536,7 @@
         {
             "id": "0xee4843818e14b988e2359f71573699578fc9fa03",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38531,6 +39564,7 @@
         {
             "id": "0xee60ca08cca968dc1b36e7bbcc779efe34d7ef62",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1a5f9352af8af974bfc03399e3767df6370d82e4",
@@ -38565,6 +39599,7 @@
         {
             "id": "0xee76d9c262ce266d79ab9e2403d0dc17532bed27",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38620,6 +39655,7 @@
         {
             "id": "0xee9a6009b926645d33e10ee5577e9c8d3c95c165",
             "swapFee": "0.0009",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -38647,6 +39683,7 @@
         {
             "id": "0xeeab7e731704be6237ca24e6c06bf58810bd2473",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xae1eaae3f627aaca434127644371b67b18444051",
@@ -38674,6 +39711,7 @@
         {
             "id": "0xeeb82fa092e3cecb1ba99f8342775b70efb40cf8",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
@@ -38722,6 +39760,7 @@
         {
             "id": "0xeed9f9795bf12739cf4f50f8c84ab9f13ada8129",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -38756,6 +39795,7 @@
         {
             "id": "0xeeeee1033f5486ccd95c77257b2a2f2ee5f1eed8",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0597eaf957d896a5751aa35324bf24e1d9bc0f2c",
@@ -38818,6 +39858,7 @@
         {
             "id": "0xef1bf761054d967a05c825ec2a7430d5ab2f3b75",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d4d57cd06fa7fe99e26fdc481b468f77f05073c",
@@ -38845,6 +39886,7 @@
         {
             "id": "0xef1d978435bc94a130885b39e49140c3fcffd93f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbd301be09eb78df47019aa833d29edc5d815d838",
@@ -38872,6 +39914,7 @@
         {
             "id": "0xef24ee4187340233427a4511f40dc516c68f0c65",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -38920,6 +39963,7 @@
         {
             "id": "0xef6b465a5ea69b502433d960248b6c99023fbda9",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -38947,6 +39991,7 @@
         {
             "id": "0xefc9bc61438e8305baa3f2ffe2a2c1554a97fd17",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -38974,6 +40019,7 @@
         {
             "id": "0xf01c4300c9e8806c39c55296783dce097c622bfc",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f00fa01a66664e0b36aa2408e425c1e1b652b0a",
@@ -39022,6 +40068,7 @@
         {
             "id": "0xf01d9f08fdd1daa58904710f8d23c54f924e32e0",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x94d863173ee77439e4292284ff13fad54b3ba182",
@@ -39049,6 +40096,7 @@
         {
             "id": "0xf0c17a4927beb81e6aba91088e326960a8d71aae",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39160,6 +40208,7 @@
         {
             "id": "0xf123f4a5f6a03926cf06c34a986f7ce7c75290bd",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
@@ -39215,6 +40264,7 @@
         {
             "id": "0xf1880d81ce7d3b4b0d96ea0665cdb03cb7332c52",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -39242,6 +40292,7 @@
         {
             "id": "0xf1f3d252be946ee079f02cf577372bdada307457",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39290,6 +40341,7 @@
         {
             "id": "0xf22c9bd7c03d7f06290d331a8ea1477ddab80e85",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a64515e5e1d1073e83f30cb97bed20400b66e10",
@@ -39317,6 +40369,7 @@
         {
             "id": "0xf24a132fb79352f80f44ff01eac4d80ccdf5390b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -39386,6 +40439,7 @@
         {
             "id": "0xf253c61049a5cb243cf07f547565a5f72e350ecb",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x042afd3869a47e2d5d42cc787d5c9e19df32185f",
@@ -39413,6 +40467,7 @@
         {
             "id": "0xf28bf5bcd8d245d4c3247f7e78a5c0dc64d4cf4d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39468,6 +40523,7 @@
         {
             "id": "0xf3168b50751173e150af543997abe0fec5d58b7f",
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -39495,6 +40551,7 @@
         {
             "id": "0xf339a90f767a8bd69748dedb17fa93aa4825c3f4",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9ba00d6856a4edf4665bca2c2309936572473b7e",
@@ -39522,6 +40579,7 @@
         {
             "id": "0xf3ad3821a0036fd9caec0a4cf5d31515fad03f00",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7",
@@ -39549,6 +40607,7 @@
         {
             "id": "0xf3b6a8b21d456c862f903c9c372c1a3e922b6b7f",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -39576,6 +40635,7 @@
         {
             "id": "0xf43b1bbcefbe88a9bb8ae6d479a3242bcfe05fa0",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x09e64c2b61a5f1690ee6fbed9baf5d6990f8dfd0",
@@ -39603,6 +40663,7 @@
         {
             "id": "0xf4d8c95478d9fb81c3ba863353b19f5484e799ed",
             "swapFee": "0.00375",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x48f07301e9e29c3c38a80ae8d9ae771f224f1054",
@@ -39665,6 +40726,7 @@
         {
             "id": "0xf54025af2dc86809be1153c1f20d77adb7e8ecf4",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39692,6 +40754,7 @@
         {
             "id": "0xf59ca35d1ed36ed4837660d56763ee7fe6e2931b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -39740,6 +40803,7 @@
         {
             "id": "0xf5ce4c73ae723e27f768ef3ebdeadfbe9c9d61b4",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9",
@@ -39767,6 +40831,7 @@
         {
             "id": "0xf5ee7deafa315c2803b13adf64c620cf3681f22e",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -39794,6 +40859,7 @@
         {
             "id": "0xf64f38ae6b1e6144f292ecfa0a7c9236885f032e",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -39821,6 +40887,7 @@
         {
             "id": "0xf658132f2a5edd07da1fde126558aabedf11398c",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6e1a19f235be7ed8e3369ef73b196c07257494de",
@@ -39876,6 +40943,7 @@
         {
             "id": "0xf6b8f17f567aa6eef9ec39bc2590dc8d5b17e71a",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -39903,6 +40971,7 @@
         {
             "id": "0xf6e31c30d26a1f9c9475864149e3fa50efb4b522",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb5b8915f2f6d3873c050bcbaeeebe6cd4a9a95a5",
@@ -39930,6 +40999,7 @@
         {
             "id": "0xf76206115617f090f5a49961a78bcf99bb91cfee",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0246c9032bc3a600820415ae600c6388619a14d",
@@ -39957,6 +41027,7 @@
         {
             "id": "0xf7c3bdc804bf95652f09a472702b0ceb867b0593",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -40026,6 +41097,7 @@
         {
             "id": "0xf7dde178fabe8386ade62d584019326a203b5394",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -40053,6 +41125,7 @@
         {
             "id": "0xf7e090ef5debe22c2076954985373adc3eb219d3",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -40080,6 +41153,7 @@
         {
             "id": "0xf7ef0536615d3c0ad6d07afaa44ff707477f31d3",
             "swapFee": "0.04",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0afaa285ce85974c3c881256cb7f225e3a1178a",
@@ -40156,6 +41230,7 @@
         {
             "id": "0xf9732cb8e16fb95cf1387067736c1cf915974c00",
             "swapFee": "0.099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbfbb9b401114e367f7e174cdf4fbb8fcc0585fcc",
@@ -40183,6 +41258,7 @@
         {
             "id": "0xf9ab7776c7baeed1d65f0492fe2bb3951a1787ef",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40217,6 +41293,7 @@
         {
             "id": "0xf9dfee233a6e6d8d8ba70a62561989d09021d0f7",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x20945ca1df56d237fd40036d47e866c7dccd2114",
@@ -40251,6 +41328,7 @@
         {
             "id": "0xfa3c06c8974afadabac543f359034129e50d91ce",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035df12e0f3ac6671126525f1015e47d79dfeddf",
@@ -40285,6 +41363,7 @@
         {
             "id": "0xfa584755a0a4a4b393315941a7610887cd37eb80",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -40312,6 +41391,7 @@
         {
             "id": "0xfaac045833b86bb7c8889d146733f09e4c427cfa",
             "swapFee": "0.01337",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -40339,6 +41419,7 @@
         {
             "id": "0xfab25bd82510a7bcf9aadc21afd5a46d623b31de",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40366,6 +41447,7 @@
         {
             "id": "0xfab9446167bd8c375a2a64fe85bd71488cf14edd",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4922a015c4407f87432b179bb209e125432e4a2a",
@@ -40400,6 +41482,7 @@
         {
             "id": "0xfad1ddc14c266868c57a1304863fd953eed57ecb",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2c537e5624e4af88a7ae4060c022609376c8d0eb",
@@ -40427,6 +41510,7 @@
         {
             "id": "0xfae2809935233d4bfe8a56c2355c4a2e7d1fff1a",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xad32a8e6220741182940c5abf610bde99e737b2d",
@@ -40454,6 +41538,7 @@
         {
             "id": "0xfb23a5806c7beeeb13a2519fae6253eec9239617",
             "swapFee": "0.07",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb72b31907c1c95f3650b64b2469e08edacee5e8f",
@@ -40481,6 +41566,7 @@
         {
             "id": "0xfb2a3b99c33895570adf893885b3fde807788cf5",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -40515,6 +41601,7 @@
         {
             "id": "0xfb44d6ebd1c659ecdb199111f9dce55a8b4d5df1",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c8c6b02e7b2be14d4fa6022dfd6d75921d90e4e",
@@ -40549,6 +41636,7 @@
         {
             "id": "0xfb74d4fe5e127f545b89e4d21211185a55a1379f",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40576,6 +41664,7 @@
         {
             "id": "0xfbb0397fa8badbba26084515529ce53cd1756d4b",
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40603,6 +41692,7 @@
         {
             "id": "0xfc3ff3e4a4a3b2aebef6d7971ec05c9b640e9e05",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
@@ -40714,6 +41804,7 @@
         {
             "id": "0xfd18f126eabfe70d3c30912986fb5bdb95a02c6c",
             "swapFee": "0.03",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4bc6741e178e8222b8554562e98c70486f9d5911",
@@ -40741,6 +41832,7 @@
         {
             "id": "0xfd51aa745a5803db66de8f853765e83981a83bf4",
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -40768,6 +41860,7 @@
         {
             "id": "0xfd6088cfe26434d9fea8b696aa0b34da3c300c3b",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -40795,6 +41888,7 @@
         {
             "id": "0xfdc285bd8a2042bd3df5c8182bc087dfe3bce86d",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x035bfe6057e15ea692c0dfdcab3bb41a64dd2ad4",
@@ -40850,6 +41944,7 @@
         {
             "id": "0xfe5fa46409a8aacda43e3d32ea9b30d10279a459",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -40877,6 +41972,7 @@
         {
             "id": "0xfe670043c158adc057b5ef2f66e753847e1c3d1d",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -40911,6 +42007,7 @@
         {
             "id": "0xfe793bc3d1ef8d38934896980254e81d0c5f6239",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40938,6 +42035,7 @@
         {
             "id": "0xfe87120c9c990a672cfaa6de54d96773e767ac22",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x07af91e4bb31aff887bb4ba9778e2b5388595969",
@@ -41035,6 +42133,7 @@
         {
             "id": "0xfec1b940b643d91a127c9b8be7e1d6f82029f81f",
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x16c9cf62d8dac4a38fb50ae5fa5d51e9170f3179",
@@ -41062,6 +42161,7 @@
         {
             "id": "0xff4ab3da6f68a97a14233159e7b852704ca4c1dd",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x695106ad73f506f9d0a9650a78019a93149ae07c",
@@ -41089,6 +42189,7 @@
         {
             "id": "0xff6984b9b960b7c666ec3952a7317310e696346c",
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -41116,6 +42217,7 @@
         {
             "id": "0xffe8c31fb0ab62c99fc6e8c724d0f1949dbaa44f",
             "swapFee": "0.02",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -41185,6 +42287,7 @@
         {
             "id": "0xfff2a5f81d14729408201341df42af29f3b30458",
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/stable-and-weighted-same-pools.json
+++ b/test/testData/testPools/stable-and-weighted-same-pools.json
@@ -14,6 +14,7 @@
             "id": "0xebfed10e11dc08fcda1af1fda146945e8710f22e00000000000000000000007f",
             "address": "0xebfed10e11dc08fcda1af1fda146945e8710f22e",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "amp": "10",
             "tokens": [
                 {
@@ -44,6 +45,7 @@
             "id": "0xebfed10e11dc08fcda1af1fda146945e8710f22e00000000000000000000008f",
             "address": "0xebfed10e11dc08fcda1af1fda146945e8710f23e",
             "swapFee": "0.0004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",

--- a/test/testData/testPools/stable-and-weighted-token-btp-test.json
+++ b/test/testData/testPools/stable-and-weighted-token-btp-test.json
@@ -990,6 +990,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1017,6 +1018,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1288,6 +1290,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -1458,6 +1461,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -1485,6 +1489,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -1696,6 +1701,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2057,6 +2063,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2261,6 +2268,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2695,6 +2703,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2790,6 +2799,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2824,6 +2834,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2900,6 +2911,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3002,6 +3014,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3275,6 +3288,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -3302,6 +3316,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3363,6 +3378,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3505,6 +3521,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3871,6 +3888,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -4231,6 +4249,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4916,6 +4935,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -5086,6 +5106,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5188,6 +5209,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5269,6 +5291,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5608,6 +5631,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5826,6 +5850,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5895,6 +5920,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5949,6 +5975,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6118,6 +6145,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6199,6 +6227,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6335,6 +6364,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6504,6 +6534,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6755,6 +6786,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -7224,6 +7256,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7769,6 +7802,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7850,6 +7884,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8026,6 +8061,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8189,6 +8225,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8324,6 +8361,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8447,6 +8485,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8488,6 +8527,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8657,6 +8697,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -9030,6 +9071,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9343,6 +9385,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9493,6 +9536,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9758,6 +9802,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10043,6 +10088,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10138,6 +10184,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11231,6 +11278,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11360,6 +11408,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11468,6 +11517,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11549,6 +11599,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11822,6 +11873,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11849,6 +11901,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12510,6 +12563,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12848,6 +12902,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13133,6 +13188,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13377,6 +13433,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13588,6 +13645,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13615,6 +13673,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13663,6 +13722,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13731,6 +13791,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14051,6 +14112,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14222,6 +14284,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14290,6 +14353,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14351,6 +14415,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14392,6 +14457,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14488,6 +14554,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14867,6 +14934,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15037,6 +15105,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15064,6 +15133,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15133,6 +15203,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15390,6 +15461,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15540,6 +15612,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15648,6 +15721,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15729,6 +15803,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15925,6 +16000,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16224,6 +16300,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16293,6 +16370,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16692,6 +16770,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17323,6 +17402,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17513,6 +17593,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17750,6 +17831,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17819,6 +17901,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18022,6 +18105,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18307,6 +18391,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18708,6 +18793,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18891,6 +18977,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18945,6 +19032,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19149,6 +19237,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19991,6 +20080,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20072,6 +20162,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20099,6 +20190,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20187,6 +20279,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20437,6 +20530,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21074,6 +21168,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21687,6 +21782,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22185,6 +22281,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22584,6 +22681,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23133,6 +23231,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -23160,6 +23259,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -23201,6 +23301,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -23371,6 +23472,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23982,6 +24084,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24118,6 +24221,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -24274,6 +24378,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24687,6 +24792,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24795,6 +24901,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25446,6 +25553,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25487,6 +25595,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26120,6 +26229,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26581,6 +26691,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26927,6 +27038,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26954,6 +27066,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27458,6 +27571,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27647,6 +27761,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27728,6 +27843,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27790,6 +27906,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27859,6 +27976,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -28055,6 +28173,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28266,6 +28385,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -28293,6 +28413,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28705,6 +28826,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28732,6 +28854,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28807,6 +28930,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28996,6 +29120,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -29138,6 +29263,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29504,6 +29630,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29788,6 +29915,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30008,6 +30136,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30157,6 +30286,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30753,6 +30883,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31133,6 +31264,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31349,6 +31481,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31993,6 +32126,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32250,6 +32384,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32305,6 +32440,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32440,6 +32576,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32747,6 +32884,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32842,6 +32980,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32985,6 +33124,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33343,6 +33483,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33559,6 +33700,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33818,6 +33960,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -34055,6 +34198,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34136,6 +34280,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34232,6 +34377,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34307,6 +34453,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34382,6 +34529,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34409,6 +34557,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34552,6 +34701,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34694,6 +34844,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34721,6 +34872,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35250,6 +35402,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35570,6 +35723,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35597,6 +35751,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35651,6 +35806,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35888,6 +36044,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35915,6 +36072,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35963,6 +36121,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36668,6 +36827,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37227,6 +37387,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37254,6 +37415,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37383,6 +37545,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37837,6 +38000,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38428,6 +38592,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38618,6 +38783,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38910,6 +39076,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38951,6 +39118,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39019,6 +39187,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39189,6 +39358,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39270,6 +39440,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39466,6 +39637,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39676,6 +39848,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39934,6 +40107,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40470,6 +40644,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40647,6 +40822,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40789,6 +40965,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/stable-and-weighted.json
+++ b/test/testData/testPools/stable-and-weighted.json
@@ -993,6 +993,7 @@
         {
             "id": "0x0092b2d25d76d84d27b999fe93d5e1c70511cd2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1020,6 +1021,7 @@
         {
             "id": "0x00e5a66d31768318a7cae45dd7a0ef8288d7288d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1291,6 +1293,7 @@
         {
             "id": "0x02c6416341a972eb1a9967ab6c4a5aa8340a791b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x530535743fe6dde70272ac3be68df97c0becb11e",
@@ -1461,6 +1464,7 @@
         {
             "id": "0x0450b752a15bb5ddb5056ad2e27ead21289d31ed",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
@@ -1488,6 +1492,7 @@
         {
             "id": "0x0490b8bc5898eac3e41857d560f0a58aa393321e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x568c928953f9ee4d3e804e916a4d2b6907fa33bd",
@@ -1699,6 +1704,7 @@
         {
             "id": "0x05d7c706210c981778dce43de41ee08766378570",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -2060,6 +2066,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2264,6 +2271,7 @@
         {
             "id": "0x09f42e8a9363867283f0eea88fa6c3700e07ef03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2698,6 +2706,7 @@
         {
             "id": "0x0ce8f4e28b175eeec37ba7e28560852b61f72971",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbc16da9df0a22f01a16bc0620a27e7d6d6488550",
@@ -2793,6 +2802,7 @@
         {
             "id": "0x0d88b55317516b84e78fbba7cde3f910d5686901",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x00a8b738e453ffd858a7edf03bccfe20412f0eb0",
@@ -2827,6 +2837,7 @@
         {
             "id": "0x0e3e2781ee4ed14758c04eca5b4cc4a7aee459cd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0cf0ee63788a0849fe5297f3407f701e122cc023",
@@ -2903,6 +2914,7 @@
             "id": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
             "balanceBpt": "2171426.916937684144378714",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3005,6 +3017,7 @@
         {
             "id": "0x0e5c1813587088378787e7dd6c9cb4cb01a0ea18",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3278,6 +3291,7 @@
         {
             "id": "0x0ffc0ac3139a7cde29e6858c369b32cbbaf41cf4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -3305,6 +3319,7 @@
         {
             "id": "0x102efb11d588fa03dfc9fb5e0894dd241839d3f8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -3366,6 +3381,7 @@
         {
             "id": "0x1066a453127fad74d0ab1c981dffa56d76310517",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -3508,6 +3524,7 @@
         {
             "id": "0x1159907045848ed563a7ab883d2abe75b02d4723",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -3874,6 +3891,7 @@
         {
             "id": "0x1373e57f764a7944bdd7a4bd5ca3007d496934da",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -4234,6 +4252,7 @@
         {
             "id": "0x1763b02a81c58bfb22f0a80272aa6721fb1a8459",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x362bc847a3a9637d3af6624eec853618a43ed7d2",
@@ -4919,6 +4938,7 @@
         {
             "id": "0x1b4a4001037363e9dc61c17fab73c9ff56a37dd9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x167e2a574669b0eeb552aaf3da47c728cb348a41",
@@ -5089,6 +5109,7 @@
         {
             "id": "0x1c3728d8a30cfda5e55885d35a36bfc397e8791c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -5191,6 +5212,7 @@
         {
             "id": "0x1cf141641ee0f1fc9f22ffb8e3da9f3a9dea4160",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5272,6 +5294,7 @@
         {
             "id": "0x1dc2948b6db34e38291090b825518c1e8346938b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2ede9cb92a6de0916889e5936b1aad0e99ddf242",
@@ -5611,6 +5634,7 @@
         {
             "id": "0x209e622cd154bfa19c019cc2048f7c10ab5b8616",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5829,6 +5853,7 @@
         {
             "id": "0x22cbe89b62f6279e5ea3a12316aa7e8e5adbef8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -5898,6 +5923,7 @@
         {
             "id": "0x22e984341c638e9051e730ec9dcf9fe631c8ce01",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -5952,6 +5978,7 @@
         {
             "id": "0x238cd61c4bfa40bff9f84088abba0a3f08242dd7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -6121,6 +6148,7 @@
         {
             "id": "0x249bb2861e1d0a3f1f065fb35830ce5f6f2409f2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6202,6 +6230,7 @@
         {
             "id": "0x24e9ec4d9e5a2e7206e1a9aaaeb567687642ab46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -6338,6 +6367,7 @@
         {
             "id": "0x25af1f2c3772d6f19aa6615571203757365d29c6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -6507,6 +6537,7 @@
         {
             "id": "0x2721114b12b03aba26aaede0a69e68cf746859d4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x77df79539083dcd4a8898dba296d899afef20067",
@@ -6758,6 +6789,7 @@
         {
             "id": "0x28841acdddd21568eade5f2ee127175bf4229c23",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x846c66cf71c43f80403b51fe3906b3599d63336f",
@@ -7227,6 +7259,7 @@
         {
             "id": "0x2b4c91935b73cf6c4dd3755a0abc83819d0f160e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -7772,6 +7805,7 @@
         {
             "id": "0x2e22a35a29f0ccafe8c6fb935f7d0269f706ea72",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x221657776846890989a759ba2973e427dff5c9bb",
@@ -7853,6 +7887,7 @@
         {
             "id": "0x2e4f8ef08217c00f30c05997ef0361218e0c8d05",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -8029,6 +8064,7 @@
         {
             "id": "0x2f06480b3415c96b1bdb82827c519d172e22903f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -8192,6 +8228,7 @@
         {
             "id": "0x3031745e732dce8fecccc94aca13d5fa18f1012d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1aa61c196e76805fcbe394ea00e4ffced24fc469",
@@ -8327,6 +8364,7 @@
         {
             "id": "0x3144cb33fbfc0877d66e7733d5d7302bf9ee87a8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -8450,6 +8488,7 @@
         {
             "id": "0x31727e83aa791a324bfa49fc305e8ef452a64a42",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8491,6 +8530,7 @@
         {
             "id": "0x31c2507dfdbb7904201f28a7e18a70f2cb8cd03e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -8660,6 +8700,7 @@
         {
             "id": "0x33a0a3d25863ad38943b1b0d6bbc96f661f461b8",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9be4f6a2558f88a82b46947e3703528919ce6414",
@@ -9033,6 +9074,7 @@
         {
             "id": "0x3554dd27ed345f4b9c09aa1283f42fa73ee12a5e",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7e8539d1e5cb91d63e46b8e188403b3f262a949b",
@@ -9346,6 +9388,7 @@
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -9496,6 +9539,7 @@
         {
             "id": "0x3a77a45f7c8aaa7544bbf01ba5a1d4ce6d50b94f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -9761,6 +9805,7 @@
         {
             "id": "0x3c01e625b4931121713d558c9165fb3c89b91394",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -10046,6 +10091,7 @@
         {
             "id": "0x3d910518d721a385fa8fc0ad95ad3de4255ba956",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -10141,6 +10187,7 @@
         {
             "id": "0x3e361ef8f3624570ca72df4d87a11dc17beaeba3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x111111111117dc0aa78b770fa6a738034120c302",
@@ -11234,6 +11281,7 @@
         {
             "id": "0x43c02636f45767ab59f7bf751eac71099e5e39e0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2367012ab9c3da91290f71590d5ce217721eefe4",
@@ -11363,6 +11411,7 @@
         {
             "id": "0x448244ac36d67096e436ee82039b432126f79b7f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11471,6 +11520,7 @@
         {
             "id": "0x4533c2377522c61fc9c6efd3e6a3abe1b2b44022",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1eab1c2f0aeef4340f9b4443848e83990cb78d0f",
@@ -11552,6 +11602,7 @@
         {
             "id": "0x45f0f4177c16cd6115f733da6c05d06aa65df497",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -11825,6 +11876,7 @@
         {
             "id": "0x47c4a126bc45739c9087af3968c8e0d2354c5cf5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -11852,6 +11904,7 @@
         {
             "id": "0x47de4e96f2366ba4eab132da944ac8e49f59cfb9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
@@ -12513,6 +12566,7 @@
         {
             "id": "0x4c0ebb723bcb72626dcf8387e642a9aa4fc69231",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -12851,6 +12905,7 @@
         {
             "id": "0x4e01dc41c37e420146cd39ec7c42c439d96e018f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x55a020a43d1c1c42c880fefb08dcec037f76f999",
@@ -13136,6 +13191,7 @@
         {
             "id": "0x4fa407ec9fad5b87a2c15ed579e021f8320017dd",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13380,6 +13436,7 @@
         {
             "id": "0x51a370f47a2def11e38ec529706cde52e7d4a333",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -13591,6 +13648,7 @@
         {
             "id": "0x530dc539771ddbf56a76988b3fd7890cef421e03",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
@@ -13618,6 +13676,7 @@
         {
             "id": "0x5339b6fcefa19808cd6fc847b8c7dcf3d3d95d45",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -13666,6 +13725,7 @@
         {
             "id": "0x533f1164facaf30bbe8cc5900fb4f505df3412f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -13734,6 +13794,7 @@
         {
             "id": "0x535442c3127656f389041f6986991e0128e4ff06",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -14054,6 +14115,7 @@
         {
             "id": "0x548b5c92a5e0006628f69c60e0085373fd5b63d9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
@@ -14225,6 +14287,7 @@
         {
             "id": "0x55d291693f444d9ebd773b38ca130cce10ec25a5",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
@@ -14293,6 +14356,7 @@
         {
             "id": "0x561aecf40dfb6773270982d8f20fe0cab582b9f3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -14354,6 +14418,7 @@
         {
             "id": "0x5664e55ebfbc7dfc283ac9a4c9e7237d546a9a7b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -14395,6 +14460,7 @@
         {
             "id": "0x569771ecc10741302dfd4119249ba0e739144e97",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -14491,6 +14557,7 @@
         {
             "id": "0x56efe58653d94f3b9c87e32cc93cd20bd0e27e14",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x26cf82e4ae43d31ea51e72b663d26e26a75af729",
@@ -14870,6 +14937,7 @@
         {
             "id": "0x589f567efab3c76a2cfe649cce4e43f818dfa19d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -15040,6 +15108,7 @@
         {
             "id": "0x59416e1aa15aab32a3ac42e34d564aa38092d1cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -15067,6 +15136,7 @@
         {
             "id": "0x594415978a756c5b02eabdff98d867cdda65e888",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -15136,6 +15206,7 @@
         {
             "id": "0x59686e01aa841f622a43688153062c2f24f8fded",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4c605f60e399b9c2dcff167e8cf7d0bd3e496e3c",
@@ -15393,6 +15464,7 @@
         {
             "id": "0x5ad8953a279e6d6dc4330cfb345cbf5b1eff81f1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb2279b6769cfba691416f00609b16244c0cf4b20",
@@ -15543,6 +15615,7 @@
         {
             "id": "0x5b475f2cc362265ddf6a958f3519a35b305d2824",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -15651,6 +15724,7 @@
         {
             "id": "0x5bfdddef3d0bab839b797d23b35797b107923095",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -15732,6 +15806,7 @@
         {
             "id": "0x5c32a53131db8c67df4eabb24b5c3e8d95fada58",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -15928,6 +16003,7 @@
         {
             "id": "0x5dcb5baa17a5af85aaec5d2b422cab13c0141bce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e2ec54fc0b509f445631bf4b91ab8168230c752",
@@ -16227,6 +16303,7 @@
         {
             "id": "0x60303ccbba2392034ed666b0ba6e4b0307aeaf38",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -16296,6 +16373,7 @@
         {
             "id": "0x60332a3263722c380ba8c0a42ff69d8e45498692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x70861e862e1ac0c96f853c8231826e469ead37b1",
@@ -16695,6 +16773,7 @@
         {
             "id": "0x63a63f2cad45fee80b242436ba71e0f462a4178e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -17326,6 +17405,7 @@
         {
             "id": "0x6792a475e00a160c572d6359b1a539fb839ca71f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -17516,6 +17596,7 @@
         {
             "id": "0x68c74e157f35a3e40f1b02bba3e6e3827d534059",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x542439eca879e52e03e0d6e87bcdca165634245d",
@@ -17753,6 +17834,7 @@
         {
             "id": "0x6b064419100d1e248fbaca5a5fd6fee559da341a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
@@ -17822,6 +17904,7 @@
         {
             "id": "0x6b74fb4e4b3b177b8e95ba9fa4c3a3121d22fbfb",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x3af375d9f77ddd4f16f86a5d51a9386b7b4493fa",
@@ -18025,6 +18108,7 @@
         {
             "id": "0x6c701226204f7937750671b041996a73180a47d6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -18310,6 +18394,7 @@
         {
             "id": "0x6d59cf780d70927f022e3b827f31d6a6235a8d20",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -18711,6 +18796,7 @@
         {
             "id": "0x70985e557ae0cd6dc88189a532e54fbc61927bad",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -18894,6 +18980,7 @@
         {
             "id": "0x72717b53da57926bdf988f5645c23f7a3214ac9a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
@@ -18948,6 +19035,7 @@
         {
             "id": "0x72a250ee19c0f8cc5772f9a33e1e330cde39e023",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -19152,6 +19240,7 @@
         {
             "id": "0x731988c38ecc5ef74c0b917d4e242a2a93227657",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32a087d5fdf8c84ec32554c56727a7c81124544e",
@@ -19994,6 +20083,7 @@
         {
             "id": "0x78a7109a753cf5a49cfbca2504e6cd09d3fcf816",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f6deaddc2a81704a206fd587d8e3643bd2d449c",
@@ -20075,6 +20165,7 @@
         {
             "id": "0x790138ec1433b483dfa73b4e531949733b7b331d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -20102,6 +20193,7 @@
         {
             "id": "0x790bae3e77fd5861a0594c99e75cc50ed7bc53b2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x52fd77b74584af390320ee2bc0de8996a27d06b8",
@@ -20190,6 +20282,7 @@
         {
             "id": "0x795e951a5e9ba5ecf54917ac8df963e588966f44",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32ce7e48debdccbfe0cd037cc89526e4382cb81b",
@@ -20440,6 +20533,7 @@
         {
             "id": "0x7b3d5adccf49c9ebf0972ee1ad560ad9bedd2c67",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -21077,6 +21171,7 @@
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -21690,6 +21785,7 @@
         {
             "id": "0x8287913adfa69adca06beb00deab68a99c9e8d46",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -22188,6 +22284,7 @@
         {
             "id": "0x85507c632849b9f2ca10a86e3935ae0bd140e575",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -22587,6 +22684,7 @@
         {
             "id": "0x89edee8eb84a17396d374f7bbc8dc8ed95a133f9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c",
@@ -23136,6 +23234,7 @@
         {
             "id": "0x8e0b1cd5d32477b3d7fb2da9d7f66a2ac7223f0f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6ae92a1fb0b376d440a5a878aa9d517b24adf747",
@@ -23163,6 +23262,7 @@
         {
             "id": "0x8e249b94a6df92dd33c56b623de3109c3eb867c9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0e511aa1a137aad267dfe3a6bfca0b856c1a3682",
@@ -23204,6 +23304,7 @@
         {
             "id": "0x8e53de9ad7ebe0b4a114eee6a956dec863258451",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -23374,6 +23475,7 @@
         {
             "id": "0x8f9b862267ed25b0ffcf3a1fb7fe43e7d99cdfaa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa1d0e215a23d7030842fc67ce582a6afa3ccab83",
@@ -23985,6 +24087,7 @@
         {
             "id": "0x93e58f2d9f0784e04fcc85af385528418095ba55",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -24121,6 +24224,7 @@
         {
             "id": "0x947743830897565aa7463fe2eaa2fd79416313ec",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
@@ -24277,6 +24381,7 @@
         {
             "id": "0x957648b83164b1ae2ae715295cf5c154c0cc4267",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -24690,6 +24795,7 @@
         {
             "id": "0x986584714ef27e6cb34788dd5e538ae467ddde8a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2688213fedd489762a281a67ae4f2295d8e17ecc",
@@ -24798,6 +24904,7 @@
         {
             "id": "0x98ad8d1dfd7d4ac0850e24ff8fa8f41b69a60de0",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6aa0a667507e02bfe86182ad9f74f69299d1a27c",
@@ -25449,6 +25556,7 @@
         {
             "id": "0x9c5ef1d941eaeff8774128a8b2c58fce2c2bc7fa",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -25490,6 +25598,7 @@
         {
             "id": "0x9ce203ad2e38e29ea7eae395cb8b8a7877fa1175",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -26123,6 +26232,7 @@
         {
             "id": "0xa03fd7aaefde6d47e133bf9922b72c0b5f2f788e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -26584,6 +26694,7 @@
         {
             "id": "0xa33a45749d4a4118ad119f7e6c1474ab568f5928",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -26930,6 +27041,7 @@
         {
             "id": "0xa5432a868622a4a75d5fac8d9e201fd7950ff28a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -26957,6 +27069,7 @@
         {
             "id": "0xa553c12ab7682efda28c47fdd832247d62788273",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27461,6 +27574,7 @@
         {
             "id": "0xa8217c7c9d0d79c5138bf418c712de6154f283bf",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5cc4d697c8dca18edc09d6b9c656a788e873c6c1",
@@ -27650,6 +27764,7 @@
         {
             "id": "0xaa6d172d0358b1612f1d99bb0d02c54949d2bcbc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -27731,6 +27846,7 @@
         {
             "id": "0xaac57d2d5caa4de52819dd70a62b1406a972ba1c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -27793,6 +27909,7 @@
         {
             "id": "0xaad387f18e015cf9be4bdf96854845be51ddc977",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -27862,6 +27979,7 @@
         {
             "id": "0xaba96d19c6b472338a126d7641d40b300e619492",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x32c4adb9cf57f972bc375129de91c897b4f364f1",
@@ -28058,6 +28176,7 @@
         {
             "id": "0xad5424b3a6c067f03358fd02e42dc4ae0f238a1f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
@@ -28269,6 +28388,7 @@
         {
             "id": "0xaf4dd4ae3fed5f0dafe5a9a15e7cb1ddf0c6a824",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x8f8221afbb33998d8584a2b05749ba73c37a938a",
@@ -28296,6 +28416,7 @@
         {
             "id": "0xaf59044157ed99f3630c4c67f8870e09a5d1a6e2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2e1e15c44ffe4df6a0cb7371cd00d5028e571d14",
@@ -28708,6 +28829,7 @@
         {
             "id": "0xb2b305040d1b75832f682f9b5077fd37c5a1fa34",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28735,6 +28857,7 @@
         {
             "id": "0xb2e2628330a15a2baf227de80780c704b557a4c3",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -28810,6 +28933,7 @@
         {
             "id": "0xb2f32a94327db0ba721427a060074c9f96ebbd28",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -28999,6 +29123,7 @@
         {
             "id": "0xb458a1b0d526519a5f36efec4ccafff73d4e749c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -29141,6 +29266,7 @@
         {
             "id": "0xb519cb3ed5764a2d1150fa48dfcd41dcce757232",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29507,6 +29633,7 @@
         {
             "id": "0xb70c68a4f5446193853a4b9cb4e8cea27b606692",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -29791,6 +29918,7 @@
         {
             "id": "0xb8f06f4ea1c9332bfb3364b5b5197cafa768de39",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -30011,6 +30139,7 @@
         {
             "id": "0xb9efee79155b4bd6d06dd1a4c8babde306960bab",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -30160,6 +30289,7 @@
         {
             "id": "0xbad3ca7e741f785a05d7b3394db79fcc4b6d85af",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x516fff6fbda945742ddd8a1109a100c27208a1a3",
@@ -30756,6 +30886,7 @@
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -31136,6 +31267,7 @@
         {
             "id": "0xc2b070ebab858b2e638b21ceae937146f9cb6d2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x28cb7e841ee97947a86b06fa4090c8451f64c0be",
@@ -31352,6 +31484,7 @@
         {
             "id": "0xc3f1f6d583fa0465e7433b5f9f05fee401e41ad2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x136fae4333ea36a24bb751e2d505d6ca4fd9f00b",
@@ -31996,6 +32129,7 @@
         {
             "id": "0xc7c52b5d386b999ffa1e469eb723a299881e9df4",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
@@ -32253,6 +32387,7 @@
         {
             "id": "0xc9b153442f909a492f4ab933b99760876ba609cc",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -32308,6 +32443,7 @@
         {
             "id": "0xc9bad7e7ee794aa25c92e9609f849bd5eacd0774",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32443,6 +32579,7 @@
         {
             "id": "0xcacc5664def7d868f80f6d55157aae0c3aebd348",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x47788bd0b95dd8e1a063843af731286c3904ec71",
@@ -32750,6 +32887,7 @@
         {
             "id": "0xcc93790045341c27ae895c685a7570ad07b78e53",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -32845,6 +32983,7 @@
         {
             "id": "0xcd461b73d5fc8ea1d69a600f44618bdfac98364d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -32988,6 +33127,7 @@
         {
             "id": "0xce0e9e7a1163badb7ee79cfe96b5148e178cab73",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x53df0bfa014b7522299c129c5a7b318f02adb469",
@@ -33346,6 +33486,7 @@
         {
             "id": "0xd17c49ca3eaee2c935601a8ab432d3612279b788",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4a6507c71393d9b55e654e6515494e26a2c982d3",
@@ -33562,6 +33703,7 @@
         {
             "id": "0xd3466427f7ee5d0d9cd68b36df677e51bda26321",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -33821,6 +33963,7 @@
         {
             "id": "0xd485e6a0389a42d75f4b00ece91fc02340b73938",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x78f225869c08d478c34e5f645d07a87d3fe8eb78",
@@ -34058,6 +34201,7 @@
         {
             "id": "0xd5f9790b02357666a168ff09f662ee569b2fee36",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34139,6 +34283,7 @@
         {
             "id": "0xd6ade46b608aa954f866d218068c3d1d1d4ba38d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -34235,6 +34380,7 @@
         {
             "id": "0xd6dc678b03b3986630808c63a431f4104a7da8c2",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6",
@@ -34310,6 +34456,7 @@
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -34385,6 +34532,7 @@
         {
             "id": "0xd7458db5142c1a1499ea740356eebc5412622ea5",
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6fe56c0bcdd471359019fcbc48863d6c3e9d4f41",
@@ -34412,6 +34560,7 @@
         {
             "id": "0xd764bb9822ee16097140031b017640e7a293e57f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -34555,6 +34704,7 @@
         {
             "id": "0xd833716afa81cda00b33e138689f7a01d8c47b8c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -34697,6 +34847,7 @@
         {
             "id": "0xd9b92e84b9f96267bf548cfe3a3ae21773872138",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1f8aa31e569fcf22e21eb124fdd46df1e990c36e",
@@ -34724,6 +34875,7 @@
         {
             "id": "0xd9d5ed792a5d89cd73a0764ee263e4a5df2dd542",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1b73f1e564c5c31e503efa8c0c50356876cc9614",
@@ -35253,6 +35405,7 @@
         {
             "id": "0xdd8ada5088fa27dfb2e1364337f8c92d4c06b611",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -35573,6 +35726,7 @@
         {
             "id": "0xdf827a8cc2628c348123882ff964ccaea58ee08e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
@@ -35600,6 +35754,7 @@
         {
             "id": "0xdf9d033617505d85720c6885859f907be4751240",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6c2e204aa30bb6e131f1e4ae6a20c8458eb28b4f",
@@ -35654,6 +35809,7 @@
         {
             "id": "0xdfe5ead7bd050eb74009e7717000eeadcf0f18db",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2b8a2f0bad1ba4d72033b8475fb0ccc4921cb6dc",
@@ -35891,6 +36047,7 @@
         {
             "id": "0xe093973b45d3ddfc7d789850ad5b5bbd6a59846f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -35918,6 +36075,7 @@
         {
             "id": "0xe0a4280c1759c82daddcf21e3cda55b43d4180a7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -35966,6 +36124,7 @@
         {
             "id": "0xe0da0a98e004b69acb9bc0cce83979c76d124ed1",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
@@ -36671,6 +36830,7 @@
         {
             "id": "0xe5ac9548275787cd86df2350248614afab0088ee",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -37230,6 +37390,7 @@
         {
             "id": "0xe7f5b65126dd3cfe341313d1e9fa5c6d8865c652",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -37257,6 +37418,7 @@
         {
             "id": "0xe84122c644cf96ed5da48de9efed81a44d03e53d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37386,6 +37548,7 @@
         {
             "id": "0xe86c049f320a944ec66129bce0a6185c6816838e",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -37840,6 +38003,7 @@
         {
             "id": "0xeb413988a42cb359603d42bf3a6b6e5b24c69346",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4156d3342d5c385a87d264f90653733592000581",
@@ -38431,6 +38595,7 @@
         {
             "id": "0xee8337f497f234442160935f210c73dc47eb2676",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38621,6 +38786,7 @@
         {
             "id": "0xeefb83a6ec983ae4556b60cff1fb25e68f16a6ea",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
@@ -38913,6 +39079,7 @@
         {
             "id": "0xf0d726d3478d6f8206eca8a52070f99054131221",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -38954,6 +39121,7 @@
         {
             "id": "0xf11da347012b9752931202a40ed1328982551f5c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -39022,6 +39190,7 @@
         {
             "id": "0xf1469c0c8cde46466d6cbf0a1e0b03b98cbb301f",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x034655e8808f6dd8715cb2d58cfa94a15d6e1835",
@@ -39192,6 +39361,7 @@
         {
             "id": "0xf2508dbfc94291d1ac4837c00ecdc684332888f7",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1456688345527be1f37e9e627da0837d6f08c925",
@@ -39273,6 +39443,7 @@
         {
             "id": "0xf2a227ff5b865a558c2e3db42715b2e9c891ee2b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -39469,6 +39640,7 @@
         {
             "id": "0xf502596a088c936d47cf73907ecafbcf0f1745b9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xba100000625a3754423978a60c9317c58a424e3d",
@@ -39679,6 +39851,7 @@
         {
             "id": "0xf677ed557d321a225aed0f17e295146bb73a3c5b",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x352e4bbdda1ed839ac07533ed9eebadc39a70963",
@@ -39937,6 +40110,7 @@
         {
             "id": "0xf8f2339f2df897dd3dea3a4d39df641bd4dc596c",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -40473,6 +40647,7 @@
         {
             "id": "0xfcdfebef6ba1fef310e073d7f88202721915e1b6",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
@@ -40650,6 +40825,7 @@
         {
             "id": "0xfde04c4e7017f7ab76c109c33ba9a18ab3e53350",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27d9c33d61b8a04c6c76270440a5b7cfee06409e",
@@ -40792,6 +40968,7 @@
         {
             "id": "0xfeb0ede2b47d2d252dde3d7b7c748139a81cecba",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",

--- a/test/testData/testPools/subgraphPoolsDecimalsTest.json
+++ b/test/testData/testPools/subgraphPoolsDecimalsTest.json
@@ -3,6 +3,7 @@
         {
             "id": "0x94c9dc354c27da349ac3944d568af73488ced65e",
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xe0c9275e44ea80ef17579d33c55136b7da269aeb",
@@ -33,6 +34,7 @@
         {
             "id": "0x072f057ff96028f8a21a2dc5b04e3cb9585704d7",
             "swapFee": "0.000001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x1528f3fcc26d13f7079325fb78d9442607781c8c",
@@ -99,6 +101,7 @@
         {
             "id": "0xd2f574637898526fcddfb3d487cc73c957fa0268",
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",

--- a/test/testData/testPools/subgraphPoolsLarge.json
+++ b/test/testData/testPools/subgraphPoolsLarge.json
@@ -2,8 +2,8 @@
     "pools": [
         {
             "id": "0x0481d726c3d25250a8963221945ed93b8a5315a9",
-            "publicSwap": true,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -55,8 +55,8 @@
         },
         {
             "id": "0x05e671f4c857d02f42d837e64e6ec50b27819261",
-            "publicSwap": true,
             "swapFee": "0.00001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x992a780fdeda7a24c52526e027dfef90cddc685f",
@@ -98,8 +98,8 @@
         },
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
-            "publicSwap": true,
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -191,8 +191,8 @@
         },
         {
             "id": "0x09574f862d32794b8636cfb9c98e6597be049c4b",
-            "publicSwap": true,
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -224,8 +224,8 @@
         },
         {
             "id": "0x10fd0adaf5de39ddd81165d770367fde8883157d",
-            "publicSwap": true,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -257,8 +257,8 @@
         },
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
-            "publicSwap": true,
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -300,8 +300,8 @@
         },
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
-            "publicSwap": true,
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -333,8 +333,8 @@
         },
         {
             "id": "0x172bf7381a344453184f62a82c4aa78cec56cc2b",
-            "publicSwap": true,
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -366,8 +366,8 @@
         },
         {
             "id": "0x1b09173a0ffbad1cb7670b1a640013c0facfb71f",
-            "publicSwap": true,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -429,8 +429,8 @@
         },
         {
             "id": "0x247ff2b322df7439b78898375be7cdadca11cf17",
-            "publicSwap": true,
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -472,8 +472,8 @@
         },
         {
             "id": "0x24f598f7df68f663bcac6f94bec005a48570d7a4",
-            "publicSwap": true,
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -505,8 +505,8 @@
         },
         {
             "id": "0x254d519110d215fb657c621afc7d4b76ce2c0265",
-            "publicSwap": true,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -538,8 +538,8 @@
         },
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
-            "publicSwap": true,
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -601,8 +601,8 @@
         },
         {
             "id": "0x2a498804b8ee42ef7b773646a7e70ad6b19dfc28",
-            "publicSwap": true,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -634,8 +634,8 @@
         },
         {
             "id": "0x2dbd24322757d2e28de4230b1ca5b88e49a76979",
-            "publicSwap": true,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -717,8 +717,8 @@
         },
         {
             "id": "0x2feb4a6322432cbe44dc54a4959ac141ece53d7c",
-            "publicSwap": true,
             "swapFee": "0.0001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x4da9b813057d04baef4e5800e36083717b4a0341",
@@ -790,8 +790,8 @@
         },
         {
             "id": "0x364b12e8f821edd4a8d7bc3ad545e4021ef2afe6",
-            "publicSwap": true,
             "swapFee": "0.05",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -823,8 +823,8 @@
         },
         {
             "id": "0x39ee0f29253017d69909b7286caf8c080e9d6da2",
-            "publicSwap": true,
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
@@ -856,8 +856,8 @@
         },
         {
             "id": "0x4b47b11c353f0056c73a87fefccb6c43dc0d8065",
-            "publicSwap": true,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -889,8 +889,8 @@
         },
         {
             "id": "0x510432e28fa9fe26df6c505104d1d66ff1f66839",
-            "publicSwap": true,
             "swapFee": "0.001",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -922,8 +922,8 @@
         },
         {
             "id": "0x53b89ce35928dda346c574d9105a5479cb87231c",
-            "publicSwap": true,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -955,8 +955,8 @@
         },
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
-            "publicSwap": true,
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -988,8 +988,8 @@
         },
         {
             "id": "0x585846fafae6740c2dc68c64f8c6b32a77c1cc94",
-            "publicSwap": true,
             "swapFee": "0.0125",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -1021,8 +1021,8 @@
         },
         {
             "id": "0x5dab55b276301951a6efd857be05a82b018c3196",
-            "publicSwap": true,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d",
@@ -1054,8 +1054,8 @@
         },
         {
             "id": "0x60e6b01456fc55de0d893487c7c9cd0851c97064",
-            "publicSwap": true,
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
@@ -1087,8 +1087,8 @@
         },
         {
             "id": "0x622a71fdae6428d015052cf991816f70bb6a4a01",
-            "publicSwap": true,
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -1120,8 +1120,8 @@
         },
         {
             "id": "0x64cd4c11b70f0ad9dccdf873a51e7f278b7fed0a",
-            "publicSwap": true,
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x408e41876cccdc0f92210600ef50372656052a38",
@@ -1153,8 +1153,8 @@
         },
         {
             "id": "0x69306157a2191ede35cbb9c4aac72a112b5557c4",
-            "publicSwap": true,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -1226,8 +1226,8 @@
         },
         {
             "id": "0x6af60fde043bebb5e1eb6b51b36cc91fb21d5fdc",
-            "publicSwap": true,
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [],
             "tokensList": [],
             "totalWeight": "0",
@@ -1237,8 +1237,8 @@
         },
         {
             "id": "0x6cff7b12a9e3481b70d1c1a6e70ee674f5b9906b",
-            "publicSwap": true,
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1270,8 +1270,8 @@
         },
         {
             "id": "0x70f1c87b22d7371c68e3ea64870833a2a64cf8b3",
-            "publicSwap": true,
             "swapFee": "0.006",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -1303,8 +1303,8 @@
         },
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
-            "publicSwap": true,
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -1346,8 +1346,8 @@
         },
         {
             "id": "0x7f0b4d22b8a9abe2ae9ea1077fe1ab77dc7283a3",
-            "publicSwap": true,
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -1379,8 +1379,8 @@
         },
         {
             "id": "0x7f3bc8cc642fb8633ef58560802643935f8b3682",
-            "publicSwap": true,
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098",
@@ -1432,8 +1432,8 @@
         },
         {
             "id": "0x8f44990d76ca83c96d71a1773a8e76396e055fbb",
-            "publicSwap": true,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1485,8 +1485,8 @@
         },
         {
             "id": "0x95f0aa355f4251291e6413dd0174488f0ca8d2db",
-            "publicSwap": true,
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1518,8 +1518,8 @@
         },
         {
             "id": "0x987d7cc04652710b74fff380403f5c02f82e290a",
-            "publicSwap": true,
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -1551,8 +1551,8 @@
         },
         {
             "id": "0x9891832633a83634765952b051bc7fef36714a46",
-            "publicSwap": true,
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1604,8 +1604,8 @@
         },
         {
             "id": "0x9b208194acc0a8ccb2a8dcafeacfbb7dcc093f81",
-            "publicSwap": true,
             "swapFee": "0.0007",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -1647,8 +1647,8 @@
         },
         {
             "id": "0xa29f5e42760aa987214844e5db9ac4a8e16ca969",
-            "publicSwap": true,
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1680,8 +1680,8 @@
         },
         {
             "id": "0xa71f8151661c98678d89a4a463629ff7dd030c3b",
-            "publicSwap": true,
             "swapFee": "0.1",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -1713,8 +1713,8 @@
         },
         {
             "id": "0xa74485e5f668bba37b5c044c386b363f4cbd7c8c",
-            "publicSwap": true,
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0ba45a8b5d5575935b8158a88c631e9f9c95a2e5",
@@ -1746,8 +1746,8 @@
         },
         {
             "id": "0xa8e4faa056c7f1c41f5838a896daa091dea93901",
-            "publicSwap": true,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
@@ -1779,8 +1779,8 @@
         },
         {
             "id": "0xb6f10037acbf7012860b658fbfc35aa55d8de883",
-            "publicSwap": true,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1832,8 +1832,8 @@
         },
         {
             "id": "0xbc1902b1a219930c06361b07d57c6312fc7b10c6",
-            "publicSwap": true,
             "swapFee": "0.004",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1865,8 +1865,8 @@
         },
         {
             "id": "0xc0b2b0c5376cb2e6f73b473a7caa341542f707ce",
-            "publicSwap": true,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -1958,8 +1958,8 @@
         },
         {
             "id": "0xc7296300cb533dc8e43c48d73e32c588b47396d4",
-            "publicSwap": true,
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
@@ -1991,8 +1991,8 @@
         },
         {
             "id": "0xcf6a51106f1ab4889a462c34cf31933ed5298df3",
-            "publicSwap": true,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2054,8 +2054,8 @@
         },
         {
             "id": "0xd262e43273ca96214bb02b4036a1f24ad9806739",
-            "publicSwap": true,
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
@@ -2087,8 +2087,8 @@
         },
         {
             "id": "0xd3891ffc9cc5e64859c4ef08d0b86043b4473622",
-            "publicSwap": true,
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -2130,8 +2130,8 @@
         },
         {
             "id": "0xd3d8f65ecd0b6917cb1543cbeb1cc920ce0c769c",
-            "publicSwap": true,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2223,8 +2223,8 @@
         },
         {
             "id": "0xd4dbf96db2fdf8ed40296d8d104b371adf7dee12",
-            "publicSwap": true,
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",
@@ -2256,8 +2256,8 @@
         },
         {
             "id": "0xd59bf8773f89e0dde3ec745aebeae0da2b4af66f",
-            "publicSwap": true,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a72400e58ecd99ee497cf89e3775d4bd732f",
@@ -2289,8 +2289,8 @@
         },
         {
             "id": "0xd6f0d319b2cce75123bf63e2c2bd8ba1f7d6b37a",
-            "publicSwap": true,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -2352,8 +2352,8 @@
         },
         {
             "id": "0xd83ed0b5344604c70d8adad0f7f65b150e9448a8",
-            "publicSwap": true,
             "swapFee": "0.005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xc011a72400e58ecd99ee497cf89e3775d4bd732f",
@@ -2385,8 +2385,8 @@
         },
         {
             "id": "0xe5d1fab0c5596ef846dcc0958d6d0b20e1ec4498",
-            "publicSwap": true,
             "swapFee": "0.002",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -2428,8 +2428,8 @@
         },
         {
             "id": "0xeba4dd6771c3e8ba3f168e47d052819abcc87cb2",
-            "publicSwap": true,
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -2481,8 +2481,8 @@
         },
         {
             "id": "0xec577a919fca1b682f584a50b1048331ef0f30dd",
-            "publicSwap": true,
             "swapFee": "0.0015",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x57ab1ec28d129707052df4df418d58a2d46d5f51",
@@ -2554,8 +2554,8 @@
         },
         {
             "id": "0xf218fe414c6b1c6b42e79b7690f1509a634baad5",
-            "publicSwap": true,
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x107c4504cd79c5d2696ea0030a8dd4e92601b82e",
@@ -2587,8 +2587,8 @@
         },
         {
             "id": "0xf218fe414c6b1c6b42e79b7690f1509a634baad6",
-            "publicSwap": true,
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -2620,8 +2620,8 @@
         },
         {
             "id": "0xf218fe414c6b1c6b42e79b7690f1509a634baad7",
-            "publicSwap": true,
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -2653,8 +2653,8 @@
         },
         {
             "id": "0xf218fe414c6b1c6b42e79b7690f1509a634baad8",
-            "publicSwap": true,
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -2686,8 +2686,8 @@
         },
         {
             "id": "0xf218fe414c6b1c6b42e79b7690f1509a634baad9",
-            "publicSwap": true,
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",
@@ -2729,8 +2729,8 @@
         },
         {
             "id": "0xf218fe414c6b1c6b42e79b7690f1509a634baad0",
-            "publicSwap": true,
             "swapFee": "0.012",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x985dd3d42de1e256d09e1c10f112bccb8015ad41",

--- a/test/testData/testPools/subgraphPoolsSmallWithTrade.json
+++ b/test/testData/testPools/subgraphPoolsSmallWithTrade.json
@@ -147,6 +147,7 @@
         {
             "id": "0x09574f862d32794b8636cfb9c98e6597be049c4b",
             "swapFee": "0.025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
@@ -208,6 +209,7 @@
         {
             "id": "0x12d6b6e24fdd9849abd42afd8f5775d36084a828",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -247,6 +249,7 @@
         {
             "id": "0x165a50bc092f6870dc111c349bae5fc35147ac86",
             "swapFee": "0.003",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -277,6 +280,7 @@
         {
             "id": "0x247ff2b322df7439b78898375be7cdadca11cf17",
             "swapFee": "0.0025",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -347,6 +351,7 @@
         {
             "id": "0x29f55de880d4dcae40ba3e63f16407a31b4d44ee",
             "swapFee": "0.008",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -480,6 +485,7 @@
         {
             "id": "0x57755f7dec33320bca83159c26e93751bfd30fbe",
             "swapFee": "0.0005",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
@@ -510,6 +516,7 @@
         {
             "id": "0x75286e183d923a5f52f52be205e358c5c9101b09",
             "swapFee": "0.0029",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0327112423f3a68efdf1fcf402f6c5cb9f7c33fd",

--- a/test/testData/testPools/subgraphPoolsSmallWithTrade.json
+++ b/test/testData/testPools/subgraphPoolsSmallWithTrade.json
@@ -13,6 +13,7 @@
         {
             "id": "0x0481d726c3d25250a8963221945ed93b8a5315a9",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -61,6 +62,7 @@
         {
             "id": "0x07d13ed39ee291c1506675ff42f9b2b6b50e2d3e",
             "swapFee": "0.0099",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -175,6 +177,7 @@
         {
             "id": "0x10fd0adaf5de39ddd81165d770367fde8883157d",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
@@ -313,6 +316,7 @@
         {
             "id": "0x254d519110d215fb657c621afc7d4b76ce2c0265",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x9cb2f26a23b8d89973f08c957c4d7cdf75cd341c",
@@ -400,6 +404,7 @@
         {
             "id": "0x2dbd24322757d2e28de4230b1ca5b88e49a76979",
             "swapFee": "0.01",
+            "swapEnabled": true,
             "tokens": [
                 {
                     "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",


### PR DESCRIPTION
`swapEnabled` is now a required field on the subgraph so I have updated the types / test data to reflect this.